### PR TITLE
ATR-377: reworked event categories - fixed bugs and improved architec…

### DIFF
--- a/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/Nodes/Graph/GraphEventsGrouping/DacEventsGroupingNodeViewModel.cs
+++ b/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/Nodes/Graph/GraphEventsGrouping/DacEventsGroupingNodeViewModel.cs
@@ -73,33 +73,12 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 
 		protected virtual void FillDacNodeChildren(IEnumerable<GraphEventInfoBase> graphEventsForDAC, bool areChildrenExpanded)
 		{
-			var dacMembers = GraphEventsCategoryVM.IsFieldEvent
-				? GetDacFieldEvents(graphEventsForDAC.OfType<GraphFieldEventInfo>(), areChildrenExpanded)
-				: GetDacRowEvents(graphEventsForDAC.OfType<GraphRowEventInfo>(), areChildrenExpanded);
-
+			var dacMembers = GraphEventsCategoryVM.GetEventsViewModelsForDAC(this, graphEventsForDAC, areChildrenExpanded)
+												 ?.Where(eventVM => eventVM != null)
+												 ?? Enumerable.Empty<TreeNodeViewModel>();
 			Children.AddRange(dacMembers);
 			EventsCount = GetDacNodeEventsCount();
 			Children.CollectionChanged += DacChildrenChanged;
-		}
-
-		protected virtual IEnumerable<TreeNodeViewModel> GetDacRowEvents(IEnumerable<GraphRowEventInfo> graphEventsForDAC, bool areChildrenExpanded)
-		{
-			return graphEventsForDAC.Select(eventInfo => GraphEventsCategoryVM.CreateNewEventVM(this, eventInfo, areChildrenExpanded))
-									.Where(graphMemberVM => graphMemberVM != null && !graphMemberVM.Name.IsNullOrEmpty())
-									.OrderBy(graphMemberVM => graphMemberVM.Name);
-		}
-
-		protected virtual IEnumerable<TreeNodeViewModel> GetDacFieldEvents(IEnumerable<GraphFieldEventInfo> graphFieldEventsForDAC,
-																		   bool areChildrenExpanded)
-		{
-			return from eventInfo in graphFieldEventsForDAC
-				   group eventInfo by eventInfo.DacFieldName
-						into dacFieldEvents
-				   select DacFieldEventsGroupingNodeViewModel.Create(this, dacFieldEvents.Key, dacFieldEvents) 
-						into dacFieldNodeVM
-				   where dacFieldNodeVM != null && !dacFieldNodeVM.DacFieldName.IsNullOrEmpty()
-				   orderby dacFieldNodeVM.DacFieldName ascending
-				   select dacFieldNodeVM;
 		}
 
 		protected virtual int GetDacNodeEventsCount() =>

--- a/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/Nodes/Graph/GraphMembers/Base/GraphEventCategoryNodeViewModel.cs
+++ b/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/Nodes/Graph/GraphMembers/Base/GraphEventCategoryNodeViewModel.cs
@@ -31,8 +31,6 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 
 		protected override bool AllowNavigation => false;
 
-		public abstract bool IsFieldEvent { get; }
-
 		protected GraphEventCategoryNodeViewModel(GraphNodeViewModel graphViewModel, GraphMemberType graphMemberType, bool isExpanded) :
 										     base(graphViewModel, graphMemberType, isExpanded)
 		{
@@ -69,5 +67,9 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 		{
 			return new GraphMemberNodeViewModel(this, eventInfo, isExpanded);
 		}
+
+		public abstract IEnumerable<TreeNodeViewModel> GetEventsViewModelsForDAC(DacEventsGroupingNodeViewModel dacVM, 
+																				 IEnumerable<GraphEventInfoBase> graphEventsForDAC,
+																				 bool areChildrenExpanded);
 	}
 }

--- a/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/Nodes/Graph/GraphMembers/CacheAttachedNodeViewModel.cs
+++ b/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/Nodes/Graph/GraphMembers/CacheAttachedNodeViewModel.cs
@@ -23,17 +23,12 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 			protected set;
 		}
 
-		public CacheAttachedNodeViewModel(DacEventsGroupingNodeViewModel dacViewModel, GraphNodeSymbolItem memberInfo,
+		public CacheAttachedNodeViewModel(DacEventsGroupingNodeViewModel dacViewModel, GraphFieldEventInfo eventInfo,
 										  bool isExpanded = false) :
-									 base(dacViewModel?.GraphEventsCategoryVM, memberInfo, isExpanded)
+									 base(dacViewModel?.GraphEventsCategoryVM, eventInfo, isExpanded)
 		{
 			DacViewModel = dacViewModel;
-
-			int startPos = dacViewModel.DacName.Length + 1;
-			int lastUnderscoreIndex = MemberSymbol.Name.LastIndexOf('_');
-			Name = lastUnderscoreIndex > 0
-				? MemberSymbol.Name.Substring(startPos, lastUnderscoreIndex - startPos)
-				: MemberSymbol.Name;
+			Name = eventInfo.DacFieldName;
 			
 			var attributeVMs = MemberSymbol.GetAttributes()
 										   .Select(a => new AttributeNodeViewModel(this, a));

--- a/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/Nodes/Graph/GraphMembers/FieldEventNodeViewModel.cs
+++ b/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/Nodes/Graph/GraphMembers/FieldEventNodeViewModel.cs
@@ -18,13 +18,11 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 			protected set;
 		}
 
-		public FieldEventNodeViewModel(DacFieldEventsGroupingNodeViewModel dacFieldVM, GraphNodeSymbolItem memberInfo, bool isExpanded = false) :
-								  base(dacFieldVM?.GraphEventsCategoryVM, memberInfo, isExpanded)
+		public FieldEventNodeViewModel(DacFieldEventsGroupingNodeViewModel dacFieldVM, GraphFieldEventInfo eventInfo, bool isExpanded = false) :
+								  base(dacFieldVM?.GraphEventsCategoryVM, eventInfo, isExpanded)
 		{
 			DacFieldVM = dacFieldVM;
-			Name = memberInfo is GraphRowEventInfo eventInfo
-				? eventInfo.EventType.ToString()
-				: MemberSymbol.Name;
+			Name = eventInfo.EventType.ToString();
 		}	
 	}
 }

--- a/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/Nodes/Graph/GraphMembers/RowEventNodeViewModel.cs
+++ b/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/Nodes/Graph/GraphMembers/RowEventNodeViewModel.cs
@@ -22,13 +22,11 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 			protected set;
 		}
 
-		public RowEventNodeViewModel(DacEventsGroupingNodeViewModel dacViewModel, GraphNodeSymbolItem memberInfo, bool isExpanded = false) :
-								base(dacViewModel?.GraphEventsCategoryVM, memberInfo, isExpanded)
+		public RowEventNodeViewModel(DacEventsGroupingNodeViewModel dacViewModel, GraphRowEventInfo eventInfo, bool isExpanded = false) :
+								base(dacViewModel?.GraphEventsCategoryVM, eventInfo, isExpanded)
 		{
 			DacViewModel = dacViewModel;
-			Name = MemberInfo is GraphRowEventInfo eventInfo
-				? eventInfo.EventType.ToString()
-				: MemberSymbol.Name;
+			Name = eventInfo.EventType.ToString();
 		}	
 	}
 }

--- a/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/Nodes/Graph/GraphMembersCategories/CacheAttachedCategoryNodeViewModel.cs
+++ b/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/Nodes/Graph/GraphMembersCategories/CacheAttachedCategoryNodeViewModel.cs
@@ -13,8 +13,6 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 {
 	public class CacheAttachedCategoryNodeViewModel : GraphEventCategoryNodeViewModel
 	{
-		public override bool IsFieldEvent => true;
-
 		public CacheAttachedCategoryNodeViewModel(GraphNodeViewModel graphViewModel, bool isExpanded) :
 									base(graphViewModel, GraphMemberType.CacheAttached, isExpanded)
 		{
@@ -22,12 +20,22 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 
 		protected override IEnumerable<GraphNodeSymbolItem> GetCategoryGraphNodeSymbols() => GraphSemanticModel.CacheAttachedEvents;
 
+		public override IEnumerable<TreeNodeViewModel> GetEventsViewModelsForDAC(DacEventsGroupingNodeViewModel dacVM,
+																				 IEnumerable<GraphEventInfoBase> graphEventsForDAC,
+																				 bool areChildrenExpanded)
+		{
+			return graphEventsForDAC.OfType<GraphFieldEventInfo>()
+									.Select(eventInfo => CreateNewEventVM(dacVM, eventInfo, areChildrenExpanded))
+									.Where(graphMemberVM => graphMemberVM != null && !graphMemberVM.Name.IsNullOrEmpty())
+									.OrderBy(graphMemberVM => graphMemberVM.Name);
+		}
+
 		public override GraphMemberNodeViewModel CreateNewEventVM<TEventNodeParent>(TEventNodeParent eventNodeParent, GraphEventInfoBase eventInfo,
 																					bool isExpanded)
 		{
-			return eventNodeParent is DacEventsGroupingNodeViewModel dacGroupVM
-				? new CacheAttachedNodeViewModel(dacGroupVM, eventInfo, isExpanded)
+			return eventNodeParent is DacEventsGroupingNodeViewModel dacGroupVM && eventInfo is GraphFieldEventInfo fieldEventInfo
+				? new CacheAttachedNodeViewModel(dacGroupVM, fieldEventInfo, isExpanded)
 				: base.CreateNewEventVM(eventNodeParent, eventInfo, isExpanded);
-		}
+		}	
 	}
 }

--- a/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/Nodes/Graph/GraphMembersCategories/FieldEventCategoryNodeViewModel.cs
+++ b/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/Nodes/Graph/GraphMembersCategories/FieldEventCategoryNodeViewModel.cs
@@ -13,8 +13,6 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 {
 	public class FieldEventCategoryNodeViewModel : GraphEventCategoryNodeViewModel
 	{
-		public override bool IsFieldEvent => true;
-
 		public FieldEventCategoryNodeViewModel(GraphNodeViewModel graphViewModel, bool isExpanded) :
 										  base(graphViewModel, GraphMemberType.FieldEvent, isExpanded)
 		{
@@ -25,14 +23,31 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 							  .Concat(GraphSemanticModel.FieldVerifyingEvents)
 							  .Concat(GraphSemanticModel.FieldSelectingEvents)
 							  .Concat(GraphSemanticModel.FieldUpdatingEvents)
-							  .Concat(GraphSemanticModel.FieldUpdatedEvents);
+							  .Concat(GraphSemanticModel.FieldUpdatedEvents)
+							  .Concat(GraphSemanticModel.ExceptionHandlingEvents)
+							  .Concat(GraphSemanticModel.CommandPreparingEvents);
+
+		public override IEnumerable<TreeNodeViewModel> GetEventsViewModelsForDAC(DacEventsGroupingNodeViewModel dacVM,
+																				 IEnumerable<GraphEventInfoBase> graphFieldEventsForDAC,
+																				 bool areChildrenExpanded)
+		{
+			return from eventInfo in graphFieldEventsForDAC.OfType<GraphFieldEventInfo>()
+				   group eventInfo by eventInfo.DacFieldName
+						into dacFieldEvents
+				   select DacFieldEventsGroupingNodeViewModel.Create(dacVM, dacFieldEvents.Key, dacFieldEvents)
+						into dacFieldNodeVM
+				   where dacFieldNodeVM != null && !dacFieldNodeVM.DacFieldName.IsNullOrEmpty()
+				   orderby dacFieldNodeVM.DacFieldName ascending
+				   select dacFieldNodeVM;
+		}
 
 		public override GraphMemberNodeViewModel CreateNewEventVM<TEventNodeParent>(TEventNodeParent eventNodeParent, GraphEventInfoBase eventInfo,
 																					bool isExpanded)
 		{
-			return eventNodeParent is DacFieldEventsGroupingNodeViewModel dacFieldVM
-				? new FieldEventNodeViewModel(dacFieldVM, eventInfo, isExpanded)
-				: base.CreateNewEventVM(eventNodeParent, eventInfo, isExpanded);
+			if (eventNodeParent is DacFieldEventsGroupingNodeViewModel dacFieldVM && eventInfo is GraphFieldEventInfo fieldEventInfo)
+				return new FieldEventNodeViewModel(dacFieldVM, fieldEventInfo, isExpanded);		
+			else
+				return base.CreateNewEventVM(eventNodeParent, eventInfo, isExpanded);
 		}
 	}
 }

--- a/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/Nodes/Graph/GraphMembersCategories/RowEventCategoryNodeViewModel.cs
+++ b/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/Nodes/Graph/GraphMembersCategories/RowEventCategoryNodeViewModel.cs
@@ -13,8 +13,6 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 {
 	public class RowEventCategoryNodeViewModel : GraphEventCategoryNodeViewModel
 	{
-		public override bool IsFieldEvent => false;
-
 		public RowEventCategoryNodeViewModel(GraphNodeViewModel graphViewModel, bool isExpanded) : 
 										base(graphViewModel, GraphMemberType.RowEvent, isExpanded)
 		{
@@ -32,11 +30,21 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 							  .Concat(GraphSemanticModel.RowPersistingEvents)
 							  .Concat(GraphSemanticModel.RowPersistedEvents);
 
+		public override IEnumerable<TreeNodeViewModel> GetEventsViewModelsForDAC(DacEventsGroupingNodeViewModel dacVM, 
+																				 IEnumerable<GraphEventInfoBase> graphEventsForDAC,
+																				 bool areChildrenExpanded)
+		{
+			return graphEventsForDAC.OfType<GraphRowEventInfo>()
+									.Select(eventInfo => CreateNewEventVM(dacVM, eventInfo, areChildrenExpanded))
+									.Where(graphMemberVM => graphMemberVM != null && !graphMemberVM.Name.IsNullOrEmpty())
+									.OrderBy(graphMemberVM => graphMemberVM.Name);
+		}
+
 		public override GraphMemberNodeViewModel CreateNewEventVM<TEventNodeParent>(TEventNodeParent eventNodeParent, GraphEventInfoBase eventInfo,
 																					bool isExpanded)
 		{
-			return eventNodeParent is DacEventsGroupingNodeViewModel dacGroupVM
-				? new RowEventNodeViewModel(dacGroupVM, eventInfo, isExpanded)
+			return eventNodeParent is DacEventsGroupingNodeViewModel dacGroupVM && eventInfo is GraphRowEventInfo rowEventInfo
+				? new RowEventNodeViewModel(dacGroupVM, rowEventInfo, isExpanded)
 				: base.CreateNewEventVM(eventNodeParent, eventInfo, isExpanded);
 		}
 	}


### PR DESCRIPTION
…ture. Now each event category node is responsible for creation of the event tree nodes for a DAC grouping node.
Fixed tooltips on the cache attached tree nodes.

Added command preparing and exception handling events to field events - now they will be displayed in Code Map