### PR TITLE
ATR-424: fix the logic for PX1043: it should allow any DB changes in …

### DIFF
--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/SavingChanges/SavingChangesInEventHandlersAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/SavingChanges/SavingChangesInEventHandlersAnalyzer.cs
@@ -109,12 +109,15 @@ namespace Acuminator.Analyzers.StaticAnalysis.SavingChanges
 							return true;
 						}
 					}
-					else if (_pxContext.CodeAnalysisSettings.IsvSpecificAnalyzersEnabled == false &&
-					         IsTransactionOpened == true &&
-							_eventType == EventType.RowPersisted &&
-					         saveOperationKind != SaveOperationKind.CachePersist)
+					else if (_eventType == EventType.RowPersisted)
 					{
-						ReportDiagnostic(_context.ReportDiagnostic, Descriptors.PX1043_SavingChangesInRowPerstistedNonISV, node);
+						if (IsTransactionOpened) 
+							return false;
+
+						ReportDiagnostic(_context.ReportDiagnostic, 
+							_pxContext.CodeAnalysisSettings.IsvSpecificAnalyzersEnabled
+								? Descriptors.PX1043_SavingChangesInEventHandlers
+								: Descriptors.PX1043_SavingChangesInRowPerstistedNonISV, node);
 						return true;
 					}
 					else

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/SavingChanges/SavingChangesInEventHandlersNonISVTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/SavingChanges/SavingChangesInEventHandlersNonISVTests.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Acuminator.Analyzers.StaticAnalysis;
 using Acuminator.Analyzers.StaticAnalysis.EventHandlers;
 using Acuminator.Analyzers.StaticAnalysis.SavingChanges;
@@ -10,7 +6,6 @@ using Acuminator.Tests.Helpers;
 using Acuminator.Tests.Verification;
 using Acuminator.Utilities;
 using Microsoft.CodeAnalysis.Diagnostics;
-using PX.Objects.FA;
 using Xunit;
 
 namespace Acuminator.Tests.Tests.StaticAnalysis.SavingChanges
@@ -26,22 +21,18 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.SavingChanges
 		[Theory]
 		[EmbeddedFileData(@"EventHandlers\PXDatabaseInsertInsideRowPersisted.cs")]
 		public Task ISV_TestDiagnostic_PXDatabaseInsertInsideRowPersisting(string actual) => 
-			VerifyCSharpDiagnosticAsync(
-				source: actual, 
-				expected: Descriptors.PX1043_SavingChangesInRowPerstistedNonISV.CreateFor(18, 5));
+			VerifyCSharpDiagnosticAsync(source: actual);
 
 		[Theory]
 		[EmbeddedFileData(@"EventHandlers\PXDatabaseInsertContainedInMethodInsideRowPersisted.cs")]
 		public Task ISV_TestDiagnostic_PXDatabaseInsertContainedInMethodInsideRowPersisted(string actual) =>
-			VerifyCSharpDiagnosticAsync(
-				source: actual,
-				expected: Descriptors.PX1043_SavingChangesInRowPerstistedNonISV.CreateFor(17, 5));
+			VerifyCSharpDiagnosticAsync(source: actual);
 
 		[Theory]
 		[EmbeddedFileData(@"EventHandlers\PXDatabaseInsertWithoutTranStatusOpenInsideRowPersisted.cs")]
 		public Task ISV_TestDiagnostic_PXDatabaseInsertWithoutTranStatusOpenInsideRowPersisted(string actual) =>
 			VerifyCSharpDiagnosticAsync(
 				source: actual,
-				expected: Descriptors.PX1043_SavingChangesInEventHandlers.CreateFor(16, 4));
+				expected: Descriptors.PX1043_SavingChangesInRowPerstistedNonISV.CreateFor(16, 4));
 	}
 }

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/SavingChanges/SavingChangesInEventHandlersTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/SavingChanges/SavingChangesInEventHandlersTests.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Acuminator.Analyzers.StaticAnalysis;
+﻿using Acuminator.Analyzers.StaticAnalysis;
 using Acuminator.Analyzers.StaticAnalysis.EventHandlers;
 using Acuminator.Analyzers.StaticAnalysis.SavingChanges;
 using Acuminator.Tests.Helpers;


### PR DESCRIPTION
…RowPersisted when the transaction is open, and show warning/error for changes outside the open transaction depending on 'ISV-only' setting