### PR TITLE
ATR-603: changed theme updater to be a static singleton independent f…

### DIFF
--- a/src/Acuminator/Acuminator.Vsix/AcuminatorVSPackage.cs
+++ b/src/Acuminator/Acuminator.Vsix/AcuminatorVSPackage.cs
@@ -99,8 +99,6 @@ namespace Acuminator.Vsix
 			private set;
 		}
 
-		internal ThemeUpdater ThemeUpdater { get; }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="AcuminatorVSPackage"/> class.
         /// </summary>
@@ -112,8 +110,6 @@ namespace Acuminator.Vsix
             // initialization is the Initialize method.
         
             SetupSingleton(this);
-
-			ThemeUpdater = new ThemeUpdater(this);
 		}
         
 		/// <summary>
@@ -259,7 +255,6 @@ namespace Acuminator.Vsix
 		{
 			base.Dispose(disposing);
 			AcuminatorLogger?.Dispose();
-			ThemeUpdater.Dispose();
 
 			SolutionEvents.OnAfterBackgroundSolutionLoadComplete -= SolutionEvents_OnAfterBackgroundSolutionLoadComplete;
 

--- a/src/Acuminator/Acuminator.Vsix/Coloriser/Formats/EditorFormatBase.cs
+++ b/src/Acuminator/Acuminator.Vsix/Coloriser/Formats/EditorFormatBase.cs
@@ -31,8 +31,7 @@ namespace Acuminator.Vsix.Coloriser
                 ForegroundColor = VSColors.GetThemedColor(_classificationTypeName);
             }
 
-            AcuminatorVSPackage.Instance.CheckIfNull(nameof(AcuminatorVSPackage))
-                               .ThemeUpdater.AcuminatorThemeChanged += AcuminatorThemeChangedHandler;
+            ThemeUpdater.Instance.AcuminatorThemeChanged += AcuminatorThemeChangedHandler;
         }
 
 		private void AcuminatorThemeChangedHandler(object sender, AcuminatorThemeChangedEventArgs e)
@@ -75,10 +74,7 @@ namespace Acuminator.Vsix.Coloriser
 
         void IDisposable.Dispose()
         {
-            if (AcuminatorVSPackage.Instance.ThemeUpdater != null)
-            {
-                AcuminatorVSPackage.Instance.ThemeUpdater.AcuminatorThemeChanged -= AcuminatorThemeChangedHandler;
-            }
+            ThemeUpdater.Instance.AcuminatorThemeChanged -= AcuminatorThemeChangedHandler;
         }
     }
 }

--- a/src/Acuminator/Acuminator.Vsix/Coloriser/Formats/Theme/ThemeUpdater.cs
+++ b/src/Acuminator/Acuminator.Vsix/Coloriser/Formats/Theme/ThemeUpdater.cs
@@ -18,7 +18,7 @@ using VSConstants =  Microsoft.VisualStudio.VSConstants;
 
 namespace Acuminator.Vsix.Coloriser
 {
-    internal class ThemeUpdater : IDisposable
+    internal class ThemeUpdater
     {
         private const string TextCategory = "text";
         private const string MefItemsGuidString = "75A05685-00A8-4DED-BAE5-E7A50BFA929A";
@@ -33,10 +33,14 @@ namespace Acuminator.Vsix.Coloriser
 
         public event EventHandler<AcuminatorThemeChangedEventArgs> AcuminatorThemeChanged;
 
+        public static ThemeUpdater Instance { get; } = new ThemeUpdater();
 
-        public ThemeUpdater(IServiceProvider serviceProvider)
+        private ThemeUpdater()
         {
-            _serviceProvider = serviceProvider.CheckIfNull(nameof(serviceProvider));
+			ThreadHelper.ThrowIfNotOnUIThread();
+
+            _serviceProvider = (AcuminatorVSPackage.Instance as IServiceProvider) ?? ServiceProvider.GlobalProvider;
+            _serviceProvider.ThrowOnNull(nameof(_serviceProvider));
 
             VSColorTheme.ThemeChanged += VSColorTheme_ThemeChanged;         
         }
@@ -95,11 +99,6 @@ namespace Acuminator.Vsix.Coloriser
 
                 _fontAndColorStorage.CloseCategory();
             }
-        }
-
-        public void Dispose()
-        {
-            VSColorTheme.ThemeChanged -= VSColorTheme_ThemeChanged;
         }
     }
 }


### PR DESCRIPTION
…rom the package class.

Changed theme updater to be a static singleton independent from the package class. Due to this change theme updater won't be disposed on hte possible apckage unload but it's affordable since the memory cost is low and VS doesn't unload packages anyway currently.
This change should prevent random NRE errors during access to the package singleton instance caused by colorizer editor formats being initialized before the package.