### PR TITLE
Bugfix/atr 528 dev do not close code map

### DIFF
--- a/src/Acuminator/Acuminator.Utilities/Roslyn/ProjectSystem/WorkspaceUtils.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/ProjectSystem/WorkspaceUtils.cs
@@ -91,6 +91,9 @@ namespace Acuminator.Utilities.Roslyn.ProjectSystem
 		private static bool HaveDocumentIdOrProjectIdChanged(WorkspaceChangeEventArgs changeEventArgs, Document? oldDocument) =>
 			oldDocument?.Id != changeEventArgs.DocumentId || oldDocument?.Project.Id != changeEventArgs.ProjectId;
 
+		public static bool IsFullyLoadedProject(this Project project) =>
+			project.CheckIfNull(nameof(project)).FilePath.NullIfWhiteSpace() != null;
+
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static bool IsProjectStatusInSolutionChanged(this WorkspaceChangeEventArgs changeEventArgs) =>
 			changeEventArgs.CheckIfNull(nameof(changeEventArgs)).Kind switch
@@ -118,12 +121,12 @@ namespace Acuminator.Utilities.Roslyn.ProjectSystem
 			if (oldProject == null || newProject == null)
 				return false;
 
-			// For simplicity and performance only the counts of metadata references are checked.
+			// For simplicity and performance only total counts of metadata references are checked.
 			// This does not cover a very rare case of one project metadata reference being replaced by another reference in a single operation.
 			// For example it can be a manual edit of a project file. However, such operations are rare and are highly unlikely to affect Acuminator.
 			// Thus for simplicity and performance reasons set equality is not checked for project metadata references
-			return oldProject.MetadataReferences.Count == newProject.MetadataReferences.Count &&
-				   oldProject.AllProjectReferences.Count == newProject.AllProjectReferences.Count;
+			return oldProject.MetadataReferences.Count != newProject.MetadataReferences.Count ||
+				   oldProject.AllProjectReferences.Count != newProject.AllProjectReferences.Count;
 		}
 	}
 }

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/ProjectSystem/WorkspaceUtils.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/ProjectSystem/WorkspaceUtils.cs
@@ -92,6 +92,15 @@ namespace Acuminator.Utilities.Roslyn.ProjectSystem
 			oldDocument?.Id != changeEventArgs.DocumentId || oldDocument?.Project.Id != changeEventArgs.ProjectId;
 
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static bool IsProjectStatusInSolutionChanged(this WorkspaceChangeEventArgs changeEventArgs) =>
+			changeEventArgs.CheckIfNull(nameof(changeEventArgs)).Kind switch
+			{
+				WorkspaceChangeKind.ProjectAdded => true,
+				WorkspaceChangeKind.ProjectRemoved => true,
+				_ => false
+			};
+
+
 		public static bool IsProjectMetadataChanged(this WorkspaceChangeEventArgs changeEventArgs)
 		{
 			changeEventArgs.ThrowOnNull(nameof(changeEventArgs));

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/ProjectSystem/WorkspaceUtils.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/ProjectSystem/WorkspaceUtils.cs
@@ -1,11 +1,14 @@
-﻿using System;
+﻿#nullable enable
+
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Globalization;
 using System.Linq;
 using System.Runtime.CompilerServices;
+
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Formatting;
+
 using Acuminator.Utilities.Common;
 using Acuminator.Utilities.DiagnosticSuppression;
 
@@ -46,7 +49,7 @@ namespace Acuminator.Utilities.Roslyn.ProjectSystem
 			return workspace.Options.GetOption(FormattingOptions.IndentationSize, LanguageNames.CSharp);
 		}		
 
-		public static bool IsActiveDocumentCleared(this WorkspaceChangeEventArgs changeEventArgs, Document oldDocument) =>
+		public static bool IsActiveDocumentCleared(this WorkspaceChangeEventArgs changeEventArgs, Document? oldDocument) =>
 			changeEventArgs.CheckIfNull(nameof(changeEventArgs)).Kind switch
 			{
 				var kind when kind == WorkspaceChangeKind.SolutionRemoved ||
@@ -61,7 +64,7 @@ namespace Acuminator.Utilities.Roslyn.ProjectSystem
 			};
 
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static bool IsActiveDocumentChanged(this WorkspaceChangeEventArgs changeEventArgs, Document oldDocument)
+		public static bool IsActiveDocumentChanged(this WorkspaceChangeEventArgs changeEventArgs, Document? oldDocument)
 		{
 			changeEventArgs.ThrowOnNull(nameof(changeEventArgs));
 
@@ -72,7 +75,7 @@ namespace Acuminator.Utilities.Roslyn.ProjectSystem
 		}
 
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static bool IsDocumentTextChanged(this WorkspaceChangeEventArgs changeEventArgs, Document oldDocument)
+		public static bool IsDocumentTextChanged(this WorkspaceChangeEventArgs changeEventArgs, Document? oldDocument)
 		{
 			changeEventArgs.ThrowOnNull(nameof(changeEventArgs));
 
@@ -85,7 +88,7 @@ namespace Acuminator.Utilities.Roslyn.ProjectSystem
 			return !HaveDocumentIdOrProjectIdChanged(changeEventArgs, oldDocument);
 		}
 
-		private static bool HaveDocumentIdOrProjectIdChanged(WorkspaceChangeEventArgs changeEventArgs, Document oldDocument) =>
+		private static bool HaveDocumentIdOrProjectIdChanged(WorkspaceChangeEventArgs changeEventArgs, Document? oldDocument) =>
 			oldDocument?.Id != changeEventArgs.DocumentId || oldDocument?.Project.Id != changeEventArgs.ProjectId;
 	}
 }

--- a/src/Acuminator/Acuminator.Vsix/AcuminatorVSPackage.cs
+++ b/src/Acuminator/Acuminator.Vsix/AcuminatorVSPackage.cs
@@ -60,7 +60,7 @@ namespace Acuminator.Vsix
 	[Guid(AcuminatorVSPackage.PackageGuidString)]
 	[ProvideOptionPage(typeof(GeneralOptionsPage), SettingsCategoryName, GeneralOptionsPage.PageTitle,
 					   categoryResourceID: 201, pageNameResourceID: 202, supportsAutomation: true, SupportsProfiles = true)]
-	[ProvideToolWindow(typeof(CodeMapWindow), MultiInstances = false, Transient = true, Orientation = ToolWindowOrientation.Left,
+	[ProvideToolWindow(typeof(CodeMapWindow), MultiInstances = false, Transient = false, Orientation = ToolWindowOrientation.Left,
 					   Style = VsDockStyle.Linked)]
 	public sealed class AcuminatorVSPackage : AsyncPackage
 	{

--- a/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/Model/DocumentModel.cs
+++ b/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/Model/DocumentModel.cs
@@ -1,16 +1,20 @@
-﻿using System;
+﻿#nullable enable
+
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.VisualStudio.Text.Editor;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Text;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
+
 using Acuminator.Utilities.Common;
 using Acuminator.Utilities.Roslyn.Semantic;
 using Acuminator.Vsix.Utilities;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.Text.Editor;
 
 namespace Acuminator.Vsix.ToolWindows.CodeMap
 {
@@ -28,13 +32,13 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 			private set;
 		}
 
-		public SyntaxNode Root
+		public SyntaxNode? Root
 		{
 			get;
 			private set;
 		}
 
-		public SemanticModel SemanticModel { get; private set; }
+		public SemanticModel? SemanticModel { get; private set; }
 
 		private readonly List<ISemanticModel> _codeMapSemanticModels = new List<ISemanticModel>(capacity: 4);
 

--- a/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/OpenCodeMapWindowCommand.cs
+++ b/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/OpenCodeMapWindowCommand.cs
@@ -1,15 +1,7 @@
 ﻿using System;
-using System.ComponentModel.Design;
-using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.Shell;
-using Microsoft.VisualStudio.Shell.Interop;
-using Microsoft.VisualStudio.Text;
-using Microsoft.VisualStudio.Text.Editor;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Text;
-using Acuminator.Vsix.Utilities;
 
 namespace Acuminator.Vsix.ToolWindows.CodeMap
 {
@@ -55,33 +47,6 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 		protected override async Task<CodeMapWindow> OpenToolWindowAsync()
 		{
 			CodeMapWindow codeMapWindow = await base.OpenToolWindowAsync();
-
-			if (codeMapWindow?.CodeMapWPFControl == null)
-				return codeMapWindow;
-
-			IWpfTextView textView = await ServiceProvider.GetWpfTextViewAsync();
-			Document document = textView?.TextSnapshot?.GetOpenDocumentInCurrentContextWithChanges();
-			CodeMapWindowViewModel codeMapViewModel = codeMapWindow.CodeMapWPFControl.DataContext as CodeMapWindowViewModel;
-
-			if (document == null)
-			{
-				if (codeMapViewModel != null)
-				{
-					await codeMapViewModel.RefreshCodeMapOnWindowOpeningAsync(textView, document);
-				}
-				
-				return codeMapWindow;
-			}
-
-			if (codeMapViewModel != null)
-			{
-				await codeMapViewModel.RefreshCodeMapOnWindowOpeningAsync(textView, document);
-			}
-			else
-			{
-				codeMapWindow.CodeMapWPFControl.DataContext = CodeMapWindowViewModel.InitCodeMap(textView, document);
-			}
-	
 			return codeMapWindow;
 		}
 	}

--- a/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/Builders/Base/TreeBuilderBase.cs
+++ b/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/Builders/Base/TreeBuilderBase.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#nullable enable
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -30,7 +32,7 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 
 		public virtual TreeViewModel CreateEmptyCodeMapTree(CodeMapWindowViewModel windowViewModel) => new TreeViewModel(windowViewModel);
 
-		public TreeViewModel BuildCodeMapTree(CodeMapWindowViewModel windowViewModel, bool expandRoots, bool expandChildren, CancellationToken cancellation)
+		public TreeViewModel? BuildCodeMapTree(CodeMapWindowViewModel windowViewModel, bool expandRoots, bool expandChildren, CancellationToken cancellation)
 		{
 			windowViewModel.ThrowOnNull(nameof(windowViewModel));
 
@@ -45,7 +47,7 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 			}		
 		}
 
-		protected TreeViewModel BuildCodeMapTree(CodeMapWindowViewModel windowViewModel, bool expandRoots, bool expandChildren)
+		protected TreeViewModel? BuildCodeMapTree(CodeMapWindowViewModel windowViewModel, bool expandRoots, bool expandChildren)
 		{
 			Cancellation.ThrowIfCancellationRequested();
 
@@ -60,7 +62,7 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 			try
 			{
 				ExpandCreatedNodes = expandRoots;
-				roots = CreateRoots(codeMapTree)?.Where(root => root != null).ToList();
+				roots = CreateRoots(codeMapTree).Where(root => root != null).ToList();
 			}
 			finally
 			{
@@ -114,14 +116,15 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 		protected virtual void BuildSubTree(TreeNodeViewModel subtreeRoot)
 		{
 			var generatedChildrenSeq = VisitNode(subtreeRoot);
-			var children = (generatedChildrenSeq as List<TreeNodeViewModel>) ?? generatedChildrenSeq?.ToList();
+			List<TreeNodeViewModel>? children = (generatedChildrenSeq as List<TreeNodeViewModel>) ?? generatedChildrenSeq?.ToList();
 
 			if (children.IsNullOrEmpty())
 				return;
 
-			foreach (var child in children)
+			foreach (TreeNodeViewModel? child in children!)
 			{
-				BuildSubTree(child);
+				if (child != null)
+					BuildSubTree(child);
 			}
 
 			var childrenToAdd = children.Where(c => c != null && (c.Children.Count > 0 || c.DisplayNodeWithoutChildren));

--- a/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/CodeMapWindowViewModel.CodeMapDteEventsObserver.cs
+++ b/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/CodeMapWindowViewModel.CodeMapDteEventsObserver.cs
@@ -1,15 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.CodeAnalysis;
 
 using Acuminator.Utilities;
-using Acuminator.Vsix.Logger;
 using Acuminator.Vsix.Utilities;
 using Acuminator.Utilities.Common;
 

--- a/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/CodeMapWindowViewModel.cs
+++ b/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/CodeMapWindowViewModel.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#nullable enable
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -26,7 +28,7 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 	public partial class CodeMapWindowViewModel : ToolWindowViewModelBase
 	{
 		private readonly CodeMapDteEventsObserver _dteEventsObserver;
-		private CancellationTokenSource _cancellationTokenSource;
+		private CancellationTokenSource? _cancellationTokenSource;
 
 		public TreeBuilderBase TreeBuilder
 		{
@@ -48,9 +50,9 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 			internal set;
 		}
 
-		private DocumentModel _documentModel;
+		private DocumentModel? _documentModel;
 
-		public DocumentModel DocumentModel
+		public DocumentModel? DocumentModel
 		{
 			get => _documentModel;
 			private set
@@ -64,7 +66,7 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 			}
 		}
 
-		public Document Document => DocumentModel?.Document;
+		public Document? Document => DocumentModel?.Document;
 
 		public Workspace Workspace
 		{
@@ -83,9 +85,9 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 			set;
 		}
 
-		private TreeViewModel _tree;
+		private TreeViewModel? _tree;
 
-		public TreeViewModel Tree
+		public TreeViewModel? Tree
 		{
 			get => _tree;
 			private set
@@ -203,7 +205,7 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 			return codeMapViewModel;
 		}
 
-		public void SortNodes(TreeNodeViewModel node, SortType sortType, SortDirection sortDirection, bool sortDescendants)
+		public void SortNodes(TreeNodeViewModel? node, SortType sortType, SortDirection sortDirection, bool sortDescendants)
 		{
 			if (node == null)
 				return;
@@ -394,7 +396,7 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 			}
 		}
 
-		private void ExpandOrCollapseNodeDescendants(TreeNodeViewModel node)
+		private void ExpandOrCollapseNodeDescendants(TreeNodeViewModel? node)
 		{
 			if (node != null)
 			{

--- a/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/CodeMapWindowViewModel.cs
+++ b/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/CodeMapWindowViewModel.cs
@@ -312,23 +312,23 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 			}
 			else if (e.IsDocumentTextChanged(Document))
 			{
-				await HandleWorkspaceChangesAsync(newWorkspace, e, onlyActiveDocumentWasChanged: true)
+				await HandleWorkspaceChangesAsync(newWorkspace, e.NewSolution, e.DocumentId, onlyActiveDocumentWasChanged: true)
 						.ConfigureAwait(false);
 			}
 			else if (Document?.Project != null && 
 					(Document.Project.Id == e.ProjectId || !Document.Project.IsFullyLoadedProject()) && 
 					(e.IsProjectStatusInSolutionChanged() || e.IsProjectMetadataChanged()))
 			{
-				await HandleWorkspaceChangesAsync(newWorkspace, e, onlyActiveDocumentWasChanged: false)
+				await HandleWorkspaceChangesAsync(newWorkspace, e.NewSolution, Document.Id, onlyActiveDocumentWasChanged: false)
 						.ConfigureAwait(false);
 			}
 		}
 
-		private async Task HandleWorkspaceChangesAsync(Workspace newWorkspace, WorkspaceChangeEventArgs e, 
-													   bool onlyActiveDocumentWasChanged)
+		private async Task HandleWorkspaceChangesAsync(Workspace newWorkspace, Microsoft.CodeAnalysis.Solution newSolution, 
+													   DocumentId activeDocumentID, bool onlyActiveDocumentWasChanged)
 		{
 			Workspace = newWorkspace;
-			Document? changedDocument = e.NewSolution.GetDocument(e.DocumentId);
+			Document? changedDocument = newSolution.GetDocument(activeDocumentID);
 			Document? oldDocument = Document;
 			SyntaxNode? oldRoot = DocumentModel?.Root;
 

--- a/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/CodeMapWindowViewModel.cs
+++ b/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/CodeMapWindowViewModel.cs
@@ -186,9 +186,11 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 			_dteEventsObserver = new CodeMapDteEventsObserver(this);
 		}
 
-		public static CodeMapWindowViewModel InitCodeMap(IWpfTextView wpfTextView, Document document)
+		public static CodeMapWindowViewModel InitEmptyCodeMap() => InitCodeMap(wpfTextView: null, document: null);
+
+		public static CodeMapWindowViewModel InitCodeMap(IWpfTextView? wpfTextView, Document? document)
 		{
-			var codeMapViewModel = wpfTextView == null || document == null
+			var codeMapViewModel = wpfTextView != null && document != null
 				? new CodeMapWindowViewModel(wpfTextView, document)
 				: new CodeMapWindowViewModel();
 

--- a/src/Acuminator/Acuminator.Vsix/source.extension.vsixmanifest
+++ b/src/Acuminator/Acuminator.Vsix/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="Acumatica.Acuminator.778b19d1-1d5e-4fcb-8edb-eb103feeab7c" Version="2.4" Language="en-US" Publisher="Acumatica" />
+        <Identity Id="Acumatica.Acuminator.778b19d1-1d5e-4fcb-8edb-eb103feeab7c" Version="3.0" Language="en-US" Publisher="Acumatica" />
         <DisplayName>Acuminator</DisplayName>
         <Description xml:space="preserve">Acuminator is a Visual Studio extension that simplifies development with Acumatica Framework.  Acuminator provides the following functionality to boost developer productivity:
 - Static code analysis diagnostics, code fixes, and refactorings
@@ -17,16 +17,16 @@
         <Tags>acumatica</Tags>
     </Metadata>
     <Installation>
-		<InstallationTarget Version="[15.0,17.0)" Id="Microsoft.VisualStudio.Community">
-			<ProductArchitecture>x86</ProductArchitecture>
-		</InstallationTarget>
-		<InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Community">
-			<ProductArchitecture>amd64</ProductArchitecture>
-		</InstallationTarget>
+        <InstallationTarget Version="[15.0,17.0)" Id="Microsoft.VisualStudio.Community">
+            <ProductArchitecture>x86</ProductArchitecture>
+        </InstallationTarget>
+        <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Community">
+            <ProductArchitecture>amd64</ProductArchitecture>
+        </InstallationTarget>
     </Installation>
     <Dependencies>
         <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.7.2,)" />
-		<Dependency Id="Microsoft.VisualStudio.MPF.11.0" DisplayName="Visual Studio MPF 11.0" d:Source="Installed" Version="[11.0,12.0)" />
+        <Dependency Id="Microsoft.VisualStudio.MPF.11.0" DisplayName="Visual Studio MPF 11.0" d:Source="Installed" Version="[11.0,12.0)" />
     </Dependencies>
     <Assets>
         <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="Acuminator.Analyzers" Path="|Acuminator.Analyzers|" />


### PR DESCRIPTION
Changes overview:
- reworked Code Map view model creation to be done from Code Map window initialization instead of "Open Code Map" VS command
- added handling of project changes to recalculate Code Map when project metadata changes. This is required to calculate Code Map when project finishes background loading
- changed VSIX version to 3.0