### PR TITLE
Feature/atr 148 dev graph captured in long run closure

### DIFF
--- a/src/Acuminator/Acuminator.Analyzers/Resources.Designer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/Resources.Designer.cs
@@ -286,7 +286,7 @@ namespace Acuminator.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Reference of @this graph in this delegate will cause synchronous delegate execution. It may lead to random bugs and data consistency issues..
+        ///   Looks up a localized string similar to Reference of @this graph in this delegate will cause synchronous delegate execution. It may lead to random bugs and data consistency issues.
         /// </summary>
         public static string PX1008Title {
             get {

--- a/src/Acuminator/Acuminator.Analyzers/Resources.Designer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace Acuminator.Analyzers {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Resources {
@@ -286,7 +286,7 @@ namespace Acuminator.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Reference of @this graph in this delegate will cause synchronous delegate execution.
+        ///   Looks up a localized string similar to Reference of @this graph in this delegate will cause synchronous delegate execution. It may lead to random bugs and data consistency issues..
         /// </summary>
         public static string PX1008Title {
             get {
@@ -1325,7 +1325,7 @@ namespace Acuminator.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Calls to Acumatica internal API marked with PXInternalUseOnlyAttribute are forbidden.
+        ///   Looks up a localized string similar to This code calls Acumatica internal API marked with PXInternalUseOnlyAttribute which is not intended for public use.
         /// </summary>
         public static string PX1076Title {
             get {

--- a/src/Acuminator/Acuminator.Analyzers/Resources.resx
+++ b/src/Acuminator/Acuminator.Analyzers/Resources.resx
@@ -166,7 +166,7 @@
     <value>A public {0} should have a description in the summary XML tag</value>
   </data>
   <data name="PX1008Title" xml:space="preserve">
-    <value>Reference of @this graph in this delegate will cause synchronous delegate execution. It may lead to random bugs and data consistency issues.</value>
+    <value>Reference of @this graph in this delegate will cause synchronous delegate execution. It may lead to random bugs and data consistency issues</value>
   </data>
   <data name="PX1009Fix" xml:space="preserve">
     <value>Change the base type to a PXCacheExtension overload</value>

--- a/src/Acuminator/Acuminator.Analyzers/Resources.resx
+++ b/src/Acuminator/Acuminator.Analyzers/Resources.resx
@@ -166,7 +166,7 @@
     <value>A public {0} should have a description in the summary XML tag</value>
   </data>
   <data name="PX1008Title" xml:space="preserve">
-    <value>Reference of @this graph in this delegate will cause synchronous delegate execution</value>
+    <value>Reference of @this graph in this delegate will cause synchronous delegate execution. It may lead to random bugs and data consistency issues.</value>
   </data>
   <data name="PX1009Fix" xml:space="preserve">
     <value>Change the base type to a PXCacheExtension overload</value>

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/LongOperationDelegateClosures/LongOperationDelegateClosuresAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/LongOperationDelegateClosures/LongOperationDelegateClosuresAnalyzer.cs
@@ -1,9 +1,14 @@
-﻿using System.Collections.Immutable;
+﻿#nullable enable
+
+using System.Collections.Immutable;
 using System.Linq;
 
 using Acuminator.Utilities;
+using Acuminator.Utilities.Common;
 using Acuminator.Utilities.DiagnosticSuppression;
+using Acuminator.Utilities.Roslyn.Constants;
 using Acuminator.Utilities.Roslyn.Semantic;
+using Acuminator.Utilities.Roslyn.Syntax;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -15,7 +20,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.LongOperationDelegateClosures
 	[DiagnosticAnalyzer(LanguageNames.CSharp)]
     public class LongOperationDelegateClosuresAnalyzer : PXDiagnosticAnalyzer
     {
-		private const string SetProcessDelegateMethodName = "SetProcessDelegate";
+		private readonly LongOperationDelegateTypeClassifier _longOperationDelegateTypeClassifier = new LongOperationDelegateTypeClassifier();
 
 		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
             ImmutableArray.Create(Descriptors.PX1008_LongOperationDelegateClosures);
@@ -23,86 +28,81 @@ namespace Acuminator.Analyzers.StaticAnalysis.LongOperationDelegateClosures
 		public LongOperationDelegateClosuresAnalyzer() : this(null)
 		{ }
 
-		public LongOperationDelegateClosuresAnalyzer(CodeAnalysisSettings codeAnalysisSettings) : base(codeAnalysisSettings)
+		public LongOperationDelegateClosuresAnalyzer(CodeAnalysisSettings? codeAnalysisSettings) : base(codeAnalysisSettings)
 		{ }
 
 		internal override void AnalyzeCompilation(CompilationStartAnalysisContext compilationStartContext, PXContext pxContext)
 		{
-            compilationStartContext.RegisterSyntaxNodeAction(c => AnalyzeSetProcessDelegateMethod(c, pxContext), SyntaxKind.InvocationExpression);
+            compilationStartContext.RegisterSyntaxNodeAction(c => AnalyzeLongOperationDelegate(c, pxContext), SyntaxKind.InvocationExpression);
 		}
 
-		private static void AnalyzeSetProcessDelegateMethod(SyntaxNodeAnalysisContext syntaxContext, PXContext pxContext)
+		private void AnalyzeLongOperationDelegate(SyntaxNodeAnalysisContext syntaxContext, PXContext pxContext)
 		{
-			var setDelegateInvocation = syntaxContext.Node as InvocationExpressionSyntax;
+			var longOperationSetupMethodInvocationNode = syntaxContext.Node as InvocationExpressionSyntax;
+			var longOperationDelegateType = _longOperationDelegateTypeClassifier.GetLongOperationDelegateType(longOperationSetupMethodInvocationNode, 
+																											  syntaxContext.SemanticModel, pxContext,
+																											  syntaxContext.CancellationToken);
+			switch (longOperationDelegateType)
+			{
+				case LongOperationDelegateType.ProcessingDelegate:
+					AnalyzeSetProcessDelegateMethod(syntaxContext, pxContext, longOperationSetupMethodInvocationNode!);
+					break;
 
-			if (!CheckIfDiagnosticIsValid(setDelegateInvocation, syntaxContext, pxContext))
-				return;
-            
-            DataFlowAnalysis dfa = null;
+				case LongOperationDelegateType.LongRunDelegate:
+					break;
+			}
+		}
 
-            switch (setDelegateInvocation.ArgumentList.Arguments[0].Expression)
-            {
-                case IdentifierNameSyntax ins:
-					ISymbol identifierSymbol = syntaxContext.SemanticModel.GetSymbolInfo(ins, syntaxContext.CancellationToken).Symbol;
+		private static void AnalyzeSetProcessDelegateMethod(SyntaxNodeAnalysisContext syntaxContext, PXContext pxContext, 
+															InvocationExpressionSyntax setDelegateInvocation)
+		{
+			DataFlowAnalysis? dfa = null;
+
+			switch (setDelegateInvocation.ArgumentList.Arguments[0].Expression)
+			{
+				case IdentifierNameSyntax ins:
+					ISymbol identifierSymbol = syntaxContext.SemanticModel?.GetSymbolInfo(ins, syntaxContext.CancellationToken).Symbol;
 
 					if (identifierSymbol != null && !identifierSymbol.IsStatic)
-                    {
-                        syntaxContext.ReportDiagnosticWithSuppressionCheck(
-                            Diagnostic.Create(
-                                Descriptors.PX1008_LongOperationDelegateClosures, setDelegateInvocation.GetLocation()),
+					{
+						syntaxContext.ReportDiagnosticWithSuppressionCheck(
+							Diagnostic.Create(
+								Descriptors.PX1008_LongOperationDelegateClosures, setDelegateInvocation.GetLocation()),
 							pxContext.CodeAnalysisSettings);
-                    }
+					}
 
-                    return;
-				case MemberAccessExpressionSyntax memberAccess 
+					return;
+				case MemberAccessExpressionSyntax memberAccess
 				when memberAccess.Expression is ElementAccessExpressionSyntax arrayIndexAccess:
 					AnalyzeMemberAccessExpressions(arrayIndexAccess.Expression, syntaxContext, pxContext);
 					return;
 				case MemberAccessExpressionSyntax memberAccess:
 					AnalyzeMemberAccessExpressions(memberAccess.Expression, syntaxContext, pxContext);
 					return;
-				case ConditionalAccessExpressionSyntax conditionalAccess 
+				case ConditionalAccessExpressionSyntax conditionalAccess
 				when conditionalAccess.Expression is ElementAccessExpressionSyntax arrayIndexAccess:
 					AnalyzeMemberAccessExpressions(arrayIndexAccess.Expression, syntaxContext, pxContext);
 					return;
 				case ConditionalAccessExpressionSyntax conditionalAccess:
 					AnalyzeMemberAccessExpressions(conditionalAccess.Expression, syntaxContext, pxContext);
 					return;
-                case AnonymousMethodExpressionSyntax anonMethodNode:
-                    dfa = syntaxContext.SemanticModel.AnalyzeDataFlow(anonMethodNode);
-                    break;
-                case LambdaExpressionSyntax lambdaNode:
-                    dfa = syntaxContext.SemanticModel.AnalyzeDataFlow(lambdaNode);
-                    break;
-            }
-
-            if (dfa != null && dfa.DataFlowsIn.OfType<IParameterSymbol>().Any(p => p.IsThis))
-            {
-                syntaxContext.ReportDiagnosticWithSuppressionCheck(
-                    Diagnostic.Create(
-                        Descriptors.PX1008_LongOperationDelegateClosures, setDelegateInvocation.GetLocation()),
-					pxContext.CodeAnalysisSettings);
-            }
-        }
-
-		private static bool CheckIfDiagnosticIsValid(InvocationExpressionSyntax setDelegateInvocation, SyntaxNodeAnalysisContext syntaxContext,
-													 PXContext pxContext)
-		{
-			var setDelegatememberAccessExpr = setDelegateInvocation?.Expression as MemberAccessExpressionSyntax;
-
-			if (setDelegatememberAccessExpr?.Name.ToString() != SetProcessDelegateMethodName ||
-				syntaxContext.CancellationToken.IsCancellationRequested)
-			{
-				return false;
+				case AnonymousMethodExpressionSyntax anonMethodNode:
+					dfa = syntaxContext.SemanticModel.AnalyzeDataFlow(anonMethodNode);
+					break;
+				case LambdaExpressionSyntax lambdaNode:
+					dfa = syntaxContext.SemanticModel.AnalyzeDataFlow(lambdaNode);
+					break;
 			}
 
-			var setDelegateSymbol = syntaxContext.SemanticModel.GetSymbolInfo(setDelegatememberAccessExpr).Symbol as IMethodSymbol;
-
-			if (setDelegateSymbol == null || !setDelegateSymbol.ContainingType.ConstructedFrom.InheritsFromOrEquals(pxContext.PXProcessingBase.Type))
-				return false;
-
-			return true;
+			if (dfa != null && dfa.DataFlowsIn.OfType<IParameterSymbol>().Any(p => p.IsThis))
+			{
+				syntaxContext.ReportDiagnosticWithSuppressionCheck(
+					Diagnostic.Create(
+						Descriptors.PX1008_LongOperationDelegateClosures, setDelegateInvocation.GetLocation()),
+					pxContext.CodeAnalysisSettings);
+			}
 		}
+
 
 		private static void AnalyzeMemberAccessExpressions(ExpressionSyntax expression, SyntaxNodeAnalysisContext syntaxContext, 
 														   PXContext pxContext)

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/LongOperationDelegateClosures/LongOperationDelegateClosuresAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/LongOperationDelegateClosures/LongOperationDelegateClosuresAnalyzer.cs
@@ -56,8 +56,14 @@ namespace Acuminator.Analyzers.StaticAnalysis.LongOperationDelegateClosures
 		private static void AnalyzeSetProcessDelegateMethod(SyntaxNodeAnalysisContext syntaxContext, PXContext pxContext, 
 															InvocationExpressionSyntax setDelegateInvocation)
 		{
-			ExpressionSyntax processDelegateParameterExpression = setDelegateInvocation.ArgumentList.Arguments[0].Expression;
-			AnalyzeDataFlowForDelegateMethod(syntaxContext, pxContext, setDelegateInvocation, processDelegateParameterExpression);	
+			ExpressionSyntax processingDelegateParameter = setDelegateInvocation.ArgumentList.Arguments[0].Expression;
+			AnalyzeDataFlowForDelegateMethod(syntaxContext, pxContext, setDelegateInvocation, processingDelegateParameter);	
+
+			if (setDelegateInvocation.ArgumentList.Arguments.Count > 1)
+			{
+				ExpressionSyntax finallyHandlerDelegateParameter = setDelegateInvocation.ArgumentList.Arguments[1].Expression;
+				AnalyzeDataFlowForDelegateMethod(syntaxContext, pxContext, setDelegateInvocation, finallyHandlerDelegateParameter);
+			}
 		}
 
 		private static void AnalyzeDataFlowForDelegateMethod(SyntaxNodeAnalysisContext syntaxContext, PXContext pxContext,

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/LongOperationDelegateClosures/LongOperationDelegateClosuresAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/LongOperationDelegateClosures/LongOperationDelegateClosuresAnalyzer.cs
@@ -49,6 +49,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.LongOperationDelegateClosures
 					break;
 
 				case LongOperationDelegateType.LongRunDelegate:
+					AnalyzeStartOperationDelegateMethod(syntaxContext, pxContext, longOperationSetupMethodInvocationNode!);
 					break;
 			}
 		}
@@ -56,6 +57,9 @@ namespace Acuminator.Analyzers.StaticAnalysis.LongOperationDelegateClosures
 		private static void AnalyzeSetProcessDelegateMethod(SyntaxNodeAnalysisContext syntaxContext, PXContext pxContext, 
 															InvocationExpressionSyntax setDelegateInvocation)
 		{
+			if (setDelegateInvocation.ArgumentList.Arguments.Count == 0)
+				return;
+
 			ExpressionSyntax processingDelegateParameter = setDelegateInvocation.ArgumentList.Arguments[0].Expression;
 			AnalyzeDataFlowForDelegateMethod(syntaxContext, pxContext, setDelegateInvocation, processingDelegateParameter);	
 
@@ -66,10 +70,22 @@ namespace Acuminator.Analyzers.StaticAnalysis.LongOperationDelegateClosures
 			}
 		}
 
+		private static void AnalyzeStartOperationDelegateMethod(SyntaxNodeAnalysisContext syntaxContext, PXContext pxContext,
+																InvocationExpressionSyntax startOperationInvocation)
+		{
+			if (startOperationInvocation.ArgumentList.Arguments.Count < 2)
+				return;
+
+			ExpressionSyntax longRunDelegateParameter = startOperationInvocation.ArgumentList.Arguments[1].Expression;
+			AnalyzeDataFlowForDelegateMethod(syntaxContext, pxContext, startOperationInvocation, longRunDelegateParameter);
+		}
+
 		private static void AnalyzeDataFlowForDelegateMethod(SyntaxNodeAnalysisContext syntaxContext, PXContext pxContext,
 															 InvocationExpressionSyntax longOperationSetupMethodInvocationNode,
 															 ExpressionSyntax longOperationDelegateNode)
 		{
+			syntaxContext.CancellationToken.ThrowIfCancellationRequested();
+
 			switch (longOperationDelegateNode)
 			{
 				case IdentifierNameSyntax graphMemberName:

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/LongOperationDelegateClosures/LongOperationDelegateClosuresAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/LongOperationDelegateClosures/LongOperationDelegateClosuresAnalyzer.cs
@@ -56,51 +56,61 @@ namespace Acuminator.Analyzers.StaticAnalysis.LongOperationDelegateClosures
 		private static void AnalyzeSetProcessDelegateMethod(SyntaxNodeAnalysisContext syntaxContext, PXContext pxContext, 
 															InvocationExpressionSyntax setDelegateInvocation)
 		{
-			DataFlowAnalysis? dfa = null;
+			ExpressionSyntax processDelegateParameterExpression = setDelegateInvocation.ArgumentList.Arguments[0].Expression;
+			AnalyzeDataFlowForDelegateMethod(syntaxContext, pxContext, setDelegateInvocation, processDelegateParameterExpression);	
+		}
 
-			switch (setDelegateInvocation.ArgumentList.Arguments[0].Expression)
+		private static void AnalyzeDataFlowForDelegateMethod(SyntaxNodeAnalysisContext syntaxContext, PXContext pxContext,
+															 InvocationExpressionSyntax longOperationSetupMethodInvocationNode,
+															 ExpressionSyntax longOperationDelegateNode)
+		{
+			switch (longOperationDelegateNode)
 			{
-				case IdentifierNameSyntax ins:
-					ISymbol identifierSymbol = syntaxContext.SemanticModel?.GetSymbolInfo(ins, syntaxContext.CancellationToken).Symbol;
+				case IdentifierNameSyntax graphMemberName:
+					ISymbol? graphMemberSymbol = syntaxContext.SemanticModel.GetSymbolInfo(graphMemberName, syntaxContext.CancellationToken).Symbol;
 
-					if (identifierSymbol != null && !identifierSymbol.IsStatic)
+					if (graphMemberSymbol?.ContainingType != null && !graphMemberSymbol.IsStatic && 
+						graphMemberSymbol.ContainingType.IsPXGraphOrExtension(pxContext))
 					{
 						syntaxContext.ReportDiagnosticWithSuppressionCheck(
 							Diagnostic.Create(
-								Descriptors.PX1008_LongOperationDelegateClosures, setDelegateInvocation.GetLocation()),
-							pxContext.CodeAnalysisSettings);
+								Descriptors.PX1008_LongOperationDelegateClosures, longOperationSetupMethodInvocationNode.GetLocation()),
+								pxContext.CodeAnalysisSettings);
 					}
 
 					return;
+
 				case MemberAccessExpressionSyntax memberAccess
 				when memberAccess.Expression is ElementAccessExpressionSyntax arrayIndexAccess:
 					AnalyzeMemberAccessExpressions(arrayIndexAccess.Expression, syntaxContext, pxContext);
 					return;
+
 				case MemberAccessExpressionSyntax memberAccess:
 					AnalyzeMemberAccessExpressions(memberAccess.Expression, syntaxContext, pxContext);
 					return;
+
 				case ConditionalAccessExpressionSyntax conditionalAccess
 				when conditionalAccess.Expression is ElementAccessExpressionSyntax arrayIndexAccess:
 					AnalyzeMemberAccessExpressions(arrayIndexAccess.Expression, syntaxContext, pxContext);
 					return;
+
 				case ConditionalAccessExpressionSyntax conditionalAccess:
 					AnalyzeMemberAccessExpressions(conditionalAccess.Expression, syntaxContext, pxContext);
 					return;
-				case AnonymousMethodExpressionSyntax anonMethodNode:
-					dfa = syntaxContext.SemanticModel.AnalyzeDataFlow(anonMethodNode);
-					break;
-				case LambdaExpressionSyntax lambdaNode:
-					dfa = syntaxContext.SemanticModel.AnalyzeDataFlow(lambdaNode);
-					break;
-			}
 
-			if (dfa != null && dfa.DataFlowsIn.OfType<IParameterSymbol>().Any(p => p.IsThis))
-			{
-				syntaxContext.ReportDiagnosticWithSuppressionCheck(
-					Diagnostic.Create(
-						Descriptors.PX1008_LongOperationDelegateClosures, setDelegateInvocation.GetLocation()),
-					pxContext.CodeAnalysisSettings);
-			}
+				case AnonymousFunctionExpressionSyntax anonMethodOrLambdaNode:
+					DataFlowAnalysis? dfa = syntaxContext.SemanticModel.AnalyzeDataFlow(anonMethodOrLambdaNode);
+
+					if (dfa != null && dfa.Succeeded && dfa.DataFlowsIn.OfType<IParameterSymbol>().Any(p => p.IsThis))
+					{
+						syntaxContext.ReportDiagnosticWithSuppressionCheck(
+							Diagnostic.Create(
+								Descriptors.PX1008_LongOperationDelegateClosures, longOperationSetupMethodInvocationNode.GetLocation()),
+								pxContext.CodeAnalysisSettings);
+					}
+
+					return;	
+			}	
 		}
 
 
@@ -112,16 +122,19 @@ namespace Acuminator.Analyzers.StaticAnalysis.LongOperationDelegateClosures
 
 			ISymbol identifierSymbol = syntaxContext.SemanticModel.GetSymbolInfo(identifier, syntaxContext.CancellationToken).Symbol;
 
-			if (identifierSymbol == null || syntaxContext.CancellationToken.IsCancellationRequested)
+			if (identifierSymbol == null || identifierSymbol.IsStatic)
 				return;
 
-			if ((identifierSymbol.Kind == SymbolKind.Field || identifierSymbol.Kind == SymbolKind.Property) && !identifierSymbol.IsStatic)
+			syntaxContext.CancellationToken.ThrowIfCancellationRequested();
+
+			if (identifierSymbol.Kind == SymbolKind.Field || identifierSymbol.Kind == SymbolKind.Property)
 			{
-				var setDelegateInvocation = syntaxContext.Node as InvocationExpressionSyntax;
+				var longOperationSetupMethodInvocationNode = (InvocationExpressionSyntax)syntaxContext.Node;
+
 				syntaxContext.ReportDiagnosticWithSuppressionCheck(
 					Diagnostic.Create(
-						Descriptors.PX1008_LongOperationDelegateClosures, setDelegateInvocation.GetLocation()),
-					pxContext.CodeAnalysisSettings);
+						Descriptors.PX1008_LongOperationDelegateClosures, longOperationSetupMethodInvocationNode.GetLocation()),
+						pxContext.CodeAnalysisSettings);
 			}
 		}
 	}

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/LongOperationDelegateClosures/LongOperationDelegateType.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/LongOperationDelegateClosures/LongOperationDelegateType.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace Acuminator.Analyzers.StaticAnalysis.LongOperationDelegateClosures
+{
+	internal enum LongOperationDelegateType
+	{
+		ProcessingDelegate,
+		LongRunDelegate
+	}
+}

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/LongOperationDelegateClosures/LongOperationDelegateTypeClassifier.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/LongOperationDelegateClosures/LongOperationDelegateTypeClassifier.cs
@@ -18,9 +18,12 @@ namespace Acuminator.Analyzers.StaticAnalysis.LongOperationDelegateClosures
 	internal class LongOperationDelegateTypeClassifier
 	{
 		public LongOperationDelegateType? GetLongOperationDelegateType(InvocationExpressionSyntax? longOperationSetupMethodInvocationNode,
-																	   SemanticModel semanticModel, PXContext pxContext, 
+																	   SemanticModel? semanticModel, PXContext pxContext, 
 																	   CancellationToken cancellationToken)
 		{
+			if (semanticModel == null)
+				return null;
+
 			cancellationToken.ThrowIfCancellationRequested();
 			string? methodName = null;
 

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/LongOperationDelegateClosures/LongOperationDelegateTypeClassifier.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/LongOperationDelegateClosures/LongOperationDelegateTypeClassifier.cs
@@ -31,12 +31,12 @@ namespace Acuminator.Analyzers.StaticAnalysis.LongOperationDelegateClosures
 			{
 				case MemberAccessExpressionSyntax memberAccessNode
 				when memberAccessNode.OperatorToken.IsKind(SyntaxKind.DotToken):
-					methodName = memberAccessNode.Name?.ToString();
+					methodName = memberAccessNode.Name?.Identifier.ValueText;
 					return GetLongOperationDelegateTypeFromMethodAccessNode(semanticModel, pxContext, memberAccessNode, methodName, cancellationToken);
 
 				case MemberBindingExpressionSyntax memberBindingNode
 				when memberBindingNode.OperatorToken.IsKind(SyntaxKind.DotToken):
-					methodName = memberBindingNode.Name?.ToString();
+					methodName = memberBindingNode.Name?.Identifier.ValueText;
 					return GetLongOperationDelegateTypeFromMethodAccessNode(semanticModel, pxContext, memberBindingNode, methodName, cancellationToken);
 
 				default:

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/LongOperationDelegateClosures/LongOperationDelegateTypeClassifier.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/LongOperationDelegateClosures/LongOperationDelegateTypeClassifier.cs
@@ -50,7 +50,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.LongOperationDelegateClosures
 		{
 			switch (methodName)
 			{
-				case DelegateNames.SetProcess:
+				case DelegateNames.SetProcessDelegate:
 					var setDelegateSymbol = semanticModel.GetSymbolInfo(methodAccessNode, cancellationToken).Symbol as IMethodSymbol;
 
 					if (setDelegateSymbol != null && setDelegateSymbol.ContainingType.ConstructedFrom.InheritsFromOrEquals(pxContext.PXProcessingBase.Type))

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/LongOperationDelegateClosures/LongOperationDelegateTypeClassifier.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/LongOperationDelegateClosures/LongOperationDelegateTypeClassifier.cs
@@ -1,0 +1,72 @@
+﻿#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+
+using Acuminator.Utilities.Common;
+using Acuminator.Utilities.Roslyn.Constants;
+using Acuminator.Utilities.Roslyn.Semantic;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Acuminator.Analyzers.StaticAnalysis.LongOperationDelegateClosures
+{
+	internal class LongOperationDelegateTypeClassifier
+	{
+		public LongOperationDelegateType? GetLongOperationDelegateType(InvocationExpressionSyntax? longOperationSetupMethodInvocationNode,
+																	   SemanticModel semanticModel, PXContext pxContext, 
+																	   CancellationToken cancellationToken)
+		{
+			cancellationToken.ThrowIfCancellationRequested();
+			string? methodName = null;
+
+			switch (longOperationSetupMethodInvocationNode?.Expression)
+			{
+				case MemberAccessExpressionSyntax memberAccessNode
+				when memberAccessNode.OperatorToken.IsKind(SyntaxKind.DotToken):
+					methodName = memberAccessNode.Name?.ToString();
+					return GetLongOperationDelegateTypeFromMethodAccessNode(semanticModel, pxContext, memberAccessNode, methodName, cancellationToken);
+
+				case MemberBindingExpressionSyntax memberBindingNode
+				when memberBindingNode.OperatorToken.IsKind(SyntaxKind.DotToken):
+					methodName = memberBindingNode.Name?.ToString();
+					return GetLongOperationDelegateTypeFromMethodAccessNode(semanticModel, pxContext, memberBindingNode, methodName, cancellationToken);
+
+				default:
+					return null;
+			}
+		}
+
+		private static LongOperationDelegateType? GetLongOperationDelegateTypeFromMethodAccessNode(SemanticModel semanticModel, PXContext pxContext,
+																								   ExpressionSyntax methodAccessNode, string? methodName,
+																								   CancellationToken cancellationToken)
+		{
+			switch (methodName)
+			{
+				case DelegateNames.SetProcess:
+					var setDelegateSymbol = semanticModel.GetSymbolInfo(methodAccessNode, cancellationToken).Symbol as IMethodSymbol;
+
+					if (setDelegateSymbol != null && setDelegateSymbol.ContainingType.ConstructedFrom.InheritsFromOrEquals(pxContext.PXProcessingBase.Type))
+						return LongOperationDelegateType.ProcessingDelegate;
+
+					return null;
+
+				case DelegateNames.StartOperation:
+					var longRunDelegate = semanticModel.GetSymbolInfo(methodAccessNode, cancellationToken).Symbol as IMethodSymbol;
+
+					if (longRunDelegate != null && longRunDelegate.IsStatic && pxContext.PXLongOperation.Equals(longRunDelegate.ContainingType))
+						return LongOperationDelegateType.LongRunDelegate;
+
+					return null;
+
+				default:
+					return null;
+			}
+
+		}
+	}
+}

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/LongOperationDelegateClosures/LongOperationDelegateTypeClassifier.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/LongOperationDelegateClosures/LongOperationDelegateTypeClassifier.cs
@@ -61,8 +61,11 @@ namespace Acuminator.Analyzers.StaticAnalysis.LongOperationDelegateClosures
 				case DelegateNames.StartOperation:
 					var longRunDelegate = semanticModel.GetSymbolInfo(methodAccessNode, cancellationToken).Symbol as IMethodSymbol;
 
-					if (longRunDelegate != null && longRunDelegate.IsStatic && pxContext.PXLongOperation.Equals(longRunDelegate.ContainingType))
+					if (longRunDelegate != null && longRunDelegate.IsStatic && longRunDelegate.DeclaredAccessibility == Accessibility.Public &&
+						pxContext.PXLongOperation.Equals(longRunDelegate.ContainingType))
+					{
 						return LongOperationDelegateType.LongRunDelegate;
+					}
 
 					return null;
 

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXDiagnosticAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXDiagnosticAnalyzer.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#nullable enable
+
+using System;
 using System.Linq;
 using System.Collections.Generic;
 
@@ -16,7 +18,7 @@ namespace Acuminator.Analyzers.StaticAnalysis
 	{
 		private readonly bool _settingsProvidedExternally;
 
-		protected CodeAnalysisSettings CodeAnalysisSettings 
+		protected CodeAnalysisSettings? CodeAnalysisSettings 
 		{ 
 			get;
 			private set;
@@ -26,7 +28,7 @@ namespace Acuminator.Analyzers.StaticAnalysis
 		/// Constructor.
 		/// </summary>
 		/// <param name="codeAnalysisSettings">(Optional) The code analysis settings for unit tests.</param>
-		protected PXDiagnosticAnalyzer(CodeAnalysisSettings codeAnalysisSettings = null)
+		protected PXDiagnosticAnalyzer(CodeAnalysisSettings? codeAnalysisSettings = null)
 		{
 			CodeAnalysisSettings = codeAnalysisSettings;
 			_settingsProvidedExternally = codeAnalysisSettings != null;
@@ -39,7 +41,7 @@ namespace Acuminator.Analyzers.StaticAnalysis
 			if (!_settingsProvidedExternally)
 				CodeAnalysisSettings = AnalyzersOutOfProcessSettingsProvider.GetCodeAnalysisSettings(); //Initialize settings from global values after potential package load
 
-			if (!CodeAnalysisSettings.StaticAnalysisEnabled)
+			if (!CodeAnalysisSettings!.StaticAnalysisEnabled)
 				return;
 
 			context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);

--- a/src/Acuminator/Acuminator.Tests/Acuminator.Tests.csproj
+++ b/src/Acuminator/Acuminator.Tests/Acuminator.Tests.csproj
@@ -238,6 +238,7 @@
     <EmbeddedResource Include="Tests\StaticAnalysis\PublicClassXmlComment\Sources\Partial\WithComment.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\PublicClassXmlComment\Sources\Partial\WithExcludeComment.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\PublicClassXmlComment\Sources\Partial\WithBadComment.cs" />
+    <EmbeddedResource Include="Tests\StaticAnalysis\LongOperationDelegateClosures\Sources\LongRunDelegateClosures.cs" />
     <Compile Include="Tests\StaticAnalysis\NoIsActiveMethodForExtension\NoIsActiveMethodForDacExtensionTests.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\NoIsActiveMethodForExtension\Sources\DacExtension_WithIsActive.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\NoIsActiveMethodForExtension\Sources\DacExtension_WithoutIsActive.cs" />

--- a/src/Acuminator/Acuminator.Tests/Acuminator.Tests.csproj
+++ b/src/Acuminator/Acuminator.Tests/Acuminator.Tests.csproj
@@ -534,7 +534,7 @@
     <EmbeddedResource Include="Tests\Utilities\AttributeInformation\Sources\PropertyIsDBBoundFieldWithDefinedAttributes.cs" />
     <Compile Include="Verification\DiagnosticResultExtensions.cs" />
     <Compile Include="Verification\FluentAssertionsExtensions.cs" />
-    <EmbeddedResource Include="Tests\StaticAnalysis\LongOperationDelegateClosures\Sources\LongOperationDelegateClosures.cs" />
+    <EmbeddedResource Include="Tests\StaticAnalysis\LongOperationDelegateClosures\Sources\SetProcessDelegateClosures.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\BqlParameterMismatch\Sources\PXUpdateCall.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\BqlParameterMismatch\Sources\InheritanceCall.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\BqlParameterMismatch\Sources\FieldInstanceCall.cs" />

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/LongOperationDelegateClosures/LongOperationDelegateClosuresTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/LongOperationDelegateClosures/LongOperationDelegateClosuresTests.cs
@@ -21,14 +21,25 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.LongOperationDelegateClosures
 
 		[Theory]
         [EmbeddedFileData("SetProcessDelegateClosures.cs")]
-        public Task TestDiagnostic(string actual) =>
+        public Task SetProcessDelegates_GraphCapturedInClosures(string actual) =>
 			VerifyCSharpDiagnosticAsync(actual,
-				Descriptors.PX1008_LongOperationDelegateClosures.CreateFor(line: 23, column: 3),
-				Descriptors.PX1008_LongOperationDelegateClosures.CreateFor(line: 34, column: 3),
-				Descriptors.PX1008_LongOperationDelegateClosures.CreateFor(line: 37, column: 3),
-				Descriptors.PX1008_LongOperationDelegateClosures.CreateFor(line: 44, column: 3),
-				Descriptors.PX1008_LongOperationDelegateClosures.CreateFor(line: 45, column: 3),
-				Descriptors.PX1008_LongOperationDelegateClosures.CreateFor(line: 49, column: 3),
-				Descriptors.PX1008_LongOperationDelegateClosures.CreateFor(line: 50, column: 3));
+				Descriptors.PX1008_LongOperationDelegateClosures.CreateFor(line: 25, column: 4),
+				Descriptors.PX1008_LongOperationDelegateClosures.CreateFor(line: 36, column: 4),
+				Descriptors.PX1008_LongOperationDelegateClosures.CreateFor(line: 39, column: 4),
+				Descriptors.PX1008_LongOperationDelegateClosures.CreateFor(line: 46, column: 4),
+				Descriptors.PX1008_LongOperationDelegateClosures.CreateFor(line: 47, column: 4),
+				Descriptors.PX1008_LongOperationDelegateClosures.CreateFor(line: 51, column: 4),
+				Descriptors.PX1008_LongOperationDelegateClosures.CreateFor(line: 52, column: 4));
+
+		[Theory]
+		[EmbeddedFileData("LongRunDelegateClosures.cs")]
+		public Task LongRunDelegates_GraphCapturedInClosures(string actual) =>
+			VerifyCSharpDiagnosticAsync(actual,
+				Descriptors.PX1008_LongOperationDelegateClosures.CreateFor(line: 36, column: 4),
+				Descriptors.PX1008_LongOperationDelegateClosures.CreateFor(line: 39, column: 4),
+				Descriptors.PX1008_LongOperationDelegateClosures.CreateFor(line: 40, column: 4),
+				Descriptors.PX1008_LongOperationDelegateClosures.CreateFor(line: 51, column: 4),
+				Descriptors.PX1008_LongOperationDelegateClosures.CreateFor(line: 58, column: 4),
+				Descriptors.PX1008_LongOperationDelegateClosures.CreateFor(line: 59, column: 4));
 	}
 }

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/LongOperationDelegateClosures/LongOperationDelegateClosuresTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/LongOperationDelegateClosures/LongOperationDelegateClosuresTests.cs
@@ -20,13 +20,15 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.LongOperationDelegateClosures
 											.WithSuppressionMechanismDisabled());
 
 		[Theory]
-        [EmbeddedFileData("LongOperationDelegateClosures.cs")]
+        [EmbeddedFileData("SetProcessDelegateClosures.cs")]
         public Task TestDiagnostic(string actual) =>
 			VerifyCSharpDiagnosticAsync(actual,
 				Descriptors.PX1008_LongOperationDelegateClosures.CreateFor(line: 23, column: 3),
 				Descriptors.PX1008_LongOperationDelegateClosures.CreateFor(line: 34, column: 3),
 				Descriptors.PX1008_LongOperationDelegateClosures.CreateFor(line: 37, column: 3),
 				Descriptors.PX1008_LongOperationDelegateClosures.CreateFor(line: 44, column: 3),
-				Descriptors.PX1008_LongOperationDelegateClosures.CreateFor(line: 45, column: 3));
+				Descriptors.PX1008_LongOperationDelegateClosures.CreateFor(line: 45, column: 3),
+				Descriptors.PX1008_LongOperationDelegateClosures.CreateFor(line: 49, column: 3),
+				Descriptors.PX1008_LongOperationDelegateClosures.CreateFor(line: 50, column: 3));
 	}
 }

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/LongOperationDelegateClosures/Sources/LongRunDelegateClosures.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/LongOperationDelegateClosures/Sources/LongRunDelegateClosures.cs
@@ -1,0 +1,91 @@
+﻿using PX.Data;
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Acuminator.Tests.Sources
+{
+	public class ProcessingGraph : PXGraph<ProcessingGraph>
+	{
+		private static readonly Guid ID = Guid.NewGuid();
+
+		public class SomeDAC : IBqlTable
+		{
+		}
+
+		private readonly Processor processor = new Processor();
+
+		private Processor ProcessorProperty => processor;
+
+		private static Processor processorStatic = new Processor();
+
+		public PXAction<SomeDAC> SomeAction;
+
+		[PXUIField(DisplayName = "Some Action", MapEnableRights = PXCacheRights.Select, MapViewRights = PXCacheRights.Select)]
+		[PXButton]
+		public virtual IEnumerable someAction(PXAdapter adapter)
+		{
+			object filter = null;
+			object[] args = new object[] { 1, 2 };
+			List<SomeDAC> inputList = new List<SomeDAC> 
+			{ 
+				new SomeDAC() 
+			}; 
+
+			PXLongOperation.StartOperation(ID, arguments => MemberFunc(), args);							//Should be diagnostic
+			PXLongOperation.StartOperation(ID, arguments => StaticFunc(filter, inputList, false), args);	//No diagnostic
+
+			PXLongOperation.StartOperation(ID, () => MemberFunc());					//Should be diagnostic
+			PXLongOperation.StartOperation(ID, delegate								//Should be diagnostic
+			{ 
+				Clear(); 
+			});
+
+			PXLongOperation.StartOperation(ID, () => StaticFuncWithNoInput());		//No diagnostic
+			PXLongOperation.StartOperation(ID, delegate								//No diagnostic
+			{
+				StaticFuncWithNoInput();
+			});
+
+			PXLongOperation.StartOperation(this, MemberFunc);						//Should be diagnostic
+			PXLongOperation.StartOperation(this, StaticFuncWithNoInput);			//No diagnostic
+
+			//Test helper static function
+			PXLongOperation.StartOperation(this, Processor.StaticFunc);				//No diagnostic
+
+			//test fields and properties
+			PXLongOperation.StartOperation(this, processor.MemberFunc);				//Should be diagnostic
+			PXLongOperation.StartOperation(this, ProcessorProperty.MemberFunc);		//Should be diagnostic
+			PXLongOperation.StartOperation(this, processorStatic.MemberFunc);		//No diagnostic
+
+			return adapter.Get();
+		}
+
+		public static void StaticFunc(object filter, List<SomeDAC> list, bool markOnly)
+		{ }
+
+		public static void StaticFunc(List<SomeDAC> list)
+		{ }
+
+		public void MemberFunc(List<SomeDAC> list)
+		{ }
+
+		public void MemberFunc()
+		{ }
+
+		public static void StaticFuncWithNoInput()
+		{
+
+		}
+
+		private class Processor
+		{
+			public void MemberFunc()
+			{ }
+
+			public static void StaticFunc()
+			{ }
+		}
+	}
+}

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/LongOperationDelegateClosures/Sources/SetProcessDelegateClosures.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/LongOperationDelegateClosures/Sources/SetProcessDelegateClosures.cs
@@ -44,6 +44,10 @@ public class SomeGraph : PXGraph<SomeGraph>
 		Processing.SetProcessDelegate(processor.MemberFunc);          //Should be diagnostic
 		Processing.SetProcessDelegate(ProcessorProperty.MemberFunc);  //Should be diagnostic
 		Processing.SetProcessDelegate(processorStatic.MemberFunc);    //No diagnostic
+
+		Processing.SetProcessDelegate<SomeGraph>((graph, dac) => StaticFuncWithNoInput(), graph => graph.FinallyHandler());				//No diagnostic
+		Processing.SetProcessDelegate<SomeGraph>((graph, dac) => MainProcessingHandler(dac), graph => FinallyHandler());				//Should be diagnostic
+		Processing.SetProcessDelegate<SomeGraph>((graph, dac) => graph.MainProcessingHandler(dac), graph => FinallyHandler());			//Should be diagnostic
 	}
 
     public static void StaticFunc(object filter, List<SomeDAC> list, bool markOnly)
@@ -54,6 +58,19 @@ public class SomeGraph : PXGraph<SomeGraph>
 
     public void MemberFunc(List<SomeDAC> list)
     { }
+
+	public static void StaticFuncWithNoInput()
+	{
+
+	}
+
+	public void MainProcessingHandler(SomeDAC dac)
+	{
+	}
+
+	public void FinallyHandler()
+	{	
+	}
 
 	private class Processor
 	{

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/LongOperationDelegateClosures/Sources/SetProcessDelegateClosures.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/LongOperationDelegateClosures/Sources/SetProcessDelegateClosures.cs
@@ -1,83 +1,86 @@
 ﻿using PX.Data;
 using System.Collections.Generic;
 
-public class SomeGraph : PXGraph<SomeGraph>
+namespace Acuminator.Tests.Sources
 {
-    public class SomeDAC : IBqlTable
-    {
-    }
-
-	private readonly Processor processor = new Processor();
-
-	private Processor ProcessorProperty => processor;
-
-	private static Processor processorStatic = new Processor();
-
-
-    public PXProcessing<SomeDAC> Processing;
-
-	public SomeGraph()
+	public class SomeGraph : PXGraph<SomeGraph>
 	{
-		object filter = null;
-
-		Processing.SetProcessDelegate(delegate (SomeGraph graph, SomeDAC applicationProjection)
+		public class SomeDAC : IBqlTable
 		{
-			this.Clear();
-		});
+		}
 
-		Processing.SetProcessDelegate(delegate (SomeGraph graph, SomeDAC applicationProjection)
+		private readonly Processor processor = new Processor();
+
+		private Processor ProcessorProperty => processor;
+
+		private static Processor processorStatic = new Processor();
+
+
+		public PXProcessing<SomeDAC> Processing;
+
+		public SomeGraph()
 		{
-			List<SomeDAC> list = new List<SomeDAC>();
-			StaticFunc(list);
-		});
+			object filter = null;
 
-		Processing.SetProcessDelegate(MemberFunc);
-		Processing.SetProcessDelegate(StaticFunc);
+			Processing.SetProcessDelegate(delegate (SomeGraph graph, SomeDAC applicationProjection)
+			{
+				this.Clear();
+			});
 
-		Processing.SetProcessDelegate(list => MemberFunc(list));
-		Processing.SetProcessDelegate(list => StaticFunc(filter, list, false));
+			Processing.SetProcessDelegate(delegate (SomeGraph graph, SomeDAC applicationProjection)
+			{
+				List<SomeDAC> list = new List<SomeDAC>();
+				StaticFunc(list);
+			});
 
-		//Test helper static function
-		Processing.SetProcessDelegate(Processor.StaticFunc);      //No diagnostic
+			Processing.SetProcessDelegate(MemberFunc);
+			Processing.SetProcessDelegate(StaticFunc);
 
-		//test fields and properties
-		Processing.SetProcessDelegate(processor.MemberFunc);          //Should be diagnostic
-		Processing.SetProcessDelegate(ProcessorProperty.MemberFunc);  //Should be diagnostic
-		Processing.SetProcessDelegate(processorStatic.MemberFunc);    //No diagnostic
+			Processing.SetProcessDelegate(list => MemberFunc(list));
+			Processing.SetProcessDelegate(list => StaticFunc(filter, list, false));
 
-		Processing.SetProcessDelegate<SomeGraph>((graph, dac) => StaticFuncWithNoInput(), graph => graph.FinallyHandler());				//No diagnostic
-		Processing.SetProcessDelegate<SomeGraph>((graph, dac) => MainProcessingHandler(dac), graph => FinallyHandler());				//Should be diagnostic
-		Processing.SetProcessDelegate<SomeGraph>((graph, dac) => graph.MainProcessingHandler(dac), graph => FinallyHandler());			//Should be diagnostic
-	}
+			//Test helper static function
+			Processing.SetProcessDelegate(Processor.StaticFunc);      //No diagnostic
 
-    public static void StaticFunc(object filter, List<SomeDAC> list, bool markOnly)
-    { }
+			//test fields and properties
+			Processing.SetProcessDelegate(processor.MemberFunc);          //Should be diagnostic
+			Processing.SetProcessDelegate(ProcessorProperty.MemberFunc);  //Should be diagnostic
+			Processing.SetProcessDelegate(processorStatic.MemberFunc);    //No diagnostic
 
-    public static void StaticFunc(List<SomeDAC> list)
-    { }
+			Processing.SetProcessDelegate<SomeGraph>((graph, dac) => StaticFuncWithNoInput(), graph => graph.FinallyHandler());             //No diagnostic
+			Processing.SetProcessDelegate<SomeGraph>((graph, dac) => MainProcessingHandler(dac), graph => FinallyHandler());                //Should be diagnostic
+			Processing.SetProcessDelegate<SomeGraph>((graph, dac) => graph.MainProcessingHandler(dac), graph => FinallyHandler());          //Should be diagnostic
+		}
 
-    public void MemberFunc(List<SomeDAC> list)
-    { }
-
-	public static void StaticFuncWithNoInput()
-	{
-
-	}
-
-	public void MainProcessingHandler(SomeDAC dac)
-	{
-	}
-
-	public void FinallyHandler()
-	{	
-	}
-
-	private class Processor
-	{
-		public void MemberFunc(List<SomeDAC> list)
+		public static void StaticFunc(object filter, List<SomeDAC> list, bool markOnly)
 		{ }
 
 		public static void StaticFunc(List<SomeDAC> list)
 		{ }
+
+		public void MemberFunc(List<SomeDAC> list)
+		{ }
+
+		public static void StaticFuncWithNoInput()
+		{
+
+		}
+
+		public void MainProcessingHandler(SomeDAC dac)
+		{
+		}
+
+		public void FinallyHandler()
+		{
+		}
+
+		private class Processor
+		{
+			public void MemberFunc(List<SomeDAC> list)
+			{ }
+
+			public static void StaticFunc(List<SomeDAC> list)
+			{ }
+		}
 	}
 }

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Constants/DelegateNames.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Constants/DelegateNames.cs
@@ -39,7 +39,7 @@ namespace Acuminator.Utilities.Roslyn.Constants
 		public const string SetList = "SetList";
 
 		public const string SetParameters = "SetParametersDelegate";
-		public const string SetProcess = "SetProcessDelegate";
+		public const string SetProcessDelegate = "SetProcessDelegate";
 
 		public const string View = "View";
 

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Constants/DelegateNames.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Constants/DelegateNames.cs
@@ -4,81 +4,81 @@ namespace Acuminator.Utilities.Roslyn.Constants
 {
 	public static class DelegateNames
 	{
-		public static readonly string IsKey = "IsKey";
-		public static readonly string IsActive = "IsActive";
+		public const string IsKey = "IsKey";
+		public const string IsActive = "IsActive";
 
-		public static readonly string SetVisible = "SetVisible";
-		public static readonly string SetVisibility = "SetVisibility";
-		public static readonly string SetEnabled = "SetEnabled";
-		public static readonly string SetRequired = "SetRequired";
-		public static readonly string SetReadOnly = "SetReadOnly";
-		public static readonly string SetDisplayName = "SetDisplayName";
-		public static readonly string SetNeutralDisplayName = "SetNeutralDisplayName";
+		public const string SetVisible = "SetVisible";
+		public const string SetVisibility = "SetVisibility";
+		public const string SetEnabled = "SetEnabled";
+		public const string SetRequired = "SetRequired";
+		public const string SetReadOnly = "SetReadOnly";
+		public const string SetDisplayName = "SetDisplayName";
+		public const string SetNeutralDisplayName = "SetNeutralDisplayName";
 
-		public static readonly string Initialize = "Initialize";
-		public static readonly string StartOperation = "StartOperation";
+		public const string Initialize = "Initialize";
+		public const string StartOperation = "StartOperation";
 		
-		public static readonly string SetCaption = "SetCaption";
-		public static readonly string SetTooltip = "SetTooltip";
-		public static readonly string Press = "Press";
+		public const string SetCaption = "SetCaption";
+		public const string SetTooltip = "SetTooltip";
+		public const string Press = "Press";
 
-		public static readonly string Insert = "Insert";
-		public static readonly string Update = "Update";
-		public static readonly string Delete = "Delete";
-		public static readonly string RaiseExceptionHandling = "RaiseExceptionHandling";
+		public const string Insert = "Insert";
+		public const string Update = "Update";
+		public const string Delete = "Delete";
+		public const string RaiseExceptionHandling = "RaiseExceptionHandling";
 
-		public static readonly string Select = "Select";
-		public static readonly string ForceDelete = "ForceDelete";
-		public static readonly string Ensure = "Ensure";
+		public const string Select = "Select";
+		public const string ForceDelete = "ForceDelete";
+		public const string Ensure = "Ensure";
 		
-		public static readonly string InstanceCreatedEvents = "PX.Data.PXGraph+InstanceCreatedEvents";
-		public static readonly string InstanceCreatedEventsAddHandler = "AddHandler";
-		public static readonly string InitCacheMapping = "InitCacheMapping";
-		public static readonly string CreateInstance = "CreateInstance";
+		public const string InstanceCreatedEvents = "PX.Data.PXGraph+InstanceCreatedEvents";
+		public const string InstanceCreatedEventsAddHandler = "AddHandler";
+		public const string InitCacheMapping = "InitCacheMapping";
+		public const string CreateInstance = "CreateInstance";
 
-		public static readonly string SetList = "SetList";
+		public const string SetList = "SetList";
 
-		public static readonly string SetParameters = "SetParametersDelegate";
-		public static readonly string SetProcess = "SetProcessDelegate";
+		public const string SetParameters = "SetParametersDelegate";
+		public const string SetProcess = "SetProcessDelegate";
 
-		public static readonly string View = "View";
+		public const string View = "View";
 
-		public static readonly string WhereAnd = "WhereAnd";
-		public static readonly string WhereNew = "WhereNew";
-		public static readonly string WhereOr = "WhereOr";
-		public static readonly string Join = "Join";
+		public const string WhereAnd = "WhereAnd";
+		public const string WhereNew = "WhereNew";
+		public const string WhereOr = "WhereOr";
+		public const string Join = "Join";
 
-		public static readonly string GetItem = "GetItem";
+		public const string GetItem = "GetItem";
 
-		public static readonly string AppendList = "AppendList";
-		public static readonly string SetLocalizable = "SetLocalizable";
+		public const string AppendList = "AppendList";
+		public const string SetLocalizable = "SetLocalizable";
 
-		public static readonly string PXSave = "PX.Data.PXSave`1";
-		public static readonly string PXCancel = "PX.Data.PXCancel`1";
-		public static readonly string PXInsert = "PX.Data.PXInsert`1";
-		public static readonly string PXDelete = "PX.Data.PXDelete`1";
-		public static readonly string PXCopyPasteAction = "PX.Data.PXCopyPasteAction`1";
-		public static readonly string PXFirst = "PX.Data.PXFirst`1";
-		public static readonly string PXPrevious = "PX.Data.PXPrevious`1";
-		public static readonly string PXNext = "PX.Data.PXNext`1";
-		public static readonly string PXLast = "PX.Data.PXLast`1";
-		public static readonly string PXChangeID = "PX.Data.PXChangeID`1";
+		public const string PXSave = "PX.Data.PXSave`1";
+		public const string PXCancel = "PX.Data.PXCancel`1";
+		public const string PXInsert = "PX.Data.PXInsert`1";
+		public const string PXDelete = "PX.Data.PXDelete`1";
+		public const string PXCopyPasteAction = "PX.Data.PXCopyPasteAction`1";
+		public const string PXFirst = "PX.Data.PXFirst`1";
+		public const string PXPrevious = "PX.Data.PXPrevious`1";
+		public const string PXNext = "PX.Data.PXNext`1";
+		public const string PXLast = "PX.Data.PXLast`1";
+		public const string PXChangeID = "PX.Data.PXChangeID`1";
 
-		public static readonly string JoinNew = "JoinNew";
-		public static readonly string StartRow = "StartRow";
+		public const string JoinNew = "JoinNew";
+		public const string StartRow = "StartRow";
 
-		public static readonly string AggregateNew = "AggregateNew";
-		public static readonly string OrderByNew = "OrderByNew";
+		public const string AggregateNew = "AggregateNew";
+		public const string OrderByNew = "OrderByNew";
 
 
-		public static readonly string Compose = "Compose";
-		public static readonly string AddJoinConditions = "AddJoinConditions";
-		public static readonly string AppendJoin = "AppendJoin";
-		public static readonly string NewJoin = "NewJoin";
+		public const string Compose = "Compose";
+		public const string AddJoinConditions = "AddJoinConditions";
+		public const string AppendJoin = "AppendJoin";
+		public const string NewJoin = "NewJoin";
 
-		public static readonly string PrimaryKeyFindMethod = "Find";
-		public static readonly string PrimaryKeyFindByMethod = "FindBy";
+		public const string PrimaryKeyFindMethod = "Find";
+		public const string PrimaryKeyFindByMethod = "FindBy";
 
-		public static readonly string Persist = "Persist";
+		public const string Persist = "Persist";
 	}
 }

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/Symbols/PXProcessingBaseSymbols.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/Symbols/PXProcessingBaseSymbols.cs
@@ -14,7 +14,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic.Symbols
         internal PXProcessingBaseSymbols(Compilation compilation) : base(compilation, typeName: TypeFullNames.PXProcessingBase)
         {
             SetParametersDelegate = Type.GetMethods(DelegateNames.SetParameters).First();
-            SetProcessDelegate = Type.GetMethods(DelegateNames.SetProcess);
+            SetProcessDelegate = Type.GetMethods(DelegateNames.SetProcessDelegate);
         }
     }
 }

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Syntax/MethodDeclarationUtils.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Syntax/MethodDeclarationUtils.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿#nullable enable
+
+using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using Acuminator.Utilities.Common;
@@ -10,7 +12,7 @@ namespace Acuminator.Utilities.Roslyn.Syntax
 {
 	public static class MethodDeclarationUtils
 	{
-		public static ExpressionSyntax GetAccessNodeFromInvocationNode(this InvocationExpressionSyntax invocationNode)
+		public static ExpressionSyntax? GetAccessNodeFromInvocationNode(this InvocationExpressionSyntax? invocationNode)
 		{
 			if (invocationNode == null)
 				return null;
@@ -54,7 +56,7 @@ namespace Acuminator.Utilities.Roslyn.Syntax
 		}
 
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static bool DoesArgumentsContainIdentifier(this InvocationExpressionSyntax invocation, string identifier)
+		public static bool DoesArgumentsContainIdentifier(this InvocationExpressionSyntax invocation, string? identifier)
 		{
 			invocation.ThrowOnNull(nameof(invocation));
 
@@ -71,7 +73,7 @@ namespace Acuminator.Utilities.Roslyn.Syntax
 							.Any(arg => arg.Identifier.ValueText == identifier);
 		}
 
-		public static IEnumerable<ArgumentSyntax> GetArgumentsContainingIdentifier(this InvocationExpressionSyntax invocation, string identifier)
+		public static IEnumerable<ArgumentSyntax> GetArgumentsContainingIdentifier(this InvocationExpressionSyntax invocation, string? identifier)
 		{
 			invocation.ThrowOnNull(nameof(invocation));
 
@@ -93,7 +95,7 @@ namespace Acuminator.Utilities.Roslyn.Syntax
 		}
 
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static StatementSyntax GetStatementNode(this SyntaxNode node)
+		public static StatementSyntax? GetStatementNode(this SyntaxNode? node)
 		{
 			if (node == null)
 				return null;
@@ -116,7 +118,7 @@ namespace Acuminator.Utilities.Roslyn.Syntax
 		/// The declaring method node.
 		/// </returns>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static MethodDeclarationSyntax GetDeclaringMethodNode(this SyntaxNode node)
+		public static MethodDeclarationSyntax? GetDeclaringMethodNode(this SyntaxNode? node)
 		{
 			var current = node;
 
@@ -128,7 +130,7 @@ namespace Acuminator.Utilities.Roslyn.Syntax
 			return current as MethodDeclarationSyntax;
 		}
 
-		public static StatementSyntax GetNextStatement(this StatementSyntax statement)
+		public static StatementSyntax? GetNextStatement(this StatementSyntax? statement)
 		{
 			if (statement == null)
 				return null;

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Syntax/RoslynSyntaxUtils.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Syntax/RoslynSyntaxUtils.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#nullable enable
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -12,7 +14,7 @@ namespace Acuminator.Utilities.Roslyn.Syntax
 {
 	public static class RoslynSyntaxUtils
 	{
-		public static bool IsLocalVariable(this SemanticModel semanticModel, MethodDeclarationSyntax containingMethod, string variableName)
+		public static bool IsLocalVariable(this SemanticModel semanticModel, MethodDeclarationSyntax containingMethod, string? variableName)
 		{
 			semanticModel.ThrowOnNull(nameof(semanticModel));
 			containingMethod.ThrowOnNull(nameof(containingMethod));
@@ -41,7 +43,7 @@ namespace Acuminator.Utilities.Roslyn.Syntax
 		/// 							simple case don't work.</param>
 		/// <param name="cancellationToken">(Optional) The cancellation token.</param>
 		/// <returns/>
-		public static int? TryGetSizeOfSingleDimensionalNonJaggedArray(ExpressionSyntax arrayCreationExpression, SemanticModel semanticModel = null,
+		public static int? TryGetSizeOfSingleDimensionalNonJaggedArray(ExpressionSyntax? arrayCreationExpression, SemanticModel? semanticModel = null,
 																	   CancellationToken cancellationToken = default)
 		{
 			return arrayCreationExpression switch
@@ -72,7 +74,7 @@ namespace Acuminator.Utilities.Roslyn.Syntax
 		/// 							Can be passed to try to fallback to its constant evaluation if simple case don't work.</param>
 		/// <param name="cancellationToken">(Optional) The cancellation token.</param>
 		/// <returns/>
-		public static int? TryGetSizeOfSingleDimensionalNonJaggedArray(ArrayTypeSyntax arrayType, SemanticModel semanticModel = null,
+		public static int? TryGetSizeOfSingleDimensionalNonJaggedArray(ArrayTypeSyntax? arrayType, SemanticModel? semanticModel = null,
 																	   CancellationToken cancellationToken = default)
 		{
 			if (arrayType == null)
@@ -110,20 +112,20 @@ namespace Acuminator.Utilities.Roslyn.Syntax
 		/// <returns>
 		/// An asynchronous task that yields the syntax.
 		/// </returns>
-		public static Task<SyntaxNode> GetSyntaxAsync(this ISymbol symbol, CancellationToken cancellationToken = default)
+		public static Task<SyntaxNode?> GetSyntaxAsync(this ISymbol? symbol, CancellationToken cancellationToken = default)
 		{
 			if (symbol == null)
-				return Task.FromResult<SyntaxNode>(null);
+				return Task.FromResult<SyntaxNode?>(null);
 
 			var declarations = symbol.DeclaringSyntaxReferences;
 
 			if (declarations.Length == 0)
-				return Task.FromResult<SyntaxNode>(null);
+				return Task.FromResult<SyntaxNode?>(null);
 
 			return declarations[0].GetSyntaxAsync(cancellationToken);
 		}
 
-		public static SyntaxNode GetSyntax(this ISymbol symbol, CancellationToken cancellationToken = default)
+		public static SyntaxNode? GetSyntax(this ISymbol? symbol, CancellationToken cancellationToken = default)
 		{
 			if (symbol == null)
 				return null;
@@ -136,12 +138,12 @@ namespace Acuminator.Utilities.Roslyn.Syntax
 			return declarations[0].GetSyntax(cancellationToken);
 		}
 
-		public static Location GetLocation(this AttributeData attribute, CancellationToken cancellationToken = default) =>
+		public static Location? GetLocation(this AttributeData? attribute, CancellationToken cancellationToken = default) =>
 			attribute?.ApplicationSyntaxReference
 					 ?.GetSyntax(cancellationToken)
 					 ?.GetLocation();
 
-		public static IEnumerable<SyntaxToken> GetIdentifiers(this MemberDeclarationSyntax member) =>
+		public static IEnumerable<SyntaxToken> GetIdentifiers(this MemberDeclarationSyntax? member) =>
 			member switch
 			{
 				PropertyDeclarationSyntax propertyDeclaration       => propertyDeclaration.Identifier.ToEnumerable(),
@@ -181,7 +183,7 @@ namespace Acuminator.Utilities.Roslyn.Syntax
 			}
 		}
 
-		public static bool IsPublic(this MemberDeclarationSyntax member)
+		public static bool IsPublic(this MemberDeclarationSyntax? member)
 		{
 			SyntaxTokenList modifiers = member.GetModifiers();
 			return modifiers.Any(SyntaxKind.PublicKeyword);
@@ -200,7 +202,7 @@ namespace Acuminator.Utilities.Roslyn.Syntax
 			return modifiers.Any(SyntaxKind.InternalKeyword) && !modifiers.Any(SyntaxKind.PrivateKeyword);  
 		}
 
-		public static SyntaxTokenList GetModifiers(this MemberDeclarationSyntax member) =>
+		public static SyntaxTokenList GetModifiers(this MemberDeclarationSyntax? member) =>
 			member.CheckIfNull(nameof(member)) switch
 			{
 				BasePropertyDeclarationSyntax basePropertyDeclaration => basePropertyDeclaration.Modifiers,
@@ -217,11 +219,11 @@ namespace Acuminator.Utilities.Roslyn.Syntax
 		/// </summary>
 		/// <param name="node">Syntax node</param>
 		/// <returns>Syntax node for the body, if any</returns>
-		public static CSharpSyntaxNode GetBody(this SyntaxNode node) =>
+		public static CSharpSyntaxNode? GetBody(this SyntaxNode? node) =>
 			node switch
 			{
 				AccessorDeclarationSyntax accessorSyntax => accessorSyntax.Body,
-				MethodDeclarationSyntax methodSyntax => methodSyntax.Body ?? (CSharpSyntaxNode)methodSyntax.ExpressionBody?.Expression,
+				MethodDeclarationSyntax methodSyntax => methodSyntax.Body ?? (methodSyntax.ExpressionBody?.Expression as CSharpSyntaxNode),
 				ConstructorDeclarationSyntax constructorSyntax => constructorSyntax.Body,
 				_ => null,
 			};
@@ -247,7 +249,7 @@ namespace Acuminator.Utilities.Roslyn.Syntax
 			}
 		}
 
-		public static SyntaxList<AttributeListSyntax> GetAttributeLists(this MemberDeclarationSyntax member) =>
+		public static SyntaxList<AttributeListSyntax> GetAttributeLists(this MemberDeclarationSyntax? member) =>
 			member switch
 			{
 				PropertyDeclarationSyntax propertyDeclaration       => propertyDeclaration.AttributeLists,
@@ -264,12 +266,12 @@ namespace Acuminator.Utilities.Roslyn.Syntax
 				_                                                   => new SyntaxList<AttributeListSyntax>()
 			};
 
-		public static SyntaxTrivia ToSingleLineComment(this string commentContent)
+		public static SyntaxTrivia ToSingleLineComment(this string? commentContent)
 		{
 			const string commentPrefix = "//";
 			string comment = commentContent.IsNullOrWhiteSpace()
 				? commentPrefix
-				: commentPrefix + " " + commentContent.Trim();
+				: commentPrefix + " " + commentContent!.Trim();
 
 			return SyntaxFactory.Comment(comment);
 		}

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Syntax/RoslynSyntaxUtils.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Syntax/RoslynSyntaxUtils.cs
@@ -223,7 +223,7 @@ namespace Acuminator.Utilities.Roslyn.Syntax
 			node switch
 			{
 				AccessorDeclarationSyntax accessorSyntax => accessorSyntax.Body,
-				MethodDeclarationSyntax methodSyntax => methodSyntax.Body ?? (methodSyntax.ExpressionBody?.Expression as CSharpSyntaxNode),
+				MethodDeclarationSyntax methodSyntax => methodSyntax.Body ?? methodSyntax.ExpressionBody?.Expression as CSharpSyntaxNode,
 				ConstructorDeclarationSyntax constructorSyntax => constructorSyntax.Body,
 				_ => null,
 			};

--- a/src/Samples/PX.Objects.HackathonDemo/PX.Objects.HackathonDemo/Graph/Closures in processing and long run delegates/SOItemProcessing.cs
+++ b/src/Samples/PX.Objects.HackathonDemo/PX.Objects.HackathonDemo/Graph/Closures in processing and long run delegates/SOItemProcessing.cs
@@ -1,0 +1,76 @@
+﻿using PX.Data;
+
+using System.Collections.Generic;
+
+public class SOItemProcessing : PXGraph<SOItemProcessing>
+{
+	public class SomeDAC : IBqlTable
+	{
+	}
+
+	private readonly Processor processor = new Processor();
+
+	private Processor ProcessorProperty => processor;
+
+	private static Processor processorStatic = new Processor();
+
+	public PXProcessing<SomeDAC> Processing;
+
+	public SOItemProcessing()
+	{
+		object filter = null;
+
+		Processing.SetProcessDelegate(delegate (SOItemProcessing graph, SomeDAC applicationProjection) {
+			this.Clear();
+		});
+
+		Processing.SetProcessDelegate(delegate (SOItemProcessing graph, SomeDAC applicationProjection) {
+			List<SomeDAC> list = new List<SomeDAC>();
+			StaticFunc(list);
+		});
+
+		Processing.SetProcessDelegate(MemberFunc);
+		Processing.SetProcessDelegate(StaticFunc);
+
+		Processing.SetProcessDelegate(list => MemberFunc(list));
+		Processing.SetProcessDelegate(list => StaticFunc(filter, list, false));
+
+		//Test helper static function
+		Processing.SetProcessDelegate(Processor.StaticFunc);      //No diagnostic
+
+		//test fields and properties
+		Processing.SetProcessDelegate(processor.MemberFunc);          //Should be diagnostic
+		Processing.SetProcessDelegate(ProcessorProperty.MemberFunc);  //Should be diagnostic
+		Processing.SetProcessDelegate(processorStatic.MemberFunc);    //No diagnostic
+
+		Processing.SetProcessDelegate<SOItemProcessing>((graph, dac) => graph.MainProcessingHandler(dac), graph => graph.FinallyHandler());    //No diagnostic
+		Processing.SetProcessDelegate<SOItemProcessing>((graph, dac) => MainProcessingHandler(dac), graph => FinallyHandler());                //Should be diagnostic
+		Processing.SetProcessDelegate<SOItemProcessing>((graph, dac) => graph.MainProcessingHandler(dac), graph => FinallyHandler());    //Should be diagnostic
+	}
+
+	public static void StaticFunc(object filter, List<SomeDAC> list, bool markOnly)
+	{ }
+
+	public static void StaticFunc(List<SomeDAC> list)
+	{ }
+
+	public void MemberFunc(List<SomeDAC> list)
+	{ }
+
+	public void MainProcessingHandler(SomeDAC dac)
+	{
+	}
+
+	public void FinallyHandler()
+	{
+	}
+
+	private class Processor
+	{
+		public void MemberFunc(List<SomeDAC> list)
+		{ }
+
+		public static void StaticFunc(List<SomeDAC> list)
+		{ }
+	}
+}

--- a/src/Samples/PX.Objects.HackathonDemo/PX.Objects.HackathonDemo/Graph/Closures in processing and long run delegates/SOItemProcessing.cs
+++ b/src/Samples/PX.Objects.HackathonDemo/PX.Objects.HackathonDemo/Graph/Closures in processing and long run delegates/SOItemProcessing.cs
@@ -1,76 +1,137 @@
-﻿using PX.Data;
+﻿using System;
+using PX.Data;
 
+using System.Collections;
 using System.Collections.Generic;
 
-public class SOItemProcessing : PXGraph<SOItemProcessing>
+namespace PX.Objects.HackathonDemo
 {
-	public class SomeDAC : IBqlTable
+	public class SOItemProcessing : PXGraph<SOItemProcessing>
 	{
-	}
+		private static readonly Guid ID = Guid.NewGuid();
 
-	private readonly Processor processor = new Processor();
+		public class SomeDAC : IBqlTable
+		{
+		}
 
-	private Processor ProcessorProperty => processor;
+		private readonly Processor processor = new Processor();
 
-	private static Processor processorStatic = new Processor();
+		private Processor ProcessorProperty => processor;
 
-	public PXProcessing<SomeDAC> Processing;
+		private static Processor processorStatic = new Processor();
 
-	public SOItemProcessing()
-	{
-		object filter = null;
+		public PXProcessing<SomeDAC> Processing;
 
-		Processing.SetProcessDelegate(delegate (SOItemProcessing graph, SomeDAC applicationProjection) {
-			this.Clear();
-		});
+		public PXAction<SomeDAC> SomeAction;
 
-		Processing.SetProcessDelegate(delegate (SOItemProcessing graph, SomeDAC applicationProjection) {
-			List<SomeDAC> list = new List<SomeDAC>();
-			StaticFunc(list);
-		});
+		[PXUIField(DisplayName = "Some Action", MapEnableRights = PXCacheRights.Select, MapViewRights = PXCacheRights.Select)]
+		[PXButton]
+		public virtual IEnumerable someAction(PXAdapter adapter)
+		{
+			object filter = null;
+			object[] args = new object[] { 1, 2 };
+			List<SomeDAC> inputList = new List<SomeDAC>
+			{
+				new SomeDAC()
+			};
 
-		Processing.SetProcessDelegate(MemberFunc);
-		Processing.SetProcessDelegate(StaticFunc);
+			PXLongOperation.StartOperation(ID, arguments => MemberFunc(), args);                            //Should be diagnostic
+			PXLongOperation.StartOperation(ID, arguments => StaticFunc(filter, inputList, false), args);    //No diagnostic
 
-		Processing.SetProcessDelegate(list => MemberFunc(list));
-		Processing.SetProcessDelegate(list => StaticFunc(filter, list, false));
+			PXLongOperation.StartOperation(ID, () => MemberFunc());                 //Should be diagnostic
+			PXLongOperation.StartOperation(ID, delegate                             //Should be diagnostic
+			{
+				Clear();
+			});
 
-		//Test helper static function
-		Processing.SetProcessDelegate(Processor.StaticFunc);      //No diagnostic
+			PXLongOperation.StartOperation(ID, () => StaticFunc());					//No diagnostic
+			PXLongOperation.StartOperation(ID, delegate                             //No diagnostic
+			{
+				StaticFunc();
+			});
 
-		//test fields and properties
-		Processing.SetProcessDelegate(processor.MemberFunc);          //Should be diagnostic
-		Processing.SetProcessDelegate(ProcessorProperty.MemberFunc);  //Should be diagnostic
-		Processing.SetProcessDelegate(processorStatic.MemberFunc);    //No diagnostic
+			PXLongOperation.StartOperation(this, MemberFunc);                       //Should be diagnostic
+			PXLongOperation.StartOperation(this, StaticFunc);						//No diagnostic
 
-		Processing.SetProcessDelegate<SOItemProcessing>((graph, dac) => graph.MainProcessingHandler(dac), graph => graph.FinallyHandler());    //No diagnostic
-		Processing.SetProcessDelegate<SOItemProcessing>((graph, dac) => MainProcessingHandler(dac), graph => FinallyHandler());                //Should be diagnostic
-		Processing.SetProcessDelegate<SOItemProcessing>((graph, dac) => graph.MainProcessingHandler(dac), graph => FinallyHandler());    //Should be diagnostic
-	}
+			//Test helper static function
+			PXLongOperation.StartOperation(this, Processor.StaticFunc);             //No diagnostic
 
-	public static void StaticFunc(object filter, List<SomeDAC> list, bool markOnly)
-	{ }
+			//test fields and properties
+			PXLongOperation.StartOperation(this, processor.MemberFunc);             //Should be diagnostic
+			PXLongOperation.StartOperation(this, ProcessorProperty.MemberFunc);     //Should be diagnostic
+			PXLongOperation.StartOperation(this, processorStatic.MemberFunc);       //No diagnostic
 
-	public static void StaticFunc(List<SomeDAC> list)
-	{ }
+			return adapter.Get();
+		}
 
-	public void MemberFunc(List<SomeDAC> list)
-	{ }
+		public SOItemProcessing()
+		{
+			object filter = null;
 
-	public void MainProcessingHandler(SomeDAC dac)
-	{
-	}
+			Processing.SetProcessDelegate(delegate (SOItemProcessing graph, SomeDAC applicationProjection) {
+				this.Clear();
+			});
 
-	public void FinallyHandler()
-	{
-	}
+			Processing.SetProcessDelegate(delegate (SOItemProcessing graph, SomeDAC applicationProjection) {
+				List<SomeDAC> list = new List<SomeDAC>();
+				StaticFunc(list);
+			});
 
-	private class Processor
-	{
-		public void MemberFunc(List<SomeDAC> list)
+			Processing.SetProcessDelegate(MemberFunc);
+			Processing.SetProcessDelegate(StaticFunc);
+
+			Processing.SetProcessDelegate(list => MemberFunc(list));
+			Processing.SetProcessDelegate(list => StaticFunc(filter, list, false));
+
+			//Test helper static function
+			Processing.SetProcessDelegate(Processor.StaticFunc);      //No diagnostic
+
+			//test fields and properties
+			Processing.SetProcessDelegate(processor.MemberFunc);          //Should be diagnostic
+			Processing.SetProcessDelegate(ProcessorProperty.MemberFunc);  //Should be diagnostic
+			Processing.SetProcessDelegate(processorStatic.MemberFunc);    //No diagnostic
+
+			Processing.SetProcessDelegate<SOItemProcessing>((graph, dac) => graph.MainProcessingHandler(dac), graph => graph.FinallyHandler());    //No diagnostic
+			Processing.SetProcessDelegate<SOItemProcessing>((graph, dac) => MainProcessingHandler(dac), graph => FinallyHandler());                //Should be diagnostic
+			Processing.SetProcessDelegate<SOItemProcessing>((graph, dac) => graph.MainProcessingHandler(dac), graph => FinallyHandler());    //Should be diagnostic
+		}
+
+		public static void StaticFunc(object filter, List<SomeDAC> list, bool markOnly)
 		{ }
 
 		public static void StaticFunc(List<SomeDAC> list)
 		{ }
+
+		public static void StaticFunc()
+		{ }
+
+		public void MemberFunc(List<SomeDAC> list)
+		{ }
+
+		public void MemberFunc()
+		{ }
+
+		public void MainProcessingHandler(SomeDAC dac)
+		{
+		}
+
+		public void FinallyHandler()
+		{
+		}
+
+		private class Processor
+		{
+			public void MemberFunc()
+			{ }
+
+			public void MemberFunc(List<SomeDAC> list)
+			{ }
+
+			public static void StaticFunc(List<SomeDAC> list)
+			{ }
+
+			public static void StaticFunc()
+			{ }
+		}
 	}
 }

--- a/src/Samples/PX.Objects.HackathonDemo/PX.Objects.HackathonDemo/PX.Objects.HackathonDemo.csproj
+++ b/src/Samples/PX.Objects.HackathonDemo/PX.Objects.HackathonDemo/PX.Objects.HackathonDemo.csproj
@@ -105,6 +105,7 @@
     <Compile Include="DAC\Forbidden Fields In DAC\POOrder.cs" />
     <Compile Include="DAC\Multiple field attributes, invalid aggregators and DAC field must be abstract\APInvoice.cs" />
     <Compile Include="DAC\APSetup.cs" />
+    <Compile Include="Graph\Closures in processing and long run delegates\SOItemProcessing.cs" />
     <Compile Include="Graph\Event Handlers\SOOrderEntryExt.cs" />
     <Compile Include="Graph\GoTo Test\SOInvoiceEntry.cs" />
     <Compile Include="Graph\GoTo Test\APInvoiceEntryExt.cs" />


### PR DESCRIPTION
Overview:
- modified PX1008 diagnostic to check long run delegates for captured graph references in closures
- enhanced `SetProcessDelegate` check to check overload with finally handler for captured graph references in closures
- added corresponding unit tests
- added nullable analysis support to some files
- minor refactoring