### PR TITLE
NuGet.CommandLine version was updated for PackageReference, but not for Exec, preventing code from compiling.

### DIFF
--- a/src/Acuminator/Acuminator.Analyzers/Acuminator.Analyzers.csproj
+++ b/src/Acuminator/Acuminator.Analyzers/Acuminator.Analyzers.csproj
@@ -78,7 +78,7 @@
     <GetAssemblyIdentity AssemblyFiles="$(OutDir)\$(AssemblyName).dll">
       <Output TaskParameter="Assemblies" ItemName="AnalyzerAssemblyInfo" />
     </GetAssemblyIdentity>
-    <Exec Command="&quot;$(SolutionDir)packages\NuGet.CommandLine\5.3.0\tools\NuGet.exe&quot; pack Acuminator.Analyzers.nuspec -NoPackageAnalysis -Version %(AnalyzerAssemblyInfo.Version) -OutputDirectory ." WorkingDirectory="$(OutDir)" LogStandardErrorAsError="true" ConsoleToMSBuild="true">
+    <Exec Command="&quot;$(SolutionDir)packages\NuGet.CommandLine\5.7.2\tools\NuGet.exe&quot; pack Acuminator.Analyzers.nuspec -NoPackageAnalysis -Version %(AnalyzerAssemblyInfo.Version) -OutputDirectory ." WorkingDirectory="$(OutDir)" LogStandardErrorAsError="true" ConsoleToMSBuild="true">
       <Output TaskParameter="ConsoleOutput" PropertyName="OutputOfExec" />
     </Exec>
   </Target>


### PR DESCRIPTION
NuGet.CommandLine version was updated for PackageReference, but not for Exec, preventing code from compiling.