### PR TITLE
Bugfix/atr 635 dev analyzer nre

### DIFF
--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/LongOperationDelegateClosures/CapturedLocalInstancesInExpressionsChecker.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/LongOperationDelegateClosures/CapturedLocalInstancesInExpressionsChecker.cs
@@ -1,0 +1,125 @@
+﻿#nullable enable
+
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+
+using Acuminator.Utilities;
+using Acuminator.Utilities.Common;
+using Acuminator.Utilities.DiagnosticSuppression;
+using Acuminator.Utilities.Roslyn.Constants;
+using Acuminator.Utilities.Roslyn.Semantic;
+using Acuminator.Utilities.Roslyn.Syntax;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Acuminator.Analyzers.StaticAnalysis.LongOperationDelegateClosures
+{
+    /// <summary>
+    /// An expression nodes checker that looks for closures that capture local instance.
+    /// </summary>
+    internal class CapturedLocalInstancesInExpressionsChecker : CSharpSyntaxWalker
+    {
+		private readonly PXContext _pxContext;
+		private readonly SemanticModel _semanticModel;
+		private readonly CancellationToken _cancellation;
+
+		private const int MaxRecursionDepth = 1000;
+		private int _recursionDepth = 0;
+		private bool _capturedLocalInstance;
+
+		public CapturedLocalInstancesInExpressionsChecker(SemanticModel semanticModel, PXContext pxContext, CancellationToken cancellation)
+		{
+			_semanticModel = semanticModel.CheckIfNull(nameof(semanticModel));
+			_pxContext = pxContext.CheckIfNull(nameof(pxContext));
+			_cancellation = cancellation;
+		}
+
+		public bool ExpressionCapturesLocalIntanceInClosure(ExpressionSyntax? expression)
+		{
+			if (expression == null)
+				return false;
+
+			if (!_capturedLocalInstance)
+				expression.Accept(this);
+
+			return _capturedLocalInstance;
+		}
+
+		public override void DefaultVisit(SyntaxNode node)
+		{
+			if (_capturedLocalInstance)
+				return;
+
+			_cancellation.ThrowIfCancellationRequested();
+
+			if (node is ExpressionSyntax expression)
+				_capturedLocalInstance = ExpressionCapturesLocalInstance(expression);
+
+			if (!_capturedLocalInstance && _recursionDepth <= MaxRecursionDepth)
+			{
+				try
+				{
+					_recursionDepth++;
+					base.DefaultVisit(node);
+				}
+				finally
+				{
+					_recursionDepth--;
+				}			
+			}
+		}
+
+		private bool ExpressionCapturesLocalInstance(ExpressionSyntax expression)
+		{
+			switch (expression)
+			{
+				case AnonymousFunctionExpressionSyntax anonMethodOrLambdaNode:
+					DataFlowAnalysis? dfa = _semanticModel.AnalyzeDataFlow(anonMethodOrLambdaNode);
+					return dfa != null && dfa.Succeeded && dfa.DataFlowsIn.OfType<IParameterSymbol>().Any(p => p.IsThis);
+
+				case IdentifierNameSyntax identifierName:
+					return IdentifierCapturesLocalInstance(identifierName);
+				default:
+					return false;
+			}
+		}
+
+		private bool IdentifierCapturesLocalInstance(IdentifierNameSyntax identifierName)
+		{
+			ISymbol? identifierSymbol = _semanticModel.GetSymbolInfo(identifierName, _cancellation).Symbol;
+
+			if (identifierSymbol?.ContainingType == null || identifierSymbol.IsStatic || !identifierSymbol.ContainingType.IsPXGraphOrExtension(_pxContext))
+				return false;
+
+			switch (identifierSymbol.Kind)
+			{
+				case SymbolKind.Local:
+					if (!(identifierSymbol is ILocalSymbol))
+						return false;
+
+					var localVariableDeclarator = identifierSymbol.DeclaringSyntaxReferences
+																  .FirstOrDefault()
+																 ?.GetSyntax(_cancellation) as VariableDeclaratorSyntax;
+					
+					// Check variable declaration to investigated assigned values.
+					// We do not check for assignments to the variable done after the declaration since this case is both difficult to analyze and very rare.
+					return ExpressionCapturesLocalIntanceInClosure(localVariableDeclarator?.Initializer?.Value);
+
+				case SymbolKind.Method:
+				case SymbolKind.Property:
+				case SymbolKind.Event:
+				case SymbolKind.Field:
+					return true;             // Instance methods, properties, fields and events hold closure
+
+				case SymbolKind.Parameter:    // We can't analyze parameter, so assume that they don't contains delegate with incorrect closures 
+				default:
+					return false;
+			}
+		}
+	}
+}

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/LongOperationDelegateClosures/LongOperationDelegateClosuresAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/LongOperationDelegateClosures/LongOperationDelegateClosuresAnalyzer.cs
@@ -125,6 +125,16 @@ namespace Acuminator.Analyzers.StaticAnalysis.LongOperationDelegateClosures
 				case ConditionalAccessExpressionSyntax conditionalAccess:
 					return MemberAccessExpressionHoldsClosure(syntaxContext, pxContext, conditionalAccess.Expression);
 
+				case CastExpressionSyntax castExpression:
+					return DelegateNodeHoldsClosure(syntaxContext, pxContext, castExpression.Expression);
+
+				case ObjectCreationExpressionSyntax objectCreationExpression:
+					if (objectCreationExpression.ArgumentList.Arguments.Count != 1)
+						return false;
+
+					ArgumentSyntax delegateCreationArg = objectCreationExpression.ArgumentList.Arguments[0];
+					return DelegateNodeHoldsClosure(syntaxContext, pxContext, delegateCreationArg.Expression);
+
 				default:
 					return false;
 			}

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/LongOperationStart/StartLongOperationDelegateWalker.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/LongOperationStart/StartLongOperationDelegateWalker.cs
@@ -7,15 +7,15 @@ using System.Linq;
 using System.Threading;
 
 using Acuminator.Utilities.Common;
-using Acuminator.Utilities.Roslyn;
 using Acuminator.Utilities.Roslyn.Semantic;
+using Acuminator.Utilities.Roslyn.Walkers;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Acuminator.Analyzers.StaticAnalysis.LongOperationStart
 {
-	public class StartLongOperationDelegateWalker : NestedInvocationWalker
+	public class StartLongOperationDelegateWalker : DelegatesWalkerBase
 	{
 		private readonly HashSet<SyntaxNode> _delegates = new HashSet<SyntaxNode>();
 		private readonly PXContext _pxContext;
@@ -52,29 +52,13 @@ namespace Acuminator.Analyzers.StaticAnalysis.LongOperationStart
 				return;
 			}
 
-			var delegateBody = GetLongRunDelegateBody(firstArgument);
+			var delegateBody = GetDelegateNode(firstArgument);
 			if (delegateBody == null)
 			{
 				return;
 			}
 
 			_delegates.Add(delegateBody);
-		}
-
-		private SyntaxNode? GetLongRunDelegateBody(ExpressionSyntax longRunDelegateExpression)
-		{
-			ThrowIfCancellationRequested();
-
-			if (longRunDelegateExpression is AnonymousFunctionExpressionSyntax anonymousFunction)
-			{
-				return anonymousFunction.Body;
-			}
-			else
-			{
-				var symbol = GetSymbol<ISymbol>(longRunDelegateExpression);
-
-				return symbol?.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax(CancellationToken);
-			}
 		}
 	}
 }

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/LongOperationStart/StartLongOperationDelegateWalker.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/LongOperationStart/StartLongOperationDelegateWalker.cs
@@ -1,78 +1,80 @@
-﻿using Acuminator.Utilities.Common;
-using Acuminator.Utilities.Roslyn;
-using Acuminator.Utilities.Roslyn.Semantic;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
+﻿#nullable enable
+
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 
+using Acuminator.Utilities.Common;
+using Acuminator.Utilities.Roslyn;
+using Acuminator.Utilities.Roslyn.Semantic;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
 namespace Acuminator.Analyzers.StaticAnalysis.LongOperationStart
 {
-    public class StartLongOperationDelegateWalker : NestedInvocationWalker
-    {
-        private readonly HashSet<SyntaxNode> _delegates = new HashSet<SyntaxNode>();
-        private readonly PXContext _pxContext;
+	public class StartLongOperationDelegateWalker : NestedInvocationWalker
+	{
+		private readonly HashSet<SyntaxNode> _delegates = new HashSet<SyntaxNode>();
+		private readonly PXContext _pxContext;
 
-        public ImmutableArray<SyntaxNode> Delegates => _delegates.ToImmutableArray();
+		public ImmutableArray<SyntaxNode> Delegates => _delegates.ToImmutableArray();
 
-        public StartLongOperationDelegateWalker(PXContext pxContext, Compilation compilation, CancellationToken cancellation)
-            : base(compilation, cancellation, pxContext.CodeAnalysisSettings)
-        {
-            pxContext.ThrowOnNull(nameof(pxContext));
+		public StartLongOperationDelegateWalker(PXContext pxContext, Compilation compilation, CancellationToken cancellation)
+			: base(compilation, cancellation, pxContext.CodeAnalysisSettings)
+		{
+			_pxContext = pxContext.CheckIfNull(nameof(pxContext));
+		}
 
-            _pxContext = pxContext;
-        }
+		public override void VisitInvocationExpression(InvocationExpressionSyntax node)
+		{
+			ThrowIfCancellationRequested();
 
-        public override void VisitInvocationExpression(InvocationExpressionSyntax node)
-        {
-            ThrowIfCancellationRequested();
+			IMethodSymbol? methodSymbol = GetSymbol<IMethodSymbol>(node);
 
-            IMethodSymbol methodSymbol = GetSymbol<IMethodSymbol>(node);
+			if (methodSymbol == null || !_pxContext.StartOperation.Contains(methodSymbol))
+			{
+				base.VisitInvocationExpression(node);
+			}
 
-            if (_pxContext.StartOperation.Contains(methodSymbol))
-            {
-                var delegateExists = node.ArgumentList?.Arguments.Count > 1;
-                if (!delegateExists)
-                {
-                    return;
-                }
+			var delegateExists = node.ArgumentList?.Arguments.Count > 1;
 
-                var firstArgument = node.ArgumentList.Arguments[1].Expression;
-                if (firstArgument == null)
-                {
-                    return;
-                }
+			if (!delegateExists)
+			{
+				return;
+			}
 
-                var delegateBody = GetDelegateBody(firstArgument);
-                if (delegateBody == null)
-                {
-                    return;
-                }
+			var firstArgument = node.ArgumentList!.Arguments[1].Expression;
+			if (firstArgument == null)
+			{
+				return;
+			}
 
-                _delegates.Add(delegateBody);
-            }
-            else
-            {
-                base.VisitInvocationExpression(node);
-            }
-        }
+			var delegateBody = GetLongRunDelegateBody(firstArgument);
+			if (delegateBody == null)
+			{
+				return;
+			}
 
-        private SyntaxNode GetDelegateBody(ExpressionSyntax expression)
-        {
-            ThrowIfCancellationRequested();
+			_delegates.Add(delegateBody);
+		}
 
-            if (expression is AnonymousFunctionExpressionSyntax anonymousFunction)
-            {
-                return anonymousFunction.Body;
-            }
-            else
-            {
-                var symbol = GetSymbol<ISymbol>(expression);
+		private SyntaxNode? GetLongRunDelegateBody(ExpressionSyntax longRunDelegateExpression)
+		{
+			ThrowIfCancellationRequested();
 
-                return symbol?.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax(CancellationToken);
-            }
-        }
-    }
+			if (longRunDelegateExpression is AnonymousFunctionExpressionSyntax anonymousFunction)
+			{
+				return anonymousFunction.Body;
+			}
+			else
+			{
+				var symbol = GetSymbol<ISymbol>(longRunDelegateExpression);
+
+				return symbol?.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax(CancellationToken);
+			}
+		}
+	}
 }

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/LongOperationStart/LongOperationInPXGraphDuringInitializationTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/LongOperationStart/LongOperationInPXGraphDuringInitializationTests.cs
@@ -31,7 +31,7 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.LongOperationStart
             VerifyCSharpDiagnostic(source, Descriptors.PX1054_PXGraphLongRunOperationDuringInitialization.CreateFor(17, 17));
         }
 
-        [Theory(Skip = "Temporarily skip to fix the build on Bamboo")]
+        [Theory]
         [EmbeddedFileData(@"PXGraph\PXGraphExtensionStartsLongOperationInInitializationMethod.cs")]
         public void GraphExtensionInitializationMethod_ReportsDiagnostic(string source)
         {

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/NestedInvocationWalker.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/NestedInvocationWalker.cs
@@ -1,14 +1,18 @@
-﻿using Acuminator.Utilities.Common;
-using Acuminator.Utilities.DiagnosticSuppression;
-using Acuminator.Utilities.Roslyn.Semantic;
-using Acuminator.Utilities.Roslyn.Syntax;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
+﻿#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+
+using Acuminator.Utilities.Common;
+using Acuminator.Utilities.DiagnosticSuppression;
+using Acuminator.Utilities.Roslyn.Semantic;
+using Acuminator.Utilities.Roslyn.Syntax;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Acuminator.Utilities.Roslyn
 {
@@ -54,7 +58,7 @@ namespace Acuminator.Utilities.Roslyn
         /// Syntax node in the original tree that is being analyzed.
         /// Typically it is the node on which a diagnostic should be reported.
         /// </summary>
-        protected SyntaxNode OriginalNode { get; private set; }
+        protected SyntaxNode? OriginalNode { get; private set; }
 
 		private readonly Stack<SyntaxNode> _nodesStack = new Stack<SyntaxNode>();
         private readonly HashSet<IMethodSymbol> _methodsInStack = new HashSet<IMethodSymbol>();
@@ -70,8 +74,8 @@ namespace Acuminator.Utilities.Roslyn
 		/// (Optional) Delegate to control if it is needed to bypass analysis of an invocation of a method and do not step into it. 
 		/// If not supplied, default implementation is used to bypass some core types from PX.Data namespace.
 		/// </param>
-		protected NestedInvocationWalker(Compilation compilation, CancellationToken cancellationToken, CodeAnalysisSettings codeAnalysisSettings,
-										 Func<IMethodSymbol, bool> bypassMethod = null)
+		protected NestedInvocationWalker(Compilation compilation, CancellationToken cancellationToken, CodeAnalysisSettings? codeAnalysisSettings,
+										 Func<IMethodSymbol, bool>? bypassMethod = null)
 		{
 			compilation.ThrowOnNull(nameof (compilation));
 
@@ -102,16 +106,13 @@ namespace Acuminator.Utilities.Roslyn
 			};
 		}
 
-		protected void ThrowIfCancellationRequested()
-		{
-            CancellationToken.ThrowIfCancellationRequested();
-		}
+		protected void ThrowIfCancellationRequested() => CancellationToken.ThrowIfCancellationRequested();
 
 		/// <summary>
 		/// Returns a symbol for an invocation expression, or, 
 		/// if the exact symbol cannot be found, returns the first candidate.
 		/// </summary>
-		protected virtual T GetSymbol<T>(ExpressionSyntax node)
+		protected virtual T? GetSymbol<T>(ExpressionSyntax node)
 			where T : class, ISymbol
 		{
 			var semanticModel = GetSemanticModel(node.SyntaxTree);
@@ -134,7 +135,7 @@ namespace Acuminator.Utilities.Roslyn
 			return null;
 		}
 
-		protected virtual SemanticModel GetSemanticModel(SyntaxTree syntaxTree)
+		protected virtual SemanticModel? GetSemanticModel(SyntaxTree syntaxTree)
 		{
 			if (!_compilation.ContainsSyntaxTree(syntaxTree))
 				return null;
@@ -192,10 +193,7 @@ namespace Acuminator.Utilities.Roslyn
 				OriginalNode = null;
 		}
 
-		private bool RecursiveAnalysisEnabled()
-		{
-			return _settings.RecursiveAnalysisEnabled && _nodesStack.Count <= MaxDepth;
-		}
+		private bool RecursiveAnalysisEnabled() => _settings.RecursiveAnalysisEnabled && _nodesStack.Count <= MaxDepth;
 
 		#region Visit
 
@@ -282,7 +280,7 @@ namespace Acuminator.Utilities.Roslyn
 		{
 		}
 
-		private void VisitMethodSymbol(IMethodSymbol symbol, SyntaxNode originalNode)
+		private void VisitMethodSymbol(IMethodSymbol? symbol, SyntaxNode originalNode)
 		{
 			if (symbol?.GetSyntax(CancellationToken) is CSharpSyntaxNode methodNode &&
                 !IsMethodInStack(symbol) && !_bypassMethod(symbol))

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/PXGraph/ProcessingDelegatesWalker.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/PXGraph/ProcessingDelegatesWalker.cs
@@ -153,14 +153,8 @@ namespace Acuminator.Utilities.Roslyn.Semantic.PXGraph
 
 			var (delegateSymbol, delegateNode) = GetDelegateSymbolAndNode(handlerNode);
 
-			if (delegateSymbol == null || delegateNode == null)
-			{
-				if (handlerNode.Root().ContainsDiagnostics)
-					return null;
-
-				throw new InvalidOperationException(
-					$"Failed to recognize syntax node passed to SetProcessDelegate/SetParametersDelegate method:{Environment.NewLine} {handlerNode}");
-			}
+			if (delegateSymbol == null || delegateNode == null)  // Skip analysis for unrecognized arguments
+				return null;
 
 			var processingDelegateInfo = new ProcessingDelegateInfo(delegateNode, delegateSymbol, _currentDeclarationOrder);
 

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Syntax/ArgumentSyntaxExtensions.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Syntax/ArgumentSyntaxExtensions.cs
@@ -1,50 +1,52 @@
-﻿using System.Collections.Immutable;
+﻿#nullable enable
+
+using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
+
 using Acuminator.Utilities.Common;
+
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Acuminator.Utilities.Roslyn.Syntax
 {
-    public static class ArgumentSyntaxExtensions
-    {
-        public static IParameterSymbol DetermineParameter(
-            this ArgumentSyntax argument,
-            ImmutableArray<IParameterSymbol> parameters,
-            bool allowParams = false)
-        {
-            argument.ThrowOnNull(nameof(argument));
+	public static class ArgumentSyntaxExtensions
+	{
+		public static IParameterSymbol? DetermineParameter(this ArgumentSyntax argument, ImmutableArray<IParameterSymbol> parameters, 
+														   bool allowParams = false)
+		{
+			argument.ThrowOnNull(nameof(argument));
 
-            if (!(argument.Parent is BaseArgumentListSyntax argumentList))
-                return null;
+			if (!(argument.Parent is BaseArgumentListSyntax argumentList))
+				return null;
 
-            // Handle named argument
-            if (argument.NameColon != null && !argument.NameColon.IsMissing)
-            {
-                string name = argument.NameColon.Name.Identifier.ValueText;
-                return parameters.FirstOrDefault(p => p.Name == name);
-            }
+			// Handle named argument
+			if (argument.NameColon != null && !argument.NameColon.IsMissing)
+			{
+				string name = argument.NameColon.Name.Identifier.ValueText;
+				return parameters.FirstOrDefault(p => p.Name == name);
+			}
 
-            // Handle positional argument
-            int index = argumentList.Arguments.IndexOf(argument);
-            if (index < 0)
-                return null;
+			// Handle positional argument
+			int index = argumentList.Arguments.IndexOf(argument);
+			if (index < 0)
+				return null;
 
-            if (index < parameters.Length)
-                return parameters[index];
+			if (index < parameters.Length)
+				return parameters[index];
 
-            if (allowParams)
-            {
-                IParameterSymbol lastParameter = parameters.LastOrDefault();
-                if (lastParameter == null)
-                    return null;
+			if (allowParams)
+			{
+				IParameterSymbol lastParameter = parameters.LastOrDefault();
+				if (lastParameter == null)
+					return null;
 
-                if (lastParameter.IsParams)
-                    return lastParameter;
-            }
+				if (lastParameter.IsParams)
+					return lastParameter;
+			}
 
-            return null;
-        }
-    }
+			return null;
+		}
+	}
 }

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Walkers/DelegatesWalkerBase.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Walkers/DelegatesWalkerBase.cs
@@ -1,0 +1,94 @@
+﻿#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+
+using Acuminator.Utilities.Common;
+using Acuminator.Utilities.Roslyn.Syntax;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Acuminator.Utilities.Roslyn.Walkers
+{
+	/// <summary>
+	/// The delegates walker base class that has some common logic for analysis of delegate expressions.
+	/// </summary>
+	public abstract class DelegatesWalkerBase : NestedInvocationWalker
+	{
+		protected DelegatesWalkerBase(Compilation compilation, CancellationToken cancellationToken, CodeAnalysisSettings? codeAnalysisSettings,
+									  Func<IMethodSymbol, bool>? bypassMethod = null) :
+								 base(compilation, cancellationToken, codeAnalysisSettings, bypassMethod)
+		{
+		}
+
+		/// <summary>
+		/// Gets delegate symbol and node from the <paramref name="delegateExpression"/>.
+		/// </summary>
+		/// <param name="delegateExpression">The delegate expression node.</param>
+		/// <returns>
+		/// The delegate expression symbol and node.
+		/// </returns>
+		protected (ISymbol? DelegateSymbol, SyntaxNode? DelegateNode) GetDelegateSymbolAndNode(ExpressionSyntax delegateExpression)
+		{
+			delegateExpression.ThrowOnNull(nameof(delegateExpression));
+			ThrowIfCancellationRequested();
+
+			switch (delegateExpression)
+			{
+				case CastExpressionSyntax castExpression:
+					return GetDelegateSymbolAndNode(castExpression.Expression);
+
+				case AnonymousFunctionExpressionSyntax anonymousFunction:
+					{
+						var delegateNode = anonymousFunction.Body;
+						var delegateSymbol = GetSemanticModel(delegateNode.SyntaxTree)
+												?.GetSymbolInfo(anonymousFunction, CancellationToken).Symbol;
+
+						return (delegateSymbol, delegateNode);
+					}
+				default:
+					{
+						var delegateSymbol = GetSymbol<ISymbol>(delegateExpression);
+						var delegateNode = delegateSymbol?.DeclaringSyntaxReferences
+														  .FirstOrDefault()
+														 ?.GetSyntax(CancellationToken);
+						return (delegateSymbol, delegateNode);
+					}
+			}
+		}
+
+		/// <summary>
+		/// Gets delegate syntax node from the <paramref name="delegateExpression"/>.
+		/// </summary>
+		/// <param name="delegateExpression">The delegate expression node.</param>
+		/// <returns>
+		/// The delegate syntax node.
+		/// </returns>
+		protected SyntaxNode? GetDelegateNode(ExpressionSyntax delegateExpression)
+		{
+			delegateExpression.ThrowOnNull(nameof(delegateExpression));
+			ThrowIfCancellationRequested();
+
+			switch (delegateExpression)
+			{
+				case CastExpressionSyntax castExpression:
+					return GetDelegateNode(castExpression.Expression);
+
+				case AnonymousFunctionExpressionSyntax anonymousFunction:
+					return anonymousFunction.Body;
+
+				default:
+					var delegateSymbol = GetSymbol<ISymbol>(delegateExpression);
+
+					return delegateSymbol?.DeclaringSyntaxReferences
+										  .FirstOrDefault()
+										 ?.GetSyntax(CancellationToken);
+			}
+		}
+	}
+}

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Walkers/DelegatesWalkerBase.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Walkers/DelegatesWalkerBase.cs
@@ -40,9 +40,6 @@ namespace Acuminator.Utilities.Roslyn.Walkers
 
 			switch (delegateExpression)
 			{
-				case CastExpressionSyntax castExpression:
-					return GetDelegateSymbolAndNode(castExpression.Expression);
-
 				case AnonymousFunctionExpressionSyntax anonymousFunction:
 					{
 						var delegateNode = anonymousFunction.Body;
@@ -50,6 +47,18 @@ namespace Acuminator.Utilities.Roslyn.Walkers
 												?.GetSymbolInfo(anonymousFunction, CancellationToken).Symbol;
 
 						return (delegateSymbol, delegateNode);
+					}
+				case CastExpressionSyntax castExpression:
+					{
+						return GetDelegateSymbolAndNode(castExpression.Expression);
+					}
+				case ObjectCreationExpressionSyntax objectCreationExpression:
+					{
+						if (objectCreationExpression.ArgumentList.Arguments.Count != 1)
+							return default;
+
+						ArgumentSyntax delegateCreationArg = objectCreationExpression.ArgumentList.Arguments[0];
+						return GetDelegateSymbolAndNode(delegateCreationArg.Expression);
 					}
 				default:
 					{
@@ -76,11 +85,18 @@ namespace Acuminator.Utilities.Roslyn.Walkers
 
 			switch (delegateExpression)
 			{
+				case AnonymousFunctionExpressionSyntax anonymousFunction:
+					return anonymousFunction.Body;
+
 				case CastExpressionSyntax castExpression:
 					return GetDelegateNode(castExpression.Expression);
 
-				case AnonymousFunctionExpressionSyntax anonymousFunction:
-					return anonymousFunction.Body;
+				case ObjectCreationExpressionSyntax objectCreationExpression:
+					if (objectCreationExpression.ArgumentList.Arguments.Count != 1)
+						return null;
+
+					ArgumentSyntax delegateCreationArg = objectCreationExpression.ArgumentList.Arguments[0];
+					return GetDelegateNode(delegateCreationArg.Expression);
 
 				default:
 					var delegateSymbol = GetSymbol<ISymbol>(delegateExpression);

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Walkers/DelegatesWalkerBase.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Walkers/DelegatesWalkerBase.cs
@@ -114,7 +114,7 @@ namespace Acuminator.Utilities.Roslyn.Walkers
 													 ?.GetSyntax(CancellationToken);
 
 					// Method is the most simple and frequent case for identifiers passed as expressions for delegates.
-					// It is very difficult to analyze local variables, properties and fields in a general case and they are rarely used
+					// It is difficult to analyze local variables, parameters, properties and fields in a general case and they are rarely used
 					// for identifiers passed as expressions for delegates. 
 					// Therefore, they are deemed as non recognized.
 					return delegateNode != null && delegateSymbol?.Kind == SymbolKind.Method

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Walkers/DelegatesWalkerBase.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Walkers/DelegatesWalkerBase.cs
@@ -62,11 +62,19 @@ namespace Acuminator.Utilities.Roslyn.Walkers
 					}
 				default:
 					{
+						// Case when an identifier is passed as an expression for a delegate
 						var delegateSymbol = GetSymbol<ISymbol>(delegateExpression);
 						var delegateNode = delegateSymbol?.DeclaringSyntaxReferences
 														  .FirstOrDefault()
 														 ?.GetSyntax(CancellationToken);
-						return (delegateSymbol, delegateNode);
+
+						// Method is the most simple and frequent case for identifiers passed as expressions for delegates.
+						// It is very difficult to analyze local variables, properties and fields in a general case and they are rarely used
+						// for identifiers passed as expressions for delegates. 
+						// Therefore, they are deemed as non recognized.
+						return delegateNode != null && delegateSymbol?.Kind == SymbolKind.Method
+							? (delegateSymbol, delegateNode)
+							: default;
 					}
 			}
 		}
@@ -99,11 +107,19 @@ namespace Acuminator.Utilities.Roslyn.Walkers
 					return GetDelegateNode(delegateCreationArg.Expression);
 
 				default:
+					// Case when an identifier is passed as an expression for a delegate
 					var delegateSymbol = GetSymbol<ISymbol>(delegateExpression);
+					var delegateNode = delegateSymbol?.DeclaringSyntaxReferences
+													  .FirstOrDefault()
+													 ?.GetSyntax(CancellationToken);
 
-					return delegateSymbol?.DeclaringSyntaxReferences
-										  .FirstOrDefault()
-										 ?.GetSyntax(CancellationToken);
+					// Method is the most simple and frequent case for identifiers passed as expressions for delegates.
+					// It is very difficult to analyze local variables, properties and fields in a general case and they are rarely used
+					// for identifiers passed as expressions for delegates. 
+					// Therefore, they are deemed as non recognized.
+					return delegateNode != null && delegateSymbol?.Kind == SymbolKind.Method
+						? delegateNode
+						: null;
 			}
 		}
 	}

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Walkers/DelegatesWalkerBase.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Walkers/DelegatesWalkerBase.cs
@@ -69,7 +69,7 @@ namespace Acuminator.Utilities.Roslyn.Walkers
 														 ?.GetSyntax(CancellationToken);
 
 						// Method is the most simple and frequent case for identifiers passed as expressions for delegates.
-						// It is very difficult to analyze local variables, properties and fields in a general case and they are rarely used
+						// It is very difficult to analyze local variables, properties, fields and general expressions and they are rarely used
 						// for identifiers passed as expressions for delegates. 
 						// Therefore, they are deemed as non recognized.
 						return delegateNode != null && delegateSymbol?.Kind == SymbolKind.Method


### PR DESCRIPTION
The bug is caused by the lack of support for more complex expressions passed to SetProcessDelegate API:
- Cast expression like:
```csharp
    ProcessProductSync.SetProcessDelegate((PXProcessingBase<KNCASyncDetails>.ProcessListDelegate)delegate
    {
        ProductCreateUpdate();
    });
```
- Object creation expression:
```csharp
    ProcessProductSync.SetProcessDelegate(new PXProcessingBase<KNCASyncDetails>.ProcessListDelegate(delegate
    {
    	ProductCreateUpdate();
    }));
```
- Local variable or parameter that store delegate
- Property or field that store delegate

Added such support to diagnostics related to long runs. 
Enhanced captured closures collection by making a dedicated walker that handles more complex cases