### PR TITLE
Bugfix/atr 675 dev px1072 false alert on static methods

### DIFF
--- a/src/Acuminator/Acuminator.Analyzers/Resources.Designer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/Resources.Designer.cs
@@ -1325,7 +1325,7 @@ namespace Acuminator.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Create a shared graph variable that can be reused by BQL queries.
+        ///   Looks up a localized string similar to Creating a graph for a BQL query is a resource consuming operation. To decrease the number of these operations, create a variable with a shared graph that can be reused by BQL queries..
         /// </summary>
         public static string PX1072Title_CreateSharedGraphVariable {
             get {

--- a/src/Acuminator/Acuminator.Analyzers/Resources.Designer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/Resources.Designer.cs
@@ -286,7 +286,7 @@ namespace Acuminator.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The reference to {0} is captured in the {1} delegate closure and will cause synchronous delegate execution. It may lead to random bugs and data consistency issues.
+        ///   Looks up a localized string similar to The reference to {0} is captured in the {1} delegate and will cause synchronous execution of the delegate. It may lead to random bugs and data consistency issues..
         /// </summary>
         public static string PX1008Title {
             get {
@@ -1325,11 +1325,20 @@ namespace Acuminator.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Create a shared graph variable that can be reused by BQL queries.
+        /// </summary>
+        public static string PX1072Title_CreateSharedGraphVariable {
+            get {
+                return ResourceManager.GetString("PX1072Title_CreateSharedGraphVariable", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to BQL queries must be executed within the context of an existing PXGraph instance.
         /// </summary>
-        public static string PX1072Title {
+        public static string PX1072Title_ReuseExistingGraphVariable {
             get {
-                return ResourceManager.GetString("PX1072Title", resourceCulture);
+                return ResourceManager.GetString("PX1072Title_ReuseExistingGraphVariable", resourceCulture);
             }
         }
         

--- a/src/Acuminator/Acuminator.Analyzers/Resources.resx
+++ b/src/Acuminator/Acuminator.Analyzers/Resources.resx
@@ -357,7 +357,7 @@
   <data name="PX1071Title" xml:space="preserve">
     <value>Actions cannot be executed within event handlers</value>
   </data>
-  <data name="PX1072Title" xml:space="preserve">
+  <data name="PX1072Title_ReuseExistingGraphVariable" xml:space="preserve">
     <value>BQL queries must be executed within the context of an existing PXGraph instance</value>
   </data>
   <data name="PX1080Title" xml:space="preserve">
@@ -636,5 +636,8 @@
   </data>
   <data name="PX1008Title_LongRunDelegateFormatArg" xml:space="preserve">
     <value>long run operation</value>
+  </data>
+  <data name="PX1072Title_CreateSharedGraphVariable" xml:space="preserve">
+    <value>Create a shared graph variable that can be reused by BQL queries</value>
   </data>
 </root>

--- a/src/Acuminator/Acuminator.Analyzers/Resources.resx
+++ b/src/Acuminator/Acuminator.Analyzers/Resources.resx
@@ -638,6 +638,6 @@
     <value>long run operation</value>
   </data>
   <data name="PX1072Title_CreateSharedGraphVariable" xml:space="preserve">
-    <value>Create a shared graph variable that can be reused by BQL queries</value>
+    <value>Creating a graph for a BQL query is a resource consuming operation. To decrease the number of these operations, create a variable with a shared graph that can be reused by BQL queries.</value>
   </data>
 </root>

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/Descriptors.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/Descriptors.cs
@@ -324,8 +324,11 @@ namespace Acuminator.Analyzers.StaticAnalysis
 		public static DiagnosticDescriptor PX1071_PXActionExecutionInEventHandlers_NonISV { get; } =
 			Rule("PX1071", nameof(Resources.PX1071Title).GetLocalized(), Category.Default, DiagnosticSeverity.Warning, DiagnosticsShortName.PX1071);
 
-		public static DiagnosticDescriptor PX1072_PXGraphCreationForBqlQueries { get; } =
-			Rule("PX1072", nameof(Resources.PX1072Title).GetLocalized(), Category.Default, DiagnosticSeverity.Warning, DiagnosticsShortName.PX1072);
+		public static DiagnosticDescriptor PX1072_PXGraphCreationForBqlQueries_ReuseExistingGraphVariable { get; } =
+			Rule("PX1072", nameof(Resources.PX1072Title_ReuseExistingGraphVariable).GetLocalized(), Category.Default, DiagnosticSeverity.Warning, DiagnosticsShortName.PX1072);
+
+		public static DiagnosticDescriptor PX1072_PXGraphCreationForBqlQueries_CreateSharedGraphVariable { get; } =
+			Rule("PX1072", nameof(Resources.PX1072Title_CreateSharedGraphVariable).GetLocalized(), Category.Default, DiagnosticSeverity.Warning, DiagnosticsShortName.PX1072);
 
 		public static DiagnosticDescriptor PX1073_ThrowingExceptionsInRowPersisted { get; } =
 			Rule("PX1073", nameof(Resources.PX1073Title).GetLocalized(), Category.Default, DiagnosticSeverity.Error, DiagnosticsShortName.PX1073);

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/Localization/LocalizationPXExceptionAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/Localization/LocalizationPXExceptionAnalyzer.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#nullable enable
+
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -74,24 +76,27 @@ namespace Acuminator.Analyzers.StaticAnalysis.Localization
             }
         }
 
-        private ExpressionSyntax GetMessageExpression(SyntaxNodeAnalysisContext syntaxContext, ImmutableArray<IParameterSymbol> pars, ArgumentListSyntax args)
+        private ExpressionSyntax? GetMessageExpression(SyntaxNodeAnalysisContext syntaxContext, ImmutableArray<IParameterSymbol> pars, ArgumentListSyntax? args)
         {
             syntaxContext.CancellationToken.ThrowIfCancellationRequested();
 
-            ArgumentSyntax messageArg = null;
+			if (args == null)
+				return null;
 
-            foreach (ArgumentSyntax a in args.Arguments)
+            ArgumentSyntax? messageArg = null;
+
+            foreach (ArgumentSyntax argument in args.Arguments)
             {
-                IParameterSymbol p = a.DetermineParameter(pars, false);
+                IParameterSymbol? parameter = argument.DetermineParameter(pars, allowParams: false);
 
-                if (_messageArgNames.Contains(p?.Name, StringComparer.Ordinal))
+                if (_messageArgNames.Contains(parameter?.Name, StringComparer.Ordinal))
                 {
-                    messageArg = a;
+                    messageArg = argument;
                     break;
                 }
             }
 
-            if (messageArg == null || messageArg.Expression == null)
+            if (messageArg?.Expression == null)
                 return null;
 
             return messageArg.Expression;

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/Localization/LocalizationPXExceptionAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/Localization/LocalizationPXExceptionAnalyzer.cs
@@ -66,7 +66,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.Localization
                     continue;
 
                 ImmutableArray<IParameterSymbol> pars = methodSymbol.Parameters;
-                ExpressionSyntax messageExpression = GetMessageExpression(syntaxContext, pars, c.ArgumentList);
+                ExpressionSyntax? messageExpression = GetMessageExpression(syntaxContext, pars, c.ArgumentList);
 
                 if (messageExpression == null)
                     continue;
@@ -119,7 +119,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.Localization
                 return;
 
             ImmutableArray<IParameterSymbol> pars = ctorSymbol.Parameters;
-            ExpressionSyntax messageExpression = GetMessageExpression(syntaxContext, pars, ctorNode.ArgumentList);
+            ExpressionSyntax? messageExpression = GetMessageExpression(syntaxContext, pars, ctorNode.ArgumentList);
 
             if (messageExpression == null)
                 return;

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXGraphCreationForBqlQueries/PXGraphCreationForBqlQueriesAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXGraphCreationForBqlQueries/PXGraphCreationForBqlQueriesAnalyzer.cs
@@ -126,18 +126,8 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXGraphCreationForBqlQueries
 				var symbolInfo = semanticModel.GetSymbolInfo(subNode, cancellation);
 				var symbol = symbolInfo.Symbol ?? symbolInfo.CandidateSymbols.FirstOrDefault();
 
-				if (symbol != null)
-				{
-					if (existingGraphs.Contains(symbol))
-						yield return symbol;
-				}
-				else
-				{
-					var declaredSymbol = semanticModel.GetDeclaredSymbol(subNode, cancellation);
-
-					if (declaredSymbol != null && existingGraphs.Contains(declaredSymbol))
-						yield return declaredSymbol;
-				}				
+				if (symbol != null && existingGraphs.Contains(symbol))	
+					yield return symbol;						
 			}
 		}
 

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXGraphCreationForBqlQueries/PXGraphCreationForBqlQueriesAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXGraphCreationForBqlQueries/PXGraphCreationForBqlQueriesAnalyzer.cs
@@ -131,7 +131,8 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXGraphCreationForBqlQueries
 		}
 
 		private void AnalyzeGraphArgumentOfBqlQuery(CodeBlockAnalysisContext context, PXContext pxContext, ExpressionSyntax graphArgSyntax,
-													List<ISymbol> availableGraphs, Dictionary<ISymbol, List<SyntaxNode>> availableGraphUsages)
+													int bqlCallsCountInBlock, List<ISymbol> availableGraphs, 
+													Dictionary<ISymbol, List<SyntaxNode>> availableGraphUsages)
 		{
 			var instantiationType = graphArgSyntax.GetGraphInstantiationType(context.SemanticModel, pxContext);
 
@@ -143,7 +144,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXGraphCreationForBqlQueries
 			{
 				var diagnosticPropertiesForGraphCreatedInArgumentExpression = CreateDiagnosticProperties(availableGraphs, pxContext);
 				context.ReportDiagnosticWithSuppressionCheck(
-					Diagnostic.Create(Descriptors.PX1072_PXGraphCreationForBqlQueries, graphArgSyntax.GetLocation(),
+					Diagnostic.Create(Descriptors.PX1072_PXGraphCreationForBqlQueries_ReuseExistingGraphVariable, graphArgSyntax.GetLocation(),
 									  diagnosticPropertiesForGraphCreatedInArgumentExpression),
 					pxContext.CodeAnalysisSettings);
 				return;
@@ -171,7 +172,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXGraphCreationForBqlQueries
 
 			var diagnosticProperties = CreateDiagnosticProperties(availableGraphsNotUsedBeforeBqlQuery.Where(graph => !localVar.Equals(graph)), pxContext);
 			context.ReportDiagnosticWithSuppressionCheck(
-				Diagnostic.Create(Descriptors.PX1072_PXGraphCreationForBqlQueries, graphArgSyntax.GetLocation(), diagnosticProperties),
+				Diagnostic.Create(Descriptors.PX1072_PXGraphCreationForBqlQueries_ReuseExistingGraphVariable, graphArgSyntax.GetLocation(), diagnosticProperties),
 				pxContext.CodeAnalysisSettings);
 		}
 

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXGraphCreationForBqlQueries/PXGraphCreationForBqlQueriesAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXGraphCreationForBqlQueries/PXGraphCreationForBqlQueriesAnalyzer.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿#nullable enable
+
+using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 
@@ -27,7 +30,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXGraphCreationForBqlQueries
 		public PXGraphCreationForBqlQueriesAnalyzer() : this(null)
 		{ }
 
-		public PXGraphCreationForBqlQueriesAnalyzer(CodeAnalysisSettings codeAnalysisSettings) : base(codeAnalysisSettings)
+		public PXGraphCreationForBqlQueriesAnalyzer(CodeAnalysisSettings? codeAnalysisSettings) : base(codeAnalysisSettings)
 		{ }
 
 		internal override void AnalyzeCompilation(CompilationStartAnalysisContext compilationStartContext, PXContext pxContext)
@@ -40,7 +43,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXGraphCreationForBqlQueries
 			context.CancellationToken.ThrowIfCancellationRequested();
 
 			// Get body from a method or property
-			CSharpSyntaxNode body = context.CodeBlock?.GetBody();
+			CSharpSyntaxNode? body = context.CodeBlock?.GetBody();
 			if (body == null) return;
 
 			// Collect all PXGraph-typed method parameters passed to BQL queries
@@ -87,9 +90,9 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXGraphCreationForBqlQueries
 		private ImmutableArray<ISymbol> GetExistingGraphInstances(SyntaxNode body, SemanticModel semanticModel, 
 			PXContext pxContext)
 		{
-			var dataFlow = semanticModel.AnalyzeDataFlow(body);
+			var dataFlow = semanticModel.TryAnalyzeDataFlow(body);
 
-			if (!dataFlow.Succeeded) 
+			if (dataFlow == null) 
 				return ImmutableArray<ISymbol>.Empty;
 
 			// this
@@ -139,7 +142,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXGraphCreationForBqlQueries
 
 			foreach (var graph in availableGraphs)
 			{
-				ITypeSymbol type = graph switch
+				ITypeSymbol? type = graph switch
 				{
 					IParameterSymbol property => property.Type,
 					ILocalSymbol local => local.Type,

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXGraphCreationForBqlQueries/PXGraphCreationForBqlQueriesFix.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXGraphCreationForBqlQueries/PXGraphCreationForBqlQueriesFix.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#nullable enable
+
+using System;
 using System.Collections.Immutable;
 using System.Composition;
 using System.Threading;
@@ -49,7 +51,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXGraphCreationForBqlQueries
 						PXGraphCreationForBqlQueriesAnalyzer.IsGraphExtensionPropertyPrefix + i);
 
 					var codeAction = CodeAction.Create(codeActionName, 
-						ct => ReplaceIdentifier(context.Document, root, node, identifierName, isGraphExtension, context.CancellationToken),
+						ct => ReplaceIdentifier(context.Document, root!, node, identifierName, isGraphExtension, context.CancellationToken),
 						equivalenceKey: codeActionName);
 					context.RegisterCodeFix(codeAction, diagnostic);
 				}

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXGraphCreationForBqlQueries/PXGraphCreationForBqlQueriesFix.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXGraphCreationForBqlQueries/PXGraphCreationForBqlQueriesFix.cs
@@ -18,7 +18,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXGraphCreationForBqlQueries
 	public class PXGraphCreationForBqlQueriesFix : CodeFixProvider
 	{
 		public override ImmutableArray<string> FixableDiagnosticIds { get; } =
-			ImmutableArray.Create(Descriptors.PX1072_PXGraphCreationForBqlQueries.Id);
+			ImmutableArray.Create(Descriptors.PX1072_PXGraphCreationForBqlQueries_ReuseExistingGraphVariable.Id);
 
 		public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
 

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXGraphCreationForBqlQueries/Walker.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXGraphCreationForBqlQueries/Walker.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#nullable enable
+
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -27,12 +29,9 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXGraphCreationForBqlQueries
 			public ImmutableArray<ExpressionSyntax> GraphArguments => _graphArguments.ToImmutableArray();
 
 			public BqlGraphArgWalker(SemanticModel semanticModel, PXContext pxContext)
-			{
-				semanticModel.ThrowOnNull(nameof (semanticModel));
-				pxContext.ThrowOnNull(nameof (pxContext));
-
-				_semanticModel = semanticModel;
-				_pxContext = pxContext;
+			{				
+				_semanticModel = semanticModel.CheckIfNull(nameof(semanticModel));
+				_pxContext = pxContext.CheckIfNull(nameof(pxContext));
 			}
 
 			public override void VisitInvocationExpression(InvocationExpressionSyntax node)
@@ -45,7 +44,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXGraphCreationForBqlQueries
 				var declaringType = methodSymbol?.ContainingType?.OriginalDefinition;
 
 				if (declaringType != null && declaringType.IsBqlCommand(_pxContext) 
-					&& !methodSymbol.Parameters.IsEmpty && methodSymbol.Parameters[0].Type.IsPXGraph(_pxContext) 
+					&& !methodSymbol!.Parameters.IsEmpty && methodSymbol.Parameters[0].Type.IsPXGraph(_pxContext) 
 					&& node.ArgumentList.Arguments.Count > 0 &&
 				    (methodSymbol.Name.StartsWith(SelectMethodName, StringComparison.Ordinal) ||
 				     methodSymbol.Name.StartsWith(SearchMethodName, StringComparison.Ordinal)))

--- a/src/Acuminator/Acuminator.Tests/Acuminator.Tests.csproj
+++ b/src/Acuminator/Acuminator.Tests/Acuminator.Tests.csproj
@@ -266,6 +266,7 @@
     <EmbeddedResource Include="Tests\StaticAnalysis\PublicClassXmlComment\Sources\ShouldNotShow.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\PXGraphCreationForBqlQueries\Sources\CustomerMaint_CheckGraphContext.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\PXGraphCreationForBqlQueries\Sources\ExternalService_SingleQueryWithGraphCreation.cs" />
+    <EmbeddedResource Include="Tests\StaticAnalysis\PXGraphCreationForBqlQueries\Sources\ExternalService_TwoQueryWithGraphCreation.cs" />
     <Compile Include="Tests\StaticAnalysis\SuppressionDiagnostics\MultipleSuppressionCodeFixTests.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\SuppressionDiagnostics\Sources\Dac\SuppressMuiltipleDiagnostics_One.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\SuppressionDiagnostics\Sources\Dac\DAC_Without_XML_Description.cs" />

--- a/src/Acuminator/Acuminator.Tests/Acuminator.Tests.csproj
+++ b/src/Acuminator/Acuminator.Tests/Acuminator.Tests.csproj
@@ -265,6 +265,7 @@
     <EmbeddedResource Include="Tests\StaticAnalysis\NonPublicExtensions\Sources\NonPublicGraphExtension_Expected.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\PublicClassXmlComment\Sources\ShouldNotShow.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\PXGraphCreationForBqlQueries\Sources\CustomerMaint_CheckGraphContext.cs" />
+    <EmbeddedResource Include="Tests\StaticAnalysis\PXGraphCreationForBqlQueries\Sources\ExternalService_SingleQueryWithGraphCreation.cs" />
     <Compile Include="Tests\StaticAnalysis\SuppressionDiagnostics\MultipleSuppressionCodeFixTests.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\SuppressionDiagnostics\Sources\Dac\SuppressMuiltipleDiagnostics_One.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\SuppressionDiagnostics\Sources\Dac\DAC_Without_XML_Description.cs" />

--- a/src/Acuminator/Acuminator.Tests/Acuminator.Tests.csproj
+++ b/src/Acuminator/Acuminator.Tests/Acuminator.Tests.csproj
@@ -264,6 +264,7 @@
     <EmbeddedResource Include="Tests\StaticAnalysis\NonPublicExtensions\Sources\NonPublicDacExtension.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\NonPublicExtensions\Sources\NonPublicGraphExtension_Expected.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\PublicClassXmlComment\Sources\ShouldNotShow.cs" />
+    <EmbeddedResource Include="Tests\StaticAnalysis\PXGraphCreationForBqlQueries\Sources\CustomerMaint_CheckGraphContext.cs" />
     <Compile Include="Tests\StaticAnalysis\SuppressionDiagnostics\MultipleSuppressionCodeFixTests.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\SuppressionDiagnostics\Sources\Dac\SuppressMuiltipleDiagnostics_One.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\SuppressionDiagnostics\Sources\Dac\DAC_Without_XML_Description.cs" />

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreationForBqlQueries/PXGraphCreationDuringInitializationTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreationForBqlQueries/PXGraphCreationDuringInitializationTests.cs
@@ -82,6 +82,13 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.PXGraphCreationForBqlQueries
 		public async Task InsideGraph_OnlyInstanceMethodsAreReported_WithThisReferenceSuggestion(string source) =>
 			await VerifyCSharpDiagnosticAsync(source,
 				Descriptors.PX1072_PXGraphCreationForBqlQueries.CreateFor(17, 50));
+
+		[Theory]
+		[EmbeddedFileData("ExternalService_TwoQueryWithGraphCreation.cs", "Customer.cs", "CustomerMaint.cs")]
+		public async Task TwoQuery_WithGraphCreationInArgument(string source, string dacSource, string graphSource) =>
+			await VerifyCSharpDiagnosticAsync(source, dacSource, graphSource,
+				Descriptors.PX1072_PXGraphCreationForBqlQueries.CreateFor(14, 51),
+				Descriptors.PX1072_PXGraphCreationForBqlQueries.CreateFor(15, 51));
 		#endregion
 
 		#region False-positive checks

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreationForBqlQueries/PXGraphCreationDuringInitializationTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreationForBqlQueries/PXGraphCreationDuringInitializationTests.cs
@@ -87,8 +87,8 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.PXGraphCreationForBqlQueries
 		[EmbeddedFileData("ExternalService_TwoQueryWithGraphCreation.cs", "Customer.cs", "CustomerMaint.cs")]
 		public async Task TwoQuery_WithGraphCreationInArgument(string source, string dacSource, string graphSource) =>
 			await VerifyCSharpDiagnosticAsync(source, dacSource, graphSource,
-				Descriptors.PX1072_PXGraphCreationForBqlQueries_ReuseExistingGraphVariable.CreateFor(14, 51),
-				Descriptors.PX1072_PXGraphCreationForBqlQueries_ReuseExistingGraphVariable.CreateFor(15, 51));
+				Descriptors.PX1072_PXGraphCreationForBqlQueries_CreateSharedGraphVariable.CreateFor(14, 51),
+				Descriptors.PX1072_PXGraphCreationForBqlQueries_CreateSharedGraphVariable.CreateFor(15, 51));
 		#endregion
 
 		#region False-positive checks

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreationForBqlQueries/PXGraphCreationDuringInitializationTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreationForBqlQueries/PXGraphCreationDuringInitializationTests.cs
@@ -18,6 +18,7 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.PXGraphCreationForBqlQueries
         protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer() => 
 			new PXGraphCreationForBqlQueriesAnalyzer(
 				CodeAnalysisSettings.Default.WithStaticAnalysisEnabled()
+											.WithRecursiveAnalysisEnabled()
 											.WithSuppressionMechanismDisabled());
 
 	    protected override CodeFixProvider GetCSharpCodeFixProvider() => new PXGraphCreationForBqlQueriesFix();
@@ -26,53 +27,53 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.PXGraphCreationForBqlQueries
 
 	    [Theory]
         [EmbeddedFileData("ExternalServiceWithPXGraphConstructor.cs", "Customer.cs", "CustomerMaint.cs")]
-        public async Task TestDiagnostic_ExternalServiceWithPXGraphConstructor(string source, string dacSource, string graphSource) => 
+        public async Task ExternalServiceWithPXGraphConstructor(string source, string dacSource, string graphSource) => 
 	        await VerifyCSharpDiagnosticAsync(source, dacSource, graphSource,
 				Descriptors.PX1072_PXGraphCreationForBqlQueries.CreateFor(17, 13));
 
 	    [Theory]
 	    [EmbeddedFileData("ExternalServiceWithCreateInstance.cs", "Customer.cs", "CustomerMaint.cs")]
-	    public async Task TestDiagnostic_ExternalServiceWithCreateInstance(string source, string dacSource, string graphSource) => 
+	    public async Task ExternalServiceWithCreateInstance(string source, string dacSource, string graphSource) => 
 		    await VerifyCSharpDiagnosticAsync(source, dacSource, graphSource,
 				Descriptors.PX1072_PXGraphCreationForBqlQueries.CreateFor(17, 13));
 
 	    [Theory]
 	    [EmbeddedFileData("InstanceMethodInPXGraphWithPXGraphConstructor.cs")]
-	    public async Task TestDiagnostic_InstanceMethodInPXGraphWithPXGraphConstructor(string source) => await VerifyCSharpDiagnosticAsync(source, 
+	    public async Task InstanceMethodInPXGraphWithPXGraphConstructor(string source) => await VerifyCSharpDiagnosticAsync(source, 
 		    Descriptors.PX1072_PXGraphCreationForBqlQueries.CreateFor(15, 13));
 
 	    [Theory]
 	    [EmbeddedFileData("InstanceMethodInPXGraphWithCreateInstance.cs")]
-	    public async Task TestDiagnostic_InstanceMethodInPXGraphWithCreateInstance(string source) => await VerifyCSharpDiagnosticAsync(source, 
+	    public async Task InstanceMethodInPXGraphWithCreateInstance(string source) => await VerifyCSharpDiagnosticAsync(source, 
 		    Descriptors.PX1072_PXGraphCreationForBqlQueries.CreateFor(15, 13));
 
 	    [Theory]
 	    [EmbeddedFileData("PXGraphConstructorInVariable.cs", "Customer.cs", "CustomerMaint.cs")]
-	    public async Task TestDiagnostic_PXGraphConstructorInVariable(string source, string dacSource, string graphSource) =>
+	    public async Task PXGraphConstructorInVariable(string source, string dacSource, string graphSource) =>
 		    await VerifyCSharpDiagnosticAsync(source, dacSource, graphSource,
 				Descriptors.PX1072_PXGraphCreationForBqlQueries.CreateFor(18, 13));
 
 	    [Theory]
 	    [EmbeddedFileData("ExternalServiceWithCreateInstanceInVariable.cs", "Customer.cs", "CustomerMaint.cs")]
-	    public async Task TestDiagnostic_ExternalServiceWithCreateInstanceInVariable(string source, string dacSource, string graphSource) =>
+	    public async Task ExternalServiceWithCreateInstanceInVariable(string source, string dacSource, string graphSource) =>
 		    await VerifyCSharpDiagnosticAsync(source, dacSource, graphSource,
 				Descriptors.PX1072_PXGraphCreationForBqlQueries.CreateFor(18, 13));
 
 	    [Theory]
 	    [EmbeddedFileData("ExternalServiceWithMethodParameter.cs", "Customer.cs", "CustomerMaint.cs")]
-	    public async Task TestDiagnostic_ExternalServiceWithMethodParameter(string source, string dacSource, string graphSource) =>
+	    public async Task ExternalServiceWithMethodParameter(string source, string dacSource, string graphSource) =>
 		    await VerifyCSharpDiagnosticAsync(source, dacSource, graphSource,
 			    Descriptors.PX1072_PXGraphCreationForBqlQueries.CreateFor(17, 13));
 
 	    [Theory]
 	    [EmbeddedFileData("PropertyInExternalService.cs", "Customer.cs", "CustomerMaint.cs")]
-	    public async Task TestDiagnostic_PropertyInExternalService(string source, string dacSource, string graphSource) =>
+	    public async Task PropertyInExternalService(string source, string dacSource, string graphSource) =>
 		    await VerifyCSharpDiagnosticAsync(source, dacSource, graphSource,
 			    Descriptors.PX1072_PXGraphCreationForBqlQueries.CreateFor(19, 14));
 
 	    [Theory]
 	    [EmbeddedFileData("InstanceMethodInPXGraphExtensionWithPXGraphConstructor.cs", "Customer.cs", "CustomerMaint.cs")]
-	    public async Task TestDiagnostic_InstanceMethodInPXGraphExtensionWithPXGraphConstructor(string source, string dacSource, string graphSource) =>
+	    public async Task InstanceMethodInPXGraphExtensionWithPXGraphConstructor(string source, string dacSource, string graphSource) =>
 		    await VerifyCSharpDiagnosticAsync(source, dacSource, graphSource,
 			    Descriptors.PX1072_PXGraphCreationForBqlQueries.CreateFor(15, 13));
 
@@ -82,22 +83,22 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.PXGraphCreationForBqlQueries
 
 	    [Theory]
 	    [EmbeddedFileData("ExternalService.cs", "Customer.cs", "CustomerMaint.cs")]
-	    public async Task TestDiagnostic_ExternalService_ShouldNotShowDiagnostic(string source, string dacSource, string graphSource) =>
+	    public async Task ExternalService_ShouldNotShowDiagnostic(string source, string dacSource, string graphSource) =>
 		    await VerifyCSharpDiagnosticAsync(source, dacSource, graphSource);
 
 	    [Theory]
 	    [EmbeddedFileData("StaticMethodInPXGraphWithPXGraphConstructor.cs")]
-	    public async Task TestDiagnostic_StaticMethodInPXGraphWithPXGraphConstructor_ShouldNotShowDiagnostic(string source) =>
+	    public async Task StaticMethodInPXGraphWithPXGraphConstructor_ShouldNotShowDiagnostic(string source) =>
 		    await VerifyCSharpDiagnosticAsync(source);
 
 	    [Theory]
 	    [EmbeddedFileData("InstanceIsUsedOutsideBql.cs", "Customer.cs", "CustomerMaint.cs")]
-	    public async Task TestDiagnostic_InstanceIsUsedOutsideBql_ShouldNotShowDiagnostic(string source, string dacSource, string graphSource) =>
+	    public async Task InstanceIsUsedOutsideBql_ShouldNotShowDiagnostic(string source, string dacSource, string graphSource) =>
 		    await VerifyCSharpDiagnosticAsync(source, dacSource, graphSource);
 
 	    [Theory]
 	    [EmbeddedFileData("ExternalServiceWithUsedVariable.cs", "Customer.cs", "CustomerMaint.cs")]
-	    public async Task TestDiagnostic_ExternalServiceWithUsedVariable_ShouldNotShowDiagnostic(string source, string dacSource, string graphSource) =>
+	    public async Task ExternalServiceWithUsedVariable_ShouldNotShowDiagnostic(string source, string dacSource, string graphSource) =>
 		    await VerifyCSharpDiagnosticAsync(source, dacSource, graphSource);
 
 		#endregion
@@ -106,27 +107,27 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.PXGraphCreationForBqlQueries
 
 	    [Theory]
 	    [EmbeddedFileData("CodeFix.cs", "CodeFix_Expected_ThisKeyword.cs")]
-	    public async Task TestCodeFix_ThisKeyword(string actual, string expected) => 
+	    public async Task CodeFix_ThisKeyword(string actual, string expected) => 
 		    await VerifyCSharpFixAsync(actual, expected, 0);
 
 	    [Theory]
 	    [EmbeddedFileData("CodeFix.cs", "CodeFix_Expected_MethodParameter.cs")]
-	    public async Task TestCodeFix_MethodParameter(string actual, string expected) => 
+	    public async Task CodeFix_MethodParameter(string actual, string expected) => 
 		    await VerifyCSharpFixAsync(actual, expected, 1);
 
 	    [Theory]
 	    [EmbeddedFileData("CodeFix.cs", "CodeFix_Expected_LocalVariable1.cs")]
-	    public async Task TestCodeFix_LocalVariable1(string actual, string expected) => 
+	    public async Task CodeFix_LocalVariable1(string actual, string expected) => 
 		    await VerifyCSharpFixAsync(actual, expected, 2);
 
 	    [Theory]
 	    [EmbeddedFileData("CodeFix.cs", "CodeFix_Expected_LocalVariable2.cs")]
-	    public async Task TestCodeFix_LocalVariable2(string actual, string expected) => 
+	    public async Task CodeFix_LocalVariable2(string actual, string expected) => 
 		    await VerifyCSharpFixAsync(actual, expected, 3);
 
 	    [Theory]
 	    [EmbeddedFileData("CodeFix_GraphExtension.cs", "CodeFix_GraphExtension_Expected.cs")]
-	    public async Task TestCodeFix_GraphExtension(string actual, string expected) => 
+	    public async Task CodeFix_GraphExtension(string actual, string expected) => 
 		    await VerifyCSharpFixAsync(actual, expected);
 
 		#endregion

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreationForBqlQueries/PXGraphCreationDuringInitializationTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreationForBqlQueries/PXGraphCreationDuringInitializationTests.cs
@@ -29,66 +29,66 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.PXGraphCreationForBqlQueries
         [EmbeddedFileData("ExternalServiceWithPXGraphConstructor.cs", "Customer.cs", "CustomerMaint.cs")]
         public async Task ExternalServiceWithPXGraphConstructor(string source, string dacSource, string graphSource) => 
 	        await VerifyCSharpDiagnosticAsync(source, dacSource, graphSource,
-				Descriptors.PX1072_PXGraphCreationForBqlQueries.CreateFor(17, 13));
+				Descriptors.PX1072_PXGraphCreationForBqlQueries_ReuseExistingGraphVariable.CreateFor(17, 13));
 
 	    [Theory]
 	    [EmbeddedFileData("ExternalServiceWithCreateInstance.cs", "Customer.cs", "CustomerMaint.cs")]
 	    public async Task ExternalServiceWithCreateInstance(string source, string dacSource, string graphSource) => 
 		    await VerifyCSharpDiagnosticAsync(source, dacSource, graphSource,
-				Descriptors.PX1072_PXGraphCreationForBqlQueries.CreateFor(17, 13));
+				Descriptors.PX1072_PXGraphCreationForBqlQueries_ReuseExistingGraphVariable.CreateFor(17, 13));
 
 	    [Theory]
 	    [EmbeddedFileData("InstanceMethodInPXGraphWithPXGraphConstructor.cs")]
 	    public async Task InstanceMethodInPXGraphWithPXGraphConstructor(string source) => await VerifyCSharpDiagnosticAsync(source, 
-		    Descriptors.PX1072_PXGraphCreationForBqlQueries.CreateFor(15, 13));
+		    Descriptors.PX1072_PXGraphCreationForBqlQueries_ReuseExistingGraphVariable.CreateFor(15, 13));
 
 	    [Theory]
 	    [EmbeddedFileData("InstanceMethodInPXGraphWithCreateInstance.cs")]
 	    public async Task InstanceMethodInPXGraphWithCreateInstance(string source) => await VerifyCSharpDiagnosticAsync(source, 
-		    Descriptors.PX1072_PXGraphCreationForBqlQueries.CreateFor(15, 13));
+		    Descriptors.PX1072_PXGraphCreationForBqlQueries_ReuseExistingGraphVariable.CreateFor(15, 13));
 
 	    [Theory]
 	    [EmbeddedFileData("PXGraphConstructorInVariable.cs", "Customer.cs", "CustomerMaint.cs")]
 	    public async Task PXGraphConstructorInVariable(string source, string dacSource, string graphSource) =>
 		    await VerifyCSharpDiagnosticAsync(source, dacSource, graphSource,
-				Descriptors.PX1072_PXGraphCreationForBqlQueries.CreateFor(18, 13));
+				Descriptors.PX1072_PXGraphCreationForBqlQueries_ReuseExistingGraphVariable.CreateFor(18, 13));
 
 	    [Theory]
 	    [EmbeddedFileData("ExternalServiceWithCreateInstanceInVariable.cs", "Customer.cs", "CustomerMaint.cs")]
 	    public async Task ExternalServiceWithCreateInstanceInVariable(string source, string dacSource, string graphSource) =>
 		    await VerifyCSharpDiagnosticAsync(source, dacSource, graphSource,
-				Descriptors.PX1072_PXGraphCreationForBqlQueries.CreateFor(18, 13));
+				Descriptors.PX1072_PXGraphCreationForBqlQueries_ReuseExistingGraphVariable.CreateFor(18, 13));
 
 	    [Theory]
 	    [EmbeddedFileData("ExternalServiceWithMethodParameter.cs", "Customer.cs", "CustomerMaint.cs")]
 	    public async Task ExternalServiceWithMethodParameter(string source, string dacSource, string graphSource) =>
 		    await VerifyCSharpDiagnosticAsync(source, dacSource, graphSource,
-			    Descriptors.PX1072_PXGraphCreationForBqlQueries.CreateFor(17, 13));
+			    Descriptors.PX1072_PXGraphCreationForBqlQueries_ReuseExistingGraphVariable.CreateFor(17, 13));
 
 	    [Theory]
 	    [EmbeddedFileData("PropertyInExternalService.cs", "Customer.cs", "CustomerMaint.cs")]
 	    public async Task PropertyInExternalService(string source, string dacSource, string graphSource) =>
 		    await VerifyCSharpDiagnosticAsync(source, dacSource, graphSource,
-			    Descriptors.PX1072_PXGraphCreationForBqlQueries.CreateFor(19, 14));
+			    Descriptors.PX1072_PXGraphCreationForBqlQueries_ReuseExistingGraphVariable.CreateFor(19, 14));
 
 	    [Theory]
 	    [EmbeddedFileData("InstanceMethodInPXGraphExtensionWithPXGraphConstructor.cs", "Customer.cs", "CustomerMaint.cs")]
 	    public async Task InstanceMethodInPXGraphExtensionWithPXGraphConstructor(string source, string dacSource, string graphSource) =>
 		    await VerifyCSharpDiagnosticAsync(source, dacSource, graphSource,
-			    Descriptors.PX1072_PXGraphCreationForBqlQueries.CreateFor(15, 13));
+			    Descriptors.PX1072_PXGraphCreationForBqlQueries_ReuseExistingGraphVariable.CreateFor(15, 13));
 
 		[Theory]
 		[EmbeddedFileData("CustomerMaint_CheckGraphContext.cs")]
 		public async Task InsideGraph_OnlyInstanceMethodsAreReported_WithThisReferenceSuggestion(string source) =>
 			await VerifyCSharpDiagnosticAsync(source,
-				Descriptors.PX1072_PXGraphCreationForBqlQueries.CreateFor(17, 50));
+				Descriptors.PX1072_PXGraphCreationForBqlQueries_ReuseExistingGraphVariable.CreateFor(17, 50));
 
 		[Theory]
 		[EmbeddedFileData("ExternalService_TwoQueryWithGraphCreation.cs", "Customer.cs", "CustomerMaint.cs")]
 		public async Task TwoQuery_WithGraphCreationInArgument(string source, string dacSource, string graphSource) =>
 			await VerifyCSharpDiagnosticAsync(source, dacSource, graphSource,
-				Descriptors.PX1072_PXGraphCreationForBqlQueries.CreateFor(14, 51),
-				Descriptors.PX1072_PXGraphCreationForBqlQueries.CreateFor(15, 51));
+				Descriptors.PX1072_PXGraphCreationForBqlQueries_ReuseExistingGraphVariable.CreateFor(14, 51),
+				Descriptors.PX1072_PXGraphCreationForBqlQueries_ReuseExistingGraphVariable.CreateFor(15, 51));
 		#endregion
 
 		#region False-positive checks

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreationForBqlQueries/PXGraphCreationDuringInitializationTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreationForBqlQueries/PXGraphCreationDuringInitializationTests.cs
@@ -77,11 +77,16 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.PXGraphCreationForBqlQueries
 		    await VerifyCSharpDiagnosticAsync(source, dacSource, graphSource,
 			    Descriptors.PX1072_PXGraphCreationForBqlQueries.CreateFor(15, 13));
 
+		[Theory]
+		[EmbeddedFileData("CustomerMaint_CheckGraphContext.cs")]
+		public async Task InsideGraph_OnlyInstanceMethodsAreReported_WithThisReferenceSuggestion(string source) =>
+			await VerifyCSharpDiagnosticAsync(source,
+				Descriptors.PX1072_PXGraphCreationForBqlQueries.CreateFor(17, 50));
 		#endregion
 
 		#region False-positive checks
 
-	    [Theory]
+		[Theory]
 	    [EmbeddedFileData("ExternalService.cs", "Customer.cs", "CustomerMaint.cs")]
 	    public async Task ExternalService_ShouldNotShowDiagnostic(string source, string dacSource, string graphSource) =>
 		    await VerifyCSharpDiagnosticAsync(source, dacSource, graphSource);

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreationForBqlQueries/PXGraphCreationDuringInitializationTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreationForBqlQueries/PXGraphCreationDuringInitializationTests.cs
@@ -96,7 +96,12 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.PXGraphCreationForBqlQueries
 	    public async Task StaticMethodInPXGraphWithPXGraphConstructor_ShouldNotShowDiagnostic(string source) =>
 		    await VerifyCSharpDiagnosticAsync(source);
 
-	    [Theory]
+		[Theory]
+		[EmbeddedFileData("ExternalService_SingleQueryWithGraphCreation.cs", "Customer.cs", "CustomerMaint.cs")]
+		public async Task SingleQuery_WithGraphCreationInArgument_ShouldNotShowDiagnostic(string source, string dacSource, string graphSource) =>
+			await VerifyCSharpDiagnosticAsync(source, dacSource, graphSource);
+
+		[Theory]
 	    [EmbeddedFileData("InstanceIsUsedOutsideBql.cs", "Customer.cs", "CustomerMaint.cs")]
 	    public async Task InstanceIsUsedOutsideBql_ShouldNotShowDiagnostic(string source, string dacSource, string graphSource) =>
 		    await VerifyCSharpDiagnosticAsync(source, dacSource, graphSource);

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreationForBqlQueries/Sources/CustomerMaint.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreationForBqlQueries/Sources/CustomerMaint.cs
@@ -11,13 +11,4 @@ namespace PX.Objects
 	{
 		public PXSelect<Customer> Customers;
 	}
-
-	public class Customer : IBqlTable
-	{
-		#region AcctCD
-		[PXDBString(8, IsKey = true, InputMask = "")]
-		public string AcctCD { get; set; }
-		public abstract class acctCd : IBqlField { }
-		#endregion	
-	}
 }

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreationForBqlQueries/Sources/CustomerMaint_CheckGraphContext.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreationForBqlQueries/Sources/CustomerMaint_CheckGraphContext.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using PX.Data;
+
+namespace PX.Objects
+{
+	public class CustomerMaint : PXGraph<CustomerMaint, Customer>
+	{
+		public PXSelect<Customer> Customers;
+
+		public Customer SelectCustomerInstance()
+		{
+			var customerGraph = PXGraph.CreateInstance<CustomerMaint>();
+			Customer customer = PXSelect<Customer>.Select(customerGraph);   // Report diagnostic
+			return customer;
+		}
+
+		public static Customer SelectCustomerStatic()
+		{
+			var customerGraph = PXGraph.CreateInstance<CustomerMaint>();
+			Customer customer = PXSelect<Customer>.Select(customerGraph);	// Should not report diagnostic
+			return customer;
+		}
+	}
+
+	[PXHidden]
+	public class Customer : IBqlTable
+	{
+		#region AcctCD
+		[PXDBString(8, IsKey = true, InputMask = "")]
+		public string AcctCD { get; set; }
+		public abstract class acctCd : IBqlField { }
+		#endregion	
+	}
+}

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreationForBqlQueries/Sources/ExternalService_SingleQueryWithGraphCreation.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreationForBqlQueries/Sources/ExternalService_SingleQueryWithGraphCreation.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using PX.Data;
+
+namespace PX.Objects
+{
+	public class CustomerService
+	{
+		public Customer SelectCustomerBaseGraphConstructor()
+		{
+			Customer customer = PXSelect<Customer>.Select(new PXGraph());     // Do not report diagnostic
+			return customer;
+		}
+
+		public Customer SelectCustomerConcreteGraphConstructor() =>
+			PXSelect<Customer>.Select(new CustomerMaint());                     // Do not report diagnostic
+
+		public Customer SelectCustomerConcreteGraphFactoryExpressionBody() =>
+			PXSelect<Customer>.Select(PXGraph.CreateInstance<CustomerMaint>());  // Do not report diagnostic
+
+		public Customer SelectCustomerConcreteGraphFactory()
+		{
+			return PXSelect<Customer>.Select(PXGraph.CreateInstance<CustomerMaint>());  // Do not report diagnostic
+		}
+	}
+}

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreationForBqlQueries/Sources/ExternalService_TwoQueryWithGraphCreation.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreationForBqlQueries/Sources/ExternalService_TwoQueryWithGraphCreation.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using PX.Data;
+
+namespace PX.Objects
+{
+	public class CustomerService
+	{
+		public Customer SelectCustomer()
+		{
+			Customer customer1 = PXSelect<Customer>.Select(new PXGraph());								// Report diagnostic
+			Customer customer2 = PXSelect<Customer>.Select(PXGraph.CreateInstance<CustomerMaint>());    // Report diagnostic
+
+			return customer1 ?? customer2;
+		}
+	}
+}

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreationForBqlQueries/Sources/InstanceIsUsedOutsideBql.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreationForBqlQueries/Sources/InstanceIsUsedOutsideBql.cs
@@ -14,8 +14,11 @@ namespace PX.Objects
 			var existingGraph = PXGraph.CreateInstance<CustomerMaint>();
 			var graph = PXGraph.CreateInstance<CustomerMaint>();
 
-			graph.Customers.Current = PXSelect<Customer, Where<Customer.bAccountID, Equal<Required<Customer.bAccountID>>>>
-				.Select(graph, acuCustomerId);
+			if (acuCustomerId > 0)
+			{
+				graph.Customers.Current = PXSelect<Customer, Where<Customer.bAccountID, Equal<Required<Customer.bAccountID>>>>
+					.Select(graph, acuCustomerId);
+			}
 
 			graph.Actions.PressSave();
 		}

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SematicModelUtils.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SematicModelUtils.cs
@@ -14,14 +14,14 @@ namespace Acuminator.Utilities.Roslyn.Semantic
 	public static class SematicModelUtils
 	{
 		/// <summary>
-		/// Analyse data flow for a <paramref name="node"/> and return <see cref="DataFlowAnalysis"/> if analysis succeeded.
+		/// Safely analyse data flow for a <paramref name="node"/> and return <see cref="DataFlowAnalysis"/> if analysis succeeded.
 		/// </summary>
 		/// <param name="semanticModel">The semanticModel to act on.</param>
 		/// <param name="node">The node to analyse.</param>
 		/// <returns>
 		/// A <see cref="DataFlowAnalysis"/> if the data flow analysis succeeded, <see langword="null"/> if not.
 		/// </returns>
-		public static DataFlowAnalysis? AnalyseDataFlow(this SemanticModel semanticModel, CSharpSyntaxNode node)
+		public static DataFlowAnalysis? TryAnalyzeDataFlow(this SemanticModel semanticModel, SyntaxNode node)
 		{
 			semanticModel.ThrowOnNull(nameof(semanticModel));
 			node.ThrowOnNull(nameof(node));

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Walkers/DelegatesWalkerBase.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Walkers/DelegatesWalkerBase.cs
@@ -54,7 +54,7 @@ namespace Acuminator.Utilities.Roslyn.Walkers
 					}
 				case ObjectCreationExpressionSyntax objectCreationExpression:
 					{
-						if (objectCreationExpression.ArgumentList.Arguments.Count != 1)
+						if (objectCreationExpression.ArgumentList?.Arguments.Count != 1)
 							return default;
 
 						ArgumentSyntax delegateCreationArg = objectCreationExpression.ArgumentList.Arguments[0];
@@ -100,7 +100,7 @@ namespace Acuminator.Utilities.Roslyn.Walkers
 					return GetDelegateNode(castExpression.Expression);
 
 				case ObjectCreationExpressionSyntax objectCreationExpression:
-					if (objectCreationExpression.ArgumentList.Arguments.Count != 1)
+					if (objectCreationExpression.ArgumentList?.Arguments.Count != 1)
 						return null;
 
 					ArgumentSyntax delegateCreationArg = objectCreationExpression.ArgumentList.Arguments[0];

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Walkers/ParametersReassignedFinder.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Walkers/ParametersReassignedFinder.cs
@@ -62,7 +62,7 @@ namespace Acuminator.Utilities.Roslyn.Walkers
 			if (body == null)
 				return null;
 			
-			var dataFlowAnalysis = semanticModel.AnalyseDataFlow(body);
+			var dataFlowAnalysis = semanticModel.TryAnalyzeDataFlow(body);
 
 			// If there is no call site then rely only on data flow analysis AlwaysAssigned results, assume that we check the whole containing type member
 			if (callSite == null)
@@ -329,7 +329,7 @@ namespace Acuminator.Utilities.Roslyn.Walkers
 				if (containingMethodsWithReassignableParameters.Count == 0)
 					return null;
 
-				var localMethodDFA = _semanticModel!.AnalyseDataFlow(localFunctionBody);
+				var localMethodDFA = _semanticModel!.TryAnalyzeDataFlow(localFunctionBody);
 
 				if (localMethodDFA == null || localMethodDFA.AlwaysAssigned.IsDefaultOrEmpty)
 					return null;


### PR DESCRIPTION
Review and merge only after https://github.com/Acumatica/Acuminator/pull/456

Changes overview:
- added nullable ref types analysis to PX1072 diagnostic
- reworked PX1072 analyzer:
        - Removed addition of this reference to the list of possible graphs for static type members
        - Do not report a case when there is a single available graph and it used by the BQL query
        - Added reporting of scenario with multiple BQL queries with graph creation in arguments and no existing graphs in the context:
        ```
        public class CustomerService
	{
		public Customer SelectCustomer()
		{
			Customer customer1 = PXSelect<Customer>.Select(new PXGraph());								// Report diagnostic
			Customer customer2 = PXSelect<Customer>.Select(PXGraph.CreateInstance<CustomerMaint>());    // Report diagnostic

			return customer1 ?? customer2;
		}
	}
        ``` 
          A new diagnostic message is added for this case.
        - Simplified the code and removed some memory allocations. Removed redundant usage of immutables in the analyzer's private code 
        - Refactored the code 
- added unit tests for: 
           - static and instance graph methods with a single local variable used in BQL query
           - multiple BQL queries with graph creation in arguments and no existing graphs in the context
           - single BQL query with graph creation in arguments and no existing graphs in the context