### PR TITLE
Feature/atr 139 dev forbid static graph members

### DIFF
--- a/src/Acuminator/Acuminator.Analyzers/DiagnosticsShortName.Designer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/DiagnosticsShortName.Designer.cs
@@ -619,6 +619,15 @@ namespace Acuminator.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to StaticPropertyOrFieldInGraph.
+        /// </summary>
+        public static string PX1062 {
+            get {
+                return ResourceManager.GetString("PX1062", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to UiPresentationLogicInEventHandlers.
         /// </summary>
         public static string PX1070 {

--- a/src/Acuminator/Acuminator.Analyzers/DiagnosticsShortName.resx
+++ b/src/Acuminator/Acuminator.Analyzers/DiagnosticsShortName.resx
@@ -372,4 +372,7 @@
   <data name="PX1056IsActiveForGraphMethod" xml:space="preserve">
     <value>PXGraphCreationInIsActiveForGraphMethod</value>
   </data>
+  <data name="PX1062" xml:space="preserve">
+    <value>StaticPropertyOrFieldInGraph</value>
+  </data>
 </root>

--- a/src/Acuminator/Acuminator.Analyzers/Resources.Designer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/Resources.Designer.cs
@@ -1307,6 +1307,105 @@ namespace Acuminator.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to action.
+        /// </summary>
+        public static string PX1062FixFormatArg_Action {
+            get {
+                return ResourceManager.GetString("PX1062FixFormatArg_Action", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to field.
+        /// </summary>
+        public static string PX1062FixFormatArg_Field {
+            get {
+                return ResourceManager.GetString("PX1062FixFormatArg_Field", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to property.
+        /// </summary>
+        public static string PX1062FixFormatArg_Property {
+            get {
+                return ResourceManager.GetString("PX1062FixFormatArg_Property", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to view.
+        /// </summary>
+        public static string PX1062FixFormatArg_View {
+            get {
+                return ResourceManager.GetString("PX1062FixFormatArg_View", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Remove static from {0}. .
+        /// </summary>
+        public static string PX1062FixMakeNonStaticFormat {
+            get {
+                return ResourceManager.GetString("PX1062FixMakeNonStaticFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Make {0} read-only..
+        /// </summary>
+        public static string PX1062FixMakeReadOnlyFormat {
+            get {
+                return ResourceManager.GetString("PX1062FixMakeReadOnlyFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Graph cannot declare static {0}..
+        /// </summary>
+        public static string PX1062MessageFormat {
+            get {
+                return ResourceManager.GetString("PX1062MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to actions.
+        /// </summary>
+        public static string PX1062MessageFormatArg_Actions {
+            get {
+                return ResourceManager.GetString("PX1062MessageFormatArg_Actions", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to mutable fields.
+        /// </summary>
+        public static string PX1062MessageFormatArg_Fields {
+            get {
+                return ResourceManager.GetString("PX1062MessageFormatArg_Fields", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to mutable properties.
+        /// </summary>
+        public static string PX1062MessageFormatArg_Properties {
+            get {
+                return ResourceManager.GetString("PX1062MessageFormatArg_Properties", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to views.
+        /// </summary>
+        public static string PX1062MessageFormatArg_Views {
+            get {
+                return ResourceManager.GetString("PX1062MessageFormatArg_Views", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The state of fields and actions can be configured only in the RowSelected event handler.
         /// </summary>
         public static string PX1070Title {

--- a/src/Acuminator/Acuminator.Analyzers/Resources.Designer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/Resources.Designer.cs
@@ -1343,7 +1343,7 @@ namespace Acuminator.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Remove static from {0}. .
+        ///   Looks up a localized string similar to Remove static from the {0}.
         /// </summary>
         public static string PX1062FixMakeNonStaticFormat {
             get {
@@ -1352,7 +1352,7 @@ namespace Acuminator.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Make {0} read-only..
+        ///   Looks up a localized string similar to Make the {0} read-only.
         /// </summary>
         public static string PX1062FixMakeReadOnlyFormat {
             get {

--- a/src/Acuminator/Acuminator.Analyzers/Resources.Designer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/Resources.Designer.cs
@@ -1343,7 +1343,7 @@ namespace Acuminator.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Remove static from the {0}.
+        ///   Looks up a localized string similar to Remove the static modifier from the {0}.
         /// </summary>
         public static string PX1062FixMakeNonStaticFormat {
             get {
@@ -1361,7 +1361,7 @@ namespace Acuminator.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Graphs and graph extensions cannot declare static {0}..
+        ///   Looks up a localized string similar to You cannot declare static {0} in graphs or graph extensions.
         /// </summary>
         public static string PX1062MessageFormat {
             get {

--- a/src/Acuminator/Acuminator.Analyzers/Resources.Designer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/Resources.Designer.cs
@@ -1361,7 +1361,7 @@ namespace Acuminator.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Graph cannot declare static {0}..
+        ///   Looks up a localized string similar to Graphs and graph extensions cannot declare static {0}..
         /// </summary>
         public static string PX1062MessageFormat {
             get {

--- a/src/Acuminator/Acuminator.Analyzers/Resources.resx
+++ b/src/Acuminator/Acuminator.Analyzers/Resources.resx
@@ -653,7 +653,7 @@
     <value>mutable properties</value>
   </data>
   <data name="PX1062FixMakeReadOnlyFormat" xml:space="preserve">
-    <value>Make {0} read-only.</value>
+    <value>Make the {0} read-only</value>
   </data>
   <data name="PX1062FixFormatArg_Field" xml:space="preserve">
     <value>field</value>
@@ -668,7 +668,7 @@
     <value>actions</value>
   </data>
   <data name="PX1062FixMakeNonStaticFormat" xml:space="preserve">
-    <value>Remove static from {0}. </value>
+    <value>Remove static from the {0}</value>
   </data>
   <data name="PX1062FixFormatArg_View" xml:space="preserve">
     <value>view</value>

--- a/src/Acuminator/Acuminator.Analyzers/Resources.resx
+++ b/src/Acuminator/Acuminator.Analyzers/Resources.resx
@@ -643,4 +643,37 @@
   <data name="PX1072Title_CreateSharedGraphVariable" xml:space="preserve">
     <value>Creating a graph for a BQL query is a resource consuming operation. To decrease the number of these operations, create a variable with a shared graph that can be reused by BQL queries.</value>
   </data>
+  <data name="PX1062MessageFormat" xml:space="preserve">
+    <value>Graph cannot declare static {0}.</value>
+  </data>
+  <data name="PX1062MessageFormatArg_Fields" xml:space="preserve">
+    <value>mutable fields</value>
+  </data>
+  <data name="PX1062MessageFormatArg_Properties" xml:space="preserve">
+    <value>mutable properties</value>
+  </data>
+  <data name="PX1062FixMakeReadOnlyFormat" xml:space="preserve">
+    <value>Make {0} read-only.</value>
+  </data>
+  <data name="PX1062FixFormatArg_Field" xml:space="preserve">
+    <value>field</value>
+  </data>
+  <data name="PX1062FixFormatArg_Property" xml:space="preserve">
+    <value>property</value>
+  </data>
+  <data name="PX1062MessageFormatArg_Views" xml:space="preserve">
+    <value>views</value>
+  </data>
+  <data name="PX1062MessageFormatArg_Actions" xml:space="preserve">
+    <value>actions</value>
+  </data>
+  <data name="PX1062FixMakeNonStaticFormat" xml:space="preserve">
+    <value>Remove static from {0}. </value>
+  </data>
+  <data name="PX1062FixFormatArg_View" xml:space="preserve">
+    <value>view</value>
+  </data>
+  <data name="PX1062FixFormatArg_Action" xml:space="preserve">
+    <value>action</value>
+  </data>
 </root>

--- a/src/Acuminator/Acuminator.Analyzers/Resources.resx
+++ b/src/Acuminator/Acuminator.Analyzers/Resources.resx
@@ -644,7 +644,7 @@
     <value>Creating a graph for a BQL query is a resource consuming operation. To decrease the number of these operations, create a variable with a shared graph that can be reused by BQL queries.</value>
   </data>
   <data name="PX1062MessageFormat" xml:space="preserve">
-    <value>Graphs and graph extensions cannot declare static {0}.</value>
+    <value>You cannot declare static {0} in graphs or graph extensions</value>
   </data>
   <data name="PX1062MessageFormatArg_Fields" xml:space="preserve">
     <value>mutable fields</value>
@@ -668,7 +668,7 @@
     <value>actions</value>
   </data>
   <data name="PX1062FixMakeNonStaticFormat" xml:space="preserve">
-    <value>Remove static from the {0}</value>
+    <value>Remove the static modifier from the {0}</value>
   </data>
   <data name="PX1062FixFormatArg_View" xml:space="preserve">
     <value>view</value>

--- a/src/Acuminator/Acuminator.Analyzers/Resources.resx
+++ b/src/Acuminator/Acuminator.Analyzers/Resources.resx
@@ -644,7 +644,7 @@
     <value>Creating a graph for a BQL query is a resource consuming operation. To decrease the number of these operations, create a variable with a shared graph that can be reused by BQL queries.</value>
   </data>
   <data name="PX1062MessageFormat" xml:space="preserve">
-    <value>Graph cannot declare static {0}.</value>
+    <value>Graphs and graph extensions cannot declare static {0}.</value>
   </data>
   <data name="PX1062MessageFormatArg_Fields" xml:space="preserve">
     <value>mutable fields</value>

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/Descriptors.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/Descriptors.cs
@@ -320,6 +320,9 @@ namespace Acuminator.Analyzers.StaticAnalysis
 		public static DiagnosticDescriptor PX1061_LegacyBqlConstant { get; } =
 			Rule("PX1061", nameof(Resources.PX1061Title).GetLocalized(), Category.Default, DiagnosticSeverity.Info, DiagnosticsShortName.PX1061);
 
+		public static DiagnosticDescriptor PX1062_StaticFieldOrPropertyInGraph { get; } =
+			Rule("PX1062", nameof(Resources.PX1062MessageFormat).GetLocalized(), Category.Default, DiagnosticSeverity.Error, DiagnosticsShortName.PX1062);
+
 		public static DiagnosticDescriptor PX1070_UiPresentationLogicInEventHandlers { get; } =
 			Rule("PX1070", nameof(Resources.PX1070Title).GetLocalized(), Category.Default, DiagnosticSeverity.Error, DiagnosticsShortName.PX1070);
 

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/DiagnosticUtils.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/DiagnosticUtils.cs
@@ -1,4 +1,8 @@
-﻿using System.Runtime.CompilerServices;
+﻿#nullable enable
+
+using System;
+using System.Runtime.CompilerServices;
+
 using Acuminator.Utilities.Common;
 using Microsoft.CodeAnalysis;
 
@@ -14,6 +18,16 @@ namespace Acuminator.Analyzers.StaticAnalysis
 			return diagnostic.Properties.TryGetValue(DiagnosticProperty.RegisterCodeFix, out string registered) 
 				? registered == bool.TrueString
 				: considerRegisteredByDefault;
+		}
+
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static bool IsFlagSet(this Diagnostic diagnostic, string flagName)
+		{
+			diagnostic.ThrowOnNull(nameof(diagnostic));
+			flagName.ThrowOnNullOrWhiteSpace(nameof(flagName));
+
+			return diagnostic.Properties?.Count > 0 && diagnostic.Properties.TryGetValue(flagName, out string value) &&
+				   bool.TrueString.Equals(value, StringComparison.OrdinalIgnoreCase);
 		}
 	}
 }

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXGraph/PXGraphAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXGraph/PXGraphAnalyzer.cs
@@ -19,6 +19,7 @@ using Acuminator.Analyzers.StaticAnalysis.NoPrimaryViewForPrimaryDac;
 using Acuminator.Analyzers.StaticAnalysis.PXActionExecution;
 using Acuminator.Analyzers.StaticAnalysis.PXGraphCreationInGraphInWrongPlaces;
 using Acuminator.Analyzers.StaticAnalysis.SavingChanges;
+using Acuminator.Analyzers.StaticAnalysis.StaticFieldOrPropertyInGraph;
 using Acuminator.Analyzers.StaticAnalysis.ThrowingExceptions;
 using Acuminator.Analyzers.StaticAnalysis.TypoInViewDelegateName;
 using Acuminator.Analyzers.StaticAnalysis.UiPresentationLogic;
@@ -59,6 +60,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXGraph
 			new NonPublicGraphAndDacExtensionAnalyzer(),
 			new NoIsActiveMethodForExtensionAnalyzer(),
 			new InvalidPXActionSignatureAnalyzer(),
+			new StaticFieldOrPropertyInGraphAnalyzer(),
 			new TypoInViewDelegateNameAnalyzer())
         {
         }

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/StaticFieldOrPropertyInGraph/StaticFieldOrPropertyInGraphAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/StaticFieldOrPropertyInGraph/StaticFieldOrPropertyInGraphAnalyzer.cs
@@ -13,6 +13,7 @@ using Acuminator.Utilities.Roslyn.Syntax;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Acuminator.Analyzers.StaticAnalysis.StaticFieldOrPropertyInGraph
@@ -64,7 +65,8 @@ namespace Acuminator.Analyzers.StaticAnalysis.StaticFieldOrPropertyInGraph
 
 		private Location? GetStaticFieldOrPropertyLocation(ISymbol staticFieldOrProperty, CancellationToken cancellation)
 		{
-			var fieldOrPropertyDeclaration = staticFieldOrProperty.GetSyntax(cancellation);
+			var fieldOrPropertyNode = staticFieldOrProperty.GetSyntax(cancellation);
+			var fieldOrPropertyDeclaration = fieldOrPropertyNode?.ParentOrSelf<MemberDeclarationSyntax>();
 			var staticModifier = fieldOrPropertyDeclaration?.GetModifiers()
 															.FirstOrDefault(modifier => modifier.IsKind(SyntaxKind.StaticKeyword));	
 			if (staticModifier != null)

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/StaticFieldOrPropertyInGraph/StaticFieldOrPropertyInGraphAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/StaticFieldOrPropertyInGraph/StaticFieldOrPropertyInGraphAnalyzer.cs
@@ -1,0 +1,109 @@
+﻿#nullable enable
+
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+
+using Acuminator.Analyzers.StaticAnalysis.PXGraph;
+using Acuminator.Utilities.DiagnosticSuppression;
+using Acuminator.Utilities.Roslyn.Semantic;
+using Acuminator.Utilities.Roslyn.Semantic.PXGraph;
+using Acuminator.Utilities.Roslyn.Syntax;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Acuminator.Analyzers.StaticAnalysis.StaticFieldOrPropertyInGraph
+{
+	public class StaticFieldOrPropertyInGraphAnalyzer : PXGraphAggregatedAnalyzerBase
+	{
+		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+			ImmutableArray.Create(Descriptors.PX1062_StaticFieldOrPropertyInGraph);
+
+		public override bool ShouldAnalyze(PXContext pxContext, PXGraphSemanticModel graph) =>
+			base.ShouldAnalyze(pxContext, graph) && graph.Type != GraphType.None; 
+
+		public override void Analyze(SymbolAnalysisContext symbolContext, PXContext pxContext, PXGraphSemanticModel graphOrExtension)
+		{
+			symbolContext.CancellationToken.ThrowIfCancellationRequested();
+
+			var graphStaticFieldsAndProperties = from member in graphOrExtension.Symbol.GetMembers()
+												 where member.IsStatic && member.CanBeReferencedByName && !member.IsImplicitlyDeclared &&
+													   graphOrExtension.Symbol.Equals(member.ContainingType) &&
+													   member is (IPropertySymbol or IFieldSymbol)
+												 select member;
+
+			foreach (ISymbol staticFieldOrProperty in graphStaticFieldsAndProperties)
+			{
+				symbolContext.CancellationToken.ThrowIfCancellationRequested();
+				ReportStaticFieldOrProperty(symbolContext, pxContext, staticFieldOrProperty, graphOrExtension);
+			}
+		}
+
+		private void ReportStaticFieldOrProperty(SymbolAnalysisContext symbolContext, PXContext pxContext, ISymbol staticFieldOrProperty,
+												PXGraphSemanticModel graphOrExtension)
+		{
+			Location? location = GetStaticFieldOrPropertyLocation(staticFieldOrProperty, symbolContext.CancellationToken);
+
+			if (location == null)
+				return;
+
+			var diagnosticInfo = GetDiagnosticFormatArgsAndProperties(staticFieldOrProperty, graphOrExtension);
+
+			if (diagnosticInfo == null)
+				return;
+
+			var (formatArg, properties) = diagnosticInfo.Value;
+
+			symbolContext.ReportDiagnosticWithSuppressionCheck(
+					Diagnostic.Create(Descriptors.PX1062_StaticFieldOrPropertyInGraph, location, properties,  formatArg),
+					pxContext.CodeAnalysisSettings);
+		}
+
+		private Location? GetStaticFieldOrPropertyLocation(ISymbol staticFieldOrProperty, CancellationToken cancellation)
+		{
+			var fieldOrPropertyDeclaration = staticFieldOrProperty.GetSyntax(cancellation);
+			var staticModifier = fieldOrPropertyDeclaration?.GetModifiers()
+															.FirstOrDefault(modifier => modifier.IsKind(SyntaxKind.StaticKeyword));	
+			if (staticModifier != null)
+				return staticModifier.Value.GetLocation();
+
+			return !staticFieldOrProperty.Locations.IsDefaultOrEmpty
+				? staticFieldOrProperty.Locations[0]
+				: null;
+		}
+
+		private (string FormatArg, ImmutableDictionary<string, string>? Properties)? GetDiagnosticFormatArgsAndProperties(ISymbol staticFieldOrProperty,
+																														  PXGraphSemanticModel graphOrExtension)
+		{
+			bool isView = graphOrExtension.ViewsByNames.ContainsKey(staticFieldOrProperty.Name);
+
+			if (isView)
+				return (Resources.PX1062MessageFormatArg_Views, CreatePropertiesWithIsViewOrAction());
+
+			bool isAction = graphOrExtension.ActionsByNames.ContainsKey(staticFieldOrProperty.Name);
+
+			if (isAction)
+				return (Resources.PX1062MessageFormatArg_Actions, CreatePropertiesWithIsViewOrAction());
+
+			switch (staticFieldOrProperty)
+			{
+				case IFieldSymbol:
+					return (Resources.PX1062MessageFormatArg_Fields , null);
+				case IPropertySymbol:
+					return (Resources.PX1062MessageFormatArg_Properties, null);
+				default:
+					return null;
+			}
+		}
+
+		private ImmutableDictionary<string, string> CreatePropertiesWithIsViewOrAction()
+		{
+			var properties = ImmutableDictionary.CreateBuilder<string, string>();
+			properties.Add(StaticFieldOrPropertyInGraphDiagnosticProperties.IsViewOrAction, bool.TrueString);
+			return properties.ToImmutable();
+		}
+	}
+}

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/StaticFieldOrPropertyInGraph/StaticFieldOrPropertyInGraphAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/StaticFieldOrPropertyInGraph/StaticFieldOrPropertyInGraphAnalyzer.cs
@@ -87,28 +87,41 @@ namespace Acuminator.Analyzers.StaticAnalysis.StaticFieldOrPropertyInGraph
 																														  bool isView, bool isAction)
 		{
 			if (isView)
-				return (Resources.PX1062MessageFormatArg_Views, CreateDiagnosticProperties(isViewOrAction: true, Resources.PX1062FixFormatArg_View));
+			{
+				return (Resources.PX1062MessageFormatArg_Views,
+							CreateDiagnosticProperties(isViewOrAction: true, isProperty: staticFieldOrProperty is IPropertySymbol,
+													   Resources.PX1062FixFormatArg_View));
+			}
 			else if (isAction)
-				return (Resources.PX1062MessageFormatArg_Actions, CreateDiagnosticProperties(isViewOrAction: true, Resources.PX1062FixFormatArg_Action));
+			{
+				return (Resources.PX1062MessageFormatArg_Actions, 
+							CreateDiagnosticProperties(isViewOrAction: true, isProperty: staticFieldOrProperty is IPropertySymbol, 
+													   Resources.PX1062FixFormatArg_Action));
+			}
 
 			switch (staticFieldOrProperty)
 			{
 				case IFieldSymbol:
-					return (Resources.PX1062MessageFormatArg_Fields, CreateDiagnosticProperties(isViewOrAction: false, Resources.PX1062FixFormatArg_Field));
+					return (Resources.PX1062MessageFormatArg_Fields, 
+							CreateDiagnosticProperties(isViewOrAction: false, isProperty: false, Resources.PX1062FixFormatArg_Field));
 				case IPropertySymbol:
-					return (Resources.PX1062MessageFormatArg_Properties, CreateDiagnosticProperties(isViewOrAction: false, Resources.PX1062FixFormatArg_Property));
+					return (Resources.PX1062MessageFormatArg_Properties, 
+							CreateDiagnosticProperties(isViewOrAction: false, isProperty: true, Resources.PX1062FixFormatArg_Property));
 				default:
 					return null;
 			}
 		}
 
-		private ImmutableDictionary<string, string> CreateDiagnosticProperties(bool isViewOrAction, string codeFixFormatArg)
+		private ImmutableDictionary<string, string> CreateDiagnosticProperties(bool isViewOrAction, bool isProperty, string codeFixFormatArg)
 		{
 			var properties = ImmutableDictionary.CreateBuilder<string, string>();
 			properties.Add(StaticFieldOrPropertyInGraphDiagnosticProperties.CodeFixFormatArg, codeFixFormatArg);
 
 			if (isViewOrAction)
 				properties.Add(StaticFieldOrPropertyInGraphDiagnosticProperties.IsViewOrAction, bool.TrueString);
+
+			if (isProperty)
+				properties.Add(StaticFieldOrPropertyInGraphDiagnosticProperties.IsProperty, bool.TrueString);
 
 			return properties.ToImmutable();
 		}

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/StaticFieldOrPropertyInGraph/StaticFieldOrPropertyInGraphAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/StaticFieldOrPropertyInGraph/StaticFieldOrPropertyInGraphAnalyzer.cs
@@ -81,28 +81,32 @@ namespace Acuminator.Analyzers.StaticAnalysis.StaticFieldOrPropertyInGraph
 			bool isView = graphOrExtension.ViewsByNames.ContainsKey(staticFieldOrProperty.Name);
 
 			if (isView)
-				return (Resources.PX1062MessageFormatArg_Views, CreatePropertiesWithIsViewOrAction());
+				return (Resources.PX1062MessageFormatArg_Views, CreateDiagnosticProperties(isViewOrAction: true, Resources.PX1062FixFormatArg_View));
 
 			bool isAction = graphOrExtension.ActionsByNames.ContainsKey(staticFieldOrProperty.Name);
 
 			if (isAction)
-				return (Resources.PX1062MessageFormatArg_Actions, CreatePropertiesWithIsViewOrAction());
+				return (Resources.PX1062MessageFormatArg_Actions, CreateDiagnosticProperties(isViewOrAction: true, Resources.PX1062FixFormatArg_Action));
 
 			switch (staticFieldOrProperty)
 			{
 				case IFieldSymbol:
-					return (Resources.PX1062MessageFormatArg_Fields , null);
+					return (Resources.PX1062MessageFormatArg_Fields, CreateDiagnosticProperties(isViewOrAction: false, Resources.PX1062FixFormatArg_Field));
 				case IPropertySymbol:
-					return (Resources.PX1062MessageFormatArg_Properties, null);
+					return (Resources.PX1062MessageFormatArg_Properties, CreateDiagnosticProperties(isViewOrAction: false, Resources.PX1062FixFormatArg_Property));
 				default:
 					return null;
 			}
 		}
 
-		private ImmutableDictionary<string, string> CreatePropertiesWithIsViewOrAction()
+		private ImmutableDictionary<string, string> CreateDiagnosticProperties(bool isViewOrAction, string codeFixFormatArg)
 		{
 			var properties = ImmutableDictionary.CreateBuilder<string, string>();
-			properties.Add(StaticFieldOrPropertyInGraphDiagnosticProperties.IsViewOrAction, bool.TrueString);
+			properties.Add(StaticFieldOrPropertyInGraphDiagnosticProperties.CodeFixFormatArg, codeFixFormatArg);
+
+			if (isViewOrAction)
+				properties.Add(StaticFieldOrPropertyInGraphDiagnosticProperties.IsViewOrAction, bool.TrueString);
+
 			return properties.ToImmutable();
 		}
 	}

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/StaticFieldOrPropertyInGraph/StaticFieldOrPropertyInGraphAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/StaticFieldOrPropertyInGraph/StaticFieldOrPropertyInGraphAnalyzer.cs
@@ -32,7 +32,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.StaticFieldOrPropertyInGraph
 			var graphStaticFieldsAndProperties = from member in graphOrExtension.Symbol.GetMembers()
 												 where member.IsStatic && member.CanBeReferencedByName && !member.IsImplicitlyDeclared &&
 													   graphOrExtension.Symbol.Equals(member.ContainingType) &&
-													   member is (IPropertySymbol or IFieldSymbol)
+													   member is IPropertySymbol or IFieldSymbol
 												 select member;
 
 			foreach (ISymbol staticFieldOrProperty in graphStaticFieldsAndProperties)

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/StaticFieldOrPropertyInGraph/StaticFieldOrPropertyInGraphDiagnosticProperties.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/StaticFieldOrPropertyInGraph/StaticFieldOrPropertyInGraphDiagnosticProperties.cs
@@ -7,6 +7,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.StaticFieldOrPropertyInGraph
 	internal static class StaticFieldOrPropertyInGraphDiagnosticProperties
 	{
 		public const string IsViewOrAction   = nameof(IsViewOrAction);
+		public const string IsProperty   = nameof(IsProperty);
 		public const string CodeFixFormatArg = nameof(CodeFixFormatArg);
 	}
 }

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/StaticFieldOrPropertyInGraph/StaticFieldOrPropertyInGraphDiagnosticProperties.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/StaticFieldOrPropertyInGraph/StaticFieldOrPropertyInGraphDiagnosticProperties.cs
@@ -1,0 +1,11 @@
+﻿#nullable enable
+
+using System;
+
+namespace Acuminator.Analyzers.StaticAnalysis.StaticFieldOrPropertyInGraph
+{
+	internal static class StaticFieldOrPropertyInGraphDiagnosticProperties
+	{
+		public const string IsViewOrAction = nameof(IsViewOrAction);
+	}
+}

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/StaticFieldOrPropertyInGraph/StaticFieldOrPropertyInGraphDiagnosticProperties.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/StaticFieldOrPropertyInGraph/StaticFieldOrPropertyInGraphDiagnosticProperties.cs
@@ -6,6 +6,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.StaticFieldOrPropertyInGraph
 {
 	internal static class StaticFieldOrPropertyInGraphDiagnosticProperties
 	{
-		public const string IsViewOrAction = nameof(IsViewOrAction);
+		public const string IsViewOrAction   = nameof(IsViewOrAction);
+		public const string CodeFixFormatArg = nameof(CodeFixFormatArg);
 	}
 }

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/StaticFieldOrPropertyInGraph/StaticFieldOrPropertyInGraphFix.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/StaticFieldOrPropertyInGraph/StaticFieldOrPropertyInGraphFix.cs
@@ -1,0 +1,187 @@
+﻿#nullable enable
+
+using System;
+using System.Collections;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Acuminator.Utilities.Common;
+using Acuminator.Utilities.Roslyn;
+using Acuminator.Utilities.Roslyn.Semantic;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.Text;
+
+using static Acuminator.Analyzers.StaticAnalysis.InvalidPXActionSignature.InvalidPXActionSignatureFix;
+
+namespace Acuminator.Analyzers.StaticAnalysis.StaticFieldOrPropertyInGraph
+{
+	[ExportCodeFixProvider(LanguageNames.CSharp), Shared]
+	public class StaticFieldOrPropertyInGraphFix : CodeFixProvider
+	{
+		public override ImmutableArray<string> FixableDiagnosticIds { get; } =
+			ImmutableArray.Create(Descriptors.PX1062_StaticFieldOrPropertyInGraph.Id);
+
+		public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+		public override Task RegisterCodeFixesAsync(CodeFixContext context)
+		{
+			context.CancellationToken.ThrowIfCancellationRequested();
+
+			var diagnostic = context.Diagnostics.FirstOrDefault(d => FixableDiagnosticIds.Contains(d.Id));
+
+			if (diagnostic == null)
+				return Task.CompletedTask;
+
+			string? codeFixFormatArg = GetCodeFixFormatArg(diagnostic);
+
+			if (codeFixFormatArg.IsNullOrWhiteSpace())
+				return Task.CompletedTask;
+
+			bool isViewOrAction = IsViewOrAction(diagnostic);
+
+			if (!isViewOrAction)
+			{
+				string makeReadOnlyCodeActionFormat = nameof(Resources.PX1062FixMakeReadOnlyFormat).GetLocalized().ToString();
+				string makeReadOnlyCodeActionName = string.Format(makeReadOnlyCodeActionFormat, codeFixFormatArg);
+
+				CodeAction makeReadOnlyCodeAction =
+					CodeAction.Create(makeReadOnlyCodeActionName,
+									  cToken => MakeReadOnly(context.Document, context.Span, cToken),
+									  equivalenceKey: makeReadOnlyCodeActionName);
+				context.RegisterCodeFix(makeReadOnlyCodeAction, diagnostic);
+			}
+
+			string makeNonStaticCodeActionFormat = nameof(Resources.PX1062FixMakeNonStaticFormat).GetLocalized().ToString();
+			string makeNonStaticCodeActionName = string.Format(makeNonStaticCodeActionFormat, codeFixFormatArg);
+
+			CodeAction makeNonStaticCodeAction =
+					CodeAction.Create(makeNonStaticCodeActionName,
+									  cToken => MakeNonStatic(context.Document, context.Span, cToken),
+									  equivalenceKey: makeNonStaticCodeActionName);
+			context.RegisterCodeFix(makeNonStaticCodeAction, diagnostic);
+			return Task.CompletedTask;
+		}
+
+		private bool IsViewOrAction(Diagnostic diagnostic) =>
+			diagnostic.Properties?.Count > 0 &&
+			diagnostic.Properties.TryGetValue(StaticFieldOrPropertyInGraphDiagnosticProperties.IsViewOrAction, out string value) &&
+			bool.TrueString.Equals(value, StringComparison.OrdinalIgnoreCase);
+
+		private string? GetCodeFixFormatArg(Diagnostic diagnostic)
+		{
+			if (diagnostic.Properties?.Count is null or 0)
+				return null;
+
+			return diagnostic.Properties.TryGetValue(StaticFieldOrPropertyInGraphDiagnosticProperties.CodeFixFormatArg, out string value)
+				? value
+				: null;
+		}
+
+		private async Task<Document> MakeReadOnly(Document document, TextSpan span, CancellationToken cancellationToken)
+		{
+			SyntaxNode root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+			SyntaxNode diagnosticNode = root?.FindNode(span);
+
+			if (diagnosticNode == null || cancellationToken.IsCancellationRequested)
+				return document;
+
+			ClassDeclarationSyntax dacDeclaration = diagnosticNode.Parent<ClassDeclarationSyntax>();
+			string identifierToRemove = diagnosticNode is ClassDeclarationSyntax dacFieldDeclaration
+											? dacFieldDeclaration.Identifier.Text
+											: (diagnosticNode as PropertyDeclarationSyntax)?.Identifier.Text;
+
+			if (identifierToRemove.IsNullOrWhiteSpace())
+				return document;
+
+			var regionsVisitor = new RegionsVisitor(identifierToRemove, cancellationToken);
+			regionsVisitor.Visit(dacDeclaration);
+
+			if (cancellationToken.IsCancellationRequested)
+				return document;
+
+			ClassDeclarationSyntax modifiedDac = RemoveRegions(dacDeclaration, regionsVisitor.RegionNodesToRemove);
+			var propertiesToRemove = modifiedDac.Members.OfType<PropertyDeclarationSyntax>() //-V3080
+														.Where(p => identifierToRemove.Equals(p.Identifier.Text,
+																							  StringComparison.OrdinalIgnoreCase));
+			modifiedDac = modifiedDac.RemoveNodes(propertiesToRemove, SyntaxRemoveOptions.KeepExteriorTrivia);
+
+			var dacFieldsToRemove = modifiedDac.Members.OfType<ClassDeclarationSyntax>()
+													   .Where(dacField => identifierToRemove.Equals(dacField.Identifier.Text,
+																									StringComparison.OrdinalIgnoreCase));
+			modifiedDac = modifiedDac.RemoveNodes(dacFieldsToRemove, SyntaxRemoveOptions.KeepExteriorTrivia);
+			var modifiedRoot = root.ReplaceNode(dacDeclaration, modifiedDac);
+
+			if (cancellationToken.IsCancellationRequested)
+				return document;
+
+			//Format tabulations
+			Workspace workspace = document.Project.Solution.Workspace;
+			OptionSet formatOptions = GetFormattingOptions(workspace);
+			modifiedRoot = Formatter.Format(modifiedRoot, workspace, formatOptions, cancellationToken);
+
+			if (cancellationToken.IsCancellationRequested)
+				return document;
+
+			return document.WithSyntaxRoot(modifiedRoot);
+		}
+
+		private async Task<Document> MakeNonStatic(Document document, TextSpan span, CancellationToken cancellationToken)
+		{
+			SyntaxNode root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+			SyntaxNode diagnosticNode = root?.FindNode(span);
+
+			if (diagnosticNode == null || cancellationToken.IsCancellationRequested)
+				return document;
+
+			ClassDeclarationSyntax dacDeclaration = diagnosticNode.Parent<ClassDeclarationSyntax>();
+			string identifierToRemove = diagnosticNode is ClassDeclarationSyntax dacFieldDeclaration
+											? dacFieldDeclaration.Identifier.Text
+											: (diagnosticNode as PropertyDeclarationSyntax)?.Identifier.Text;
+
+			if (identifierToRemove.IsNullOrWhiteSpace())
+				return document;
+
+			var regionsVisitor = new RegionsVisitor(identifierToRemove, cancellationToken);
+			regionsVisitor.Visit(dacDeclaration);
+
+			if (cancellationToken.IsCancellationRequested)
+				return document;
+
+			ClassDeclarationSyntax modifiedDac = RemoveRegions(dacDeclaration, regionsVisitor.RegionNodesToRemove);
+			var propertiesToRemove = modifiedDac.Members.OfType<PropertyDeclarationSyntax>() //-V3080
+														.Where(p => identifierToRemove.Equals(p.Identifier.Text,
+																							  StringComparison.OrdinalIgnoreCase));
+			modifiedDac = modifiedDac.RemoveNodes(propertiesToRemove, SyntaxRemoveOptions.KeepExteriorTrivia);
+
+			var dacFieldsToRemove = modifiedDac.Members.OfType<ClassDeclarationSyntax>()
+													   .Where(dacField => identifierToRemove.Equals(dacField.Identifier.Text,
+																									StringComparison.OrdinalIgnoreCase));
+			modifiedDac = modifiedDac.RemoveNodes(dacFieldsToRemove, SyntaxRemoveOptions.KeepExteriorTrivia);
+			var modifiedRoot = root.ReplaceNode(dacDeclaration, modifiedDac);
+
+			if (cancellationToken.IsCancellationRequested)
+				return document;
+
+			//Format tabulations
+			Workspace workspace = document.Project.Solution.Workspace;
+			OptionSet formatOptions = GetFormattingOptions(workspace);
+			modifiedRoot = Formatter.Format(modifiedRoot, workspace, formatOptions, cancellationToken);
+
+			if (cancellationToken.IsCancellationRequested)
+				return document;
+
+			return document.WithSyntaxRoot(modifiedRoot);
+		}
+	}
+}

--- a/src/Acuminator/Acuminator.Tests/Acuminator.Tests.csproj
+++ b/src/Acuminator/Acuminator.Tests/Acuminator.Tests.csproj
@@ -270,6 +270,13 @@
     <EmbeddedResource Include="Tests\StaticAnalysis\PXGraphCreationForBqlQueries\Sources\ExternalService_SingleQueryWithGraphCreation.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\PXGraphCreationForBqlQueries\Sources\ExternalService_TwoQueryWithGraphCreation.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\StaticFieldOrPropertyInGraph\Sources\GraphWithStaticMembers.cs" />
+    <EmbeddedResource Include="Tests\StaticAnalysis\StaticFieldOrPropertyInGraph\Sources\GraphExtensionWithStaticMembers.cs" />
+    <EmbeddedResource Include="Tests\StaticAnalysis\StaticFieldOrPropertyInGraph\Sources\CodeFix\GraphWithStaticField_ReadOnlyFix_Expected.cs" />
+    <EmbeddedResource Include="Tests\StaticAnalysis\StaticFieldOrPropertyInGraph\Sources\CodeFix\GraphWithStaticField_ReadOnlyFix.cs" />
+    <EmbeddedResource Include="Tests\StaticAnalysis\StaticFieldOrPropertyInGraph\Sources\CodeFix\GraphWithStaticReadOnlyView_RemoveStaticFix_Expected.cs" />
+    <EmbeddedResource Include="Tests\StaticAnalysis\StaticFieldOrPropertyInGraph\Sources\CodeFix\GraphWithStaticReadOnlyView_RemoveStaticFix.cs" />
+    <EmbeddedResource Include="Tests\StaticAnalysis\StaticFieldOrPropertyInGraph\Sources\CodeFix\GraphWithStaticAction_RemoveStaticFix_Expected.cs" />
+    <EmbeddedResource Include="Tests\StaticAnalysis\StaticFieldOrPropertyInGraph\Sources\CodeFix\GraphWithStaticAction_RemoveStaticFix.cs" />
     <Compile Include="Tests\StaticAnalysis\StaticFieldOrPropertyInGraph\StaticFieldOrPropertyInGraphTests.cs" />
     <Compile Include="Tests\StaticAnalysis\SuppressionDiagnostics\MultipleSuppressionCodeFixTests.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\SuppressionDiagnostics\Sources\Dac\SuppressMuiltipleDiagnostics_One.cs" />

--- a/src/Acuminator/Acuminator.Tests/Acuminator.Tests.csproj
+++ b/src/Acuminator/Acuminator.Tests/Acuminator.Tests.csproj
@@ -277,6 +277,8 @@
     <EmbeddedResource Include="Tests\StaticAnalysis\StaticFieldOrPropertyInGraph\Sources\CodeFix\GraphWithStaticReadOnlyView_RemoveStaticFix.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\StaticFieldOrPropertyInGraph\Sources\CodeFix\GraphWithStaticAction_RemoveStaticFix_Expected.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\StaticFieldOrPropertyInGraph\Sources\CodeFix\GraphWithStaticAction_RemoveStaticFix.cs" />
+    <EmbeddedResource Include="Tests\StaticAnalysis\StaticFieldOrPropertyInGraph\Sources\CodeFix\GraphWithStaticProperty_ReadOnlyFix_Expected.cs" />
+    <EmbeddedResource Include="Tests\StaticAnalysis\StaticFieldOrPropertyInGraph\Sources\CodeFix\GraphWithStaticProperty_ReadOnlyFix.cs" />
     <Compile Include="Tests\StaticAnalysis\StaticFieldOrPropertyInGraph\StaticFieldOrPropertyInGraphTests.cs" />
     <Compile Include="Tests\StaticAnalysis\SuppressionDiagnostics\MultipleSuppressionCodeFixTests.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\SuppressionDiagnostics\Sources\Dac\SuppressMuiltipleDiagnostics_One.cs" />

--- a/src/Acuminator/Acuminator.Tests/Acuminator.Tests.csproj
+++ b/src/Acuminator/Acuminator.Tests/Acuminator.Tests.csproj
@@ -269,6 +269,8 @@
     <EmbeddedResource Include="Tests\StaticAnalysis\PXGraphCreationForBqlQueries\Sources\CustomerMaint_CheckGraphContext.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\PXGraphCreationForBqlQueries\Sources\ExternalService_SingleQueryWithGraphCreation.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\PXGraphCreationForBqlQueries\Sources\ExternalService_TwoQueryWithGraphCreation.cs" />
+    <EmbeddedResource Include="Tests\StaticAnalysis\StaticFieldOrPropertyInGraph\Sources\GraphWithStaticMembers.cs" />
+    <Compile Include="Tests\StaticAnalysis\StaticFieldOrPropertyInGraph\StaticFieldOrPropertyInGraphTests.cs" />
     <Compile Include="Tests\StaticAnalysis\SuppressionDiagnostics\MultipleSuppressionCodeFixTests.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\SuppressionDiagnostics\Sources\Dac\SuppressMuiltipleDiagnostics_One.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\SuppressionDiagnostics\Sources\Dac\DAC_Without_XML_Description.cs" />

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXActionOnNonPrimaryView/PXActionOnNonPrimaryViewTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXActionOnNonPrimaryView/PXActionOnNonPrimaryViewTests.cs
@@ -16,8 +16,10 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.PXActionOnNonPrimaryView
 	public class PXActionOnNonPrimaryViewTests : CodeFixVerifier
 	{
 		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer() =>
-			new PXGraphAnalyzer(CodeAnalysisSettings.Default,
-				new PXActionOnNonPrimaryViewAnalyzer());
+			new PXGraphAnalyzer(CodeAnalysisSettings.Default
+													.WithStaticAnalysisEnabled()
+													.WithSuppressionMechanismDisabled(),
+								new PXActionOnNonPrimaryViewAnalyzer());
 
 		protected override CodeFixProvider GetCSharpCodeFixProvider() => new PXActionOnNonPrimaryViewFix();
 

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/StaticFieldOrPropertyInGraph/Sources/CodeFix/GraphWithStaticAction_RemoveStaticFix.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/StaticFieldOrPropertyInGraph/Sources/CodeFix/GraphWithStaticAction_RemoveStaticFix.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections;
+using PX.Data;
+using PX.Objects.PO;
+
+namespace Acuminator.Tests.Tests.StaticAnalysis.StaticFieldOrPropertyInGraph.Sources
+{
+	// Acuminator disable once PX1016 ExtensionDoesNotDeclareIsActiveMethod extension should be constantly active
+	public class POCustomOrderEntryExt : PXGraphExtension<POCustomOrderEntry>
+    {
+		public static PXAction<POOrder> ReleaseOrder;
+
+		[PXButton]
+		[PXUIField]
+		public virtual void releaseOrder()
+		{
+
+		}
+	}
+
+	public class POCustomOrderEntry : PXGraph<POCustomOrderEntry>
+	{
+
+	}
+}

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/StaticFieldOrPropertyInGraph/Sources/CodeFix/GraphWithStaticAction_RemoveStaticFix_Expected.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/StaticFieldOrPropertyInGraph/Sources/CodeFix/GraphWithStaticAction_RemoveStaticFix_Expected.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections;
+using PX.Data;
+using PX.Objects.PO;
+
+namespace Acuminator.Tests.Tests.StaticAnalysis.StaticFieldOrPropertyInGraph.Sources
+{
+	// Acuminator disable once PX1016 ExtensionDoesNotDeclareIsActiveMethod extension should be constantly active
+	public class POCustomOrderEntryExt : PXGraphExtension<POCustomOrderEntry>
+    {
+		public PXAction<POOrder> ReleaseOrder;
+
+		[PXButton]
+		[PXUIField]
+		public virtual void releaseOrder()
+		{
+
+		}
+	}
+
+	public class POCustomOrderEntry : PXGraph<POCustomOrderEntry>
+	{
+
+	}
+}

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/StaticFieldOrPropertyInGraph/Sources/CodeFix/GraphWithStaticField_ReadOnlyFix.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/StaticFieldOrPropertyInGraph/Sources/CodeFix/GraphWithStaticField_ReadOnlyFix.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections;
+using PX.Data;
+
+namespace Acuminator.Tests.Tests.StaticAnalysis.StaticFieldOrPropertyInGraph.Sources
+{
+	public class POCustomOrderEntry : PXGraph<POCustomOrderEntry>
+    {
+		public static int Field = 1;
+	}
+}

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/StaticFieldOrPropertyInGraph/Sources/CodeFix/GraphWithStaticField_ReadOnlyFix_Expected.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/StaticFieldOrPropertyInGraph/Sources/CodeFix/GraphWithStaticField_ReadOnlyFix_Expected.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections;
+using PX.Data;
+
+namespace Acuminator.Tests.Tests.StaticAnalysis.StaticFieldOrPropertyInGraph.Sources
+{
+	public class POCustomOrderEntry : PXGraph<POCustomOrderEntry>
+    {
+		public static readonly int Field = 1;
+	}
+}

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/StaticFieldOrPropertyInGraph/Sources/CodeFix/GraphWithStaticProperty_ReadOnlyFix.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/StaticFieldOrPropertyInGraph/Sources/CodeFix/GraphWithStaticProperty_ReadOnlyFix.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections;
+using PX.Data;
+
+namespace Acuminator.Tests.Tests.StaticAnalysis.StaticFieldOrPropertyInGraph.Sources
+{
+	public class POCustomOrderEntry : PXGraph<POCustomOrderEntry>
+    {
+		public static int Property { get; set; }
+	}
+}

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/StaticFieldOrPropertyInGraph/Sources/CodeFix/GraphWithStaticProperty_ReadOnlyFix_Expected.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/StaticFieldOrPropertyInGraph/Sources/CodeFix/GraphWithStaticProperty_ReadOnlyFix_Expected.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections;
+using PX.Data;
+
+namespace Acuminator.Tests.Tests.StaticAnalysis.StaticFieldOrPropertyInGraph.Sources
+{
+	public class POCustomOrderEntry : PXGraph<POCustomOrderEntry>
+    {
+		public static int Property { get; }
+	}
+}

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/StaticFieldOrPropertyInGraph/Sources/CodeFix/GraphWithStaticReadOnlyView_RemoveStaticFix.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/StaticFieldOrPropertyInGraph/Sources/CodeFix/GraphWithStaticReadOnlyView_RemoveStaticFix.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections;
+using PX.Data;
+using PX.Objects.PO;
+
+namespace Acuminator.Tests.Tests.StaticAnalysis.StaticFieldOrPropertyInGraph.Sources
+{
+	public class POCustomOrderEntry : PXGraph<POCustomOrderEntry>
+    {
+		public static readonly PXSelect<POOrder,
+								  Where<POOrder.orderNbr, Equal<Current<POOrder.orderNbr>>,
+									And<POOrder.orderType, Equal<Current<POOrder.orderType>>>>> CurrentOrder;
+	}
+}

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/StaticFieldOrPropertyInGraph/Sources/CodeFix/GraphWithStaticReadOnlyView_RemoveStaticFix_Expected.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/StaticFieldOrPropertyInGraph/Sources/CodeFix/GraphWithStaticReadOnlyView_RemoveStaticFix_Expected.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections;
+using PX.Data;
+using PX.Objects.PO;
+
+namespace Acuminator.Tests.Tests.StaticAnalysis.StaticFieldOrPropertyInGraph.Sources
+{
+	public class POCustomOrderEntry : PXGraph<POCustomOrderEntry>
+    {
+		public readonly PXSelect<POOrder,
+								  Where<POOrder.orderNbr, Equal<Current<POOrder.orderNbr>>,
+									And<POOrder.orderType, Equal<Current<POOrder.orderType>>>>> CurrentOrder;
+	}
+}

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/StaticFieldOrPropertyInGraph/Sources/GraphExtensionWithStaticMembers.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/StaticFieldOrPropertyInGraph/Sources/GraphExtensionWithStaticMembers.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections;
+using PX.Data;
+using PX.Objects.PO;
+
+namespace Acuminator.Tests.Tests.StaticAnalysis.StaticFieldOrPropertyInGraph.Sources
+{
+	public class POCustomOrderEntryExt : PXGraphExtension<POCustomOrderEntry>
+    {
+		public static int Field = 1;
+
+		public static int Property { get; set; } = 1;
+
+		public static readonly int ReadonlyField = 1;
+
+		public static int ReadonlyProperty { get; } = 1;
+
+		public static PXSelect<POOrder> CustomOrders;
+
+		public static readonly PXSelect<POOrder,
+								  Where<POOrder.orderNbr, Equal<Current<POOrder.orderNbr>>,
+									And<POOrder.orderType, Equal<Current<POOrder.orderType>>>>> CurrentOrder;
+
+		public static readonly PXAction<POOrder> ReleaseOrder;
+
+		[PXButton]
+		[PXUIField]
+		public virtual void releaseOrder()
+		{
+			
+		}
+
+		public static bool IsActive() => true;
+	}
+
+	public class POCustomOrderEntry : PXGraph<POCustomOrderEntry>
+	{
+	}
+}

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/StaticFieldOrPropertyInGraph/Sources/GraphWithStaticMembers.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/StaticFieldOrPropertyInGraph/Sources/GraphWithStaticMembers.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections;
+using PX.Data;
+using PX.Objects.PO;
+
+namespace Acuminator.Tests.Tests.StaticAnalysis.StaticFieldOrPropertyInGraph.Sources
+{
+	public class POCustomOrderEntry : PXGraph<POCustomOrderEntry, POOrder>
+    {
+		public static int Field = 1;
+
+		public static int Property { get; set; } = 1;
+
+		public static readonly int ReadonlyField = 1;
+
+		public static int ReadonlyProperty { get; } = 1;
+
+		public static PXSelect<POOrder> CustomOrders;
+
+		public static readonly PXSelect<POOrder,
+								  Where<POOrder.orderNbr, Equal<Current<POOrder.orderNbr>>,
+									And<POOrder.orderType, Equal<Current<POOrder.orderType>>>>> CurrentOrder;
+
+		public static readonly PXAction<POOrder> ReleaseOrder;
+
+		[PXButton]
+		[PXUIField]
+		public virtual void releaseOrder()
+		{
+			
+		}
+	}
+}

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/StaticFieldOrPropertyInGraph/StaticFieldOrPropertyInGraphTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/StaticFieldOrPropertyInGraph/StaticFieldOrPropertyInGraphTests.cs
@@ -40,19 +40,31 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.StaticFieldOrPropertyInGraph
 				Descriptors.PX1062_StaticFieldOrPropertyInGraph.CreateFor(24, 10, AnalysisResources.PX1062MessageFormatArg_Actions));
 
 		[Theory]
-		[EmbeddedFileData("GraphWithNonPrimaryDacView.cs",
-						  "GraphWithNonPrimaryDacView_Expected.cs")]
-		public void Test_Code_Fix_For_Graph_And_Graph_Extension(string actual, string expected)
-		{
-			//VerifyCSharpFix(actual, expected);
-		}
+		[EmbeddedFileData("GraphExtensionWithStaticMembers.cs")]
+		public virtual async Task GraphExtension_WithStatic_Fields_Properties_Actions_Views(string source) =>
+			await VerifyCSharpDiagnosticAsync(source,
+				Descriptors.PX1062_StaticFieldOrPropertyInGraph.CreateFor(10, 10, AnalysisResources.PX1062MessageFormatArg_Fields),
+				Descriptors.PX1062_StaticFieldOrPropertyInGraph.CreateFor(12, 10, AnalysisResources.PX1062MessageFormatArg_Properties),
+				Descriptors.PX1062_StaticFieldOrPropertyInGraph.CreateFor(18, 10, AnalysisResources.PX1062MessageFormatArg_Views),
+				Descriptors.PX1062_StaticFieldOrPropertyInGraph.CreateFor(20, 10, AnalysisResources.PX1062MessageFormatArg_Views),
+				Descriptors.PX1062_StaticFieldOrPropertyInGraph.CreateFor(24, 10, AnalysisResources.PX1062MessageFormatArg_Actions));
 
 		[Theory]
-		[EmbeddedFileData("DerivedGraphWithBaseGraphPrimaryDac.cs",
-						  "DerivedGraphWithBaseGraphPrimaryDac_Expected.cs")]
-		public void Test_Code_Fix_For_Derived_Graph(string actual, string expected)
-		{
-			//VerifyCSharpFix(actual, expected);
-		}
+		[EmbeddedFileData(@"CodeFix\GraphWithStaticField_ReadOnlyFix.cs",
+						  @"CodeFix\GraphWithStaticField_ReadOnlyFix_Expected.cs")]
+		public async Task CodeFix_Graph_WithStaticMutableField_MakeFieldReadonly(string actual, string expected) =>
+			await VerifyCSharpFixAsync(actual, expected);
+
+		[Theory]
+		[EmbeddedFileData(@"CodeFix\GraphWithStaticAction_RemoveStaticFix.cs",
+						  @"CodeFix\GraphWithStaticAction_RemoveStaticFix_Expected.cs")]
+		public async Task CodeFix_Graph_WithStaticAction_RemoveStatic(string actual, string expected) =>
+			await VerifyCSharpFixAsync(actual, expected);
+
+		[Theory]
+		[EmbeddedFileData(@"CodeFix\GraphWithStaticReadOnlyView_RemoveStaticFix.cs",
+						  @"CodeFix\GraphWithStaticReadOnlyView_RemoveStaticFix_Expected.cs")]
+		public async Task CodeFix_Graph_WithStaticReadOnlyView_RemoveStatic(string actual, string expected) =>
+			await VerifyCSharpFixAsync(actual, expected);
 	}
 }

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/StaticFieldOrPropertyInGraph/StaticFieldOrPropertyInGraphTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/StaticFieldOrPropertyInGraph/StaticFieldOrPropertyInGraphTests.cs
@@ -1,0 +1,58 @@
+﻿#nullable enable
+
+using System;
+using System.Threading.Tasks;
+
+using Acuminator.Analyzers.StaticAnalysis;
+using Acuminator.Analyzers.StaticAnalysis.PXGraph;
+using Acuminator.Analyzers.StaticAnalysis.StaticFieldOrPropertyInGraph;
+using Acuminator.Utilities;
+using Acuminator.Tests.Helpers;
+using Acuminator.Tests.Verification;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Xunit;
+
+using AnalysisResources = Acuminator.Analyzers.Resources;
+
+namespace Acuminator.Tests.Tests.StaticAnalysis.StaticFieldOrPropertyInGraph
+{
+	public class StaticFieldOrPropertyInGraphTests : CodeFixVerifier
+	{
+		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer() =>
+			new PXGraphAnalyzer(CodeAnalysisSettings.Default
+													.WithStaticAnalysisEnabled()
+													.WithSuppressionMechanismDisabled(),
+								new StaticFieldOrPropertyInGraphAnalyzer());
+
+		protected override CodeFixProvider GetCSharpCodeFixProvider() => 
+			new StaticFieldOrPropertyInGraphFix();
+
+		[Theory]
+		[EmbeddedFileData("GraphWithStaticMembers.cs")] 
+		public virtual async Task Graph_WithStatic_Fields_Properties_Actions_Views(string source) =>
+			await VerifyCSharpDiagnosticAsync(source,
+				Descriptors.PX1062_StaticFieldOrPropertyInGraph.CreateFor(10, 10, AnalysisResources.PX1062MessageFormatArg_Fields),
+				Descriptors.PX1062_StaticFieldOrPropertyInGraph.CreateFor(12, 10, AnalysisResources.PX1062MessageFormatArg_Properties),
+				Descriptors.PX1062_StaticFieldOrPropertyInGraph.CreateFor(18, 10, AnalysisResources.PX1062MessageFormatArg_Views),
+				Descriptors.PX1062_StaticFieldOrPropertyInGraph.CreateFor(20, 10, AnalysisResources.PX1062MessageFormatArg_Views),
+				Descriptors.PX1062_StaticFieldOrPropertyInGraph.CreateFor(24, 10, AnalysisResources.PX1062MessageFormatArg_Actions));
+
+		[Theory]
+		[EmbeddedFileData("GraphWithNonPrimaryDacView.cs",
+						  "GraphWithNonPrimaryDacView_Expected.cs")]
+		public void Test_Code_Fix_For_Graph_And_Graph_Extension(string actual, string expected)
+		{
+			//VerifyCSharpFix(actual, expected);
+		}
+
+		[Theory]
+		[EmbeddedFileData("DerivedGraphWithBaseGraphPrimaryDac.cs",
+						  "DerivedGraphWithBaseGraphPrimaryDac_Expected.cs")]
+		public void Test_Code_Fix_For_Derived_Graph(string actual, string expected)
+		{
+			//VerifyCSharpFix(actual, expected);
+		}
+	}
+}

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/StaticFieldOrPropertyInGraph/StaticFieldOrPropertyInGraphTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/StaticFieldOrPropertyInGraph/StaticFieldOrPropertyInGraphTests.cs
@@ -52,7 +52,13 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.StaticFieldOrPropertyInGraph
 		[Theory]
 		[EmbeddedFileData(@"CodeFix\GraphWithStaticField_ReadOnlyFix.cs",
 						  @"CodeFix\GraphWithStaticField_ReadOnlyFix_Expected.cs")]
-		public async Task CodeFix_Graph_WithStaticMutableField_MakeFieldReadonly(string actual, string expected) =>
+		public async Task CodeFix_Graph_WithStaticMutableField_MakeReadonly(string actual, string expected) =>
+			await VerifyCSharpFixAsync(actual, expected);
+
+		[Theory]
+		[EmbeddedFileData(@"CodeFix\GraphWithStaticProperty_ReadOnlyFix.cs",
+						  @"CodeFix\GraphWithStaticProperty_ReadOnlyFix_Expected.cs")]
+		public async Task CodeFix_Graph_WithStaticMutableProperty_MakeReadonly(string actual, string expected) =>
 			await VerifyCSharpFixAsync(actual, expected);
 
 		[Theory]

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/ISymbolGenericUtils.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/ISymbolGenericUtils.cs
@@ -1,0 +1,50 @@
+﻿#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using Microsoft.CodeAnalysis;
+
+using Acuminator.Utilities.Common;
+using Acuminator.Utilities.Roslyn.Syntax;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Acuminator.Utilities.Roslyn.Semantic
+{
+	/// <summary>
+	/// A generic utilities for <see cref="ISymbol"/>.
+	/// </summary>
+	public static class ISymbolGenericUtils
+	{
+		public static bool IsReadOnly(this ISymbol symbol) =>
+			symbol.CheckIfNull(nameof(symbol)) switch
+			{
+				IFieldSymbol field       => field.IsReadOnly,
+				IPropertySymbol property => property.IsReadOnly, 
+				ITypeSymbol type         => type.IsReadOnly(),
+				_                        => false
+			};
+
+		public static bool IsReadOnly(this ITypeSymbol typeSymbol)
+		{
+			typeSymbol.ThrowOnNull(nameof(typeSymbol));
+
+			var readonlyProperty = typeSymbol.GetType().GetProperty("IsReadOnly");
+
+			if (readonlyProperty != null && readonlyProperty.PropertyType == typeof(bool))
+			{
+				try
+				{
+					return (bool)readonlyProperty.GetValue(typeSymbol);
+				}
+				catch (Exception e)
+				{ 
+				}
+			}
+
+			var typeNode = typeSymbol.GetSyntax() as MemberDeclarationSyntax;
+			return typeNode?.IsReadOnly() ?? false;
+		}
+	}
+}

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Syntax/RoslynSyntaxUtils.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Syntax/RoslynSyntaxUtils.cs
@@ -195,6 +195,12 @@ namespace Acuminator.Utilities.Roslyn.Syntax
 			return modifiers.Any(SyntaxKind.PublicKeyword);
 		}
 
+		public static bool IsReadOnly(this MemberDeclarationSyntax member)
+		{
+			SyntaxTokenList modifiers = member.GetModifiers();
+			return modifiers.Any(SyntaxKind.ReadOnlyKeyword);
+		}
+
 		public static bool IsPartial(this TypeDeclarationSyntax typeDeclaration) =>
 			typeDeclaration.CheckIfNull(nameof(typeDeclaration))
 						   .Modifiers

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Syntax/SyntaxTreeUtils.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Syntax/SyntaxTreeUtils.cs
@@ -30,19 +30,38 @@ namespace Acuminator.Utilities.Roslyn.Syntax
 		}
 
 		/// <summary>
-		/// Get a parent with a specified type <typeparamref name="TParent"/>
+		/// Get the first parent node with a specified type <typeparamref name="TParent"/>
 		/// </summary>
 		/// <typeparam name="TParent">Parent node type.</typeparam>
 		/// <param name="node">The node to act on.</param>
 		/// <returns/>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static TParent? Parent<TParent>(this SyntaxNode node)
+		public static TParent? Parent<TParent>(this SyntaxNode? node)
 		where TParent : SyntaxNode
 		{
-			if (node == null)
-				return null;
+			return node.ParentOrSelf<TParent>(includeSelf: false);
+		}
 
-			SyntaxNode curNode = node.Parent;
+		/// <summary>
+		/// Get the first parent node or self with a specified type <typeparamref name="TParent"/>
+		/// </summary>
+		/// <typeparam name="TParent">Parent or self node type.</typeparam>
+		/// <param name="node">The node to act on.</param>
+		/// <returns/>
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static TParent? ParentOrSelf<TParent>(this SyntaxNode? node)
+		where TParent : SyntaxNode
+		{
+			return node.ParentOrSelf<TParent>(includeSelf: true);
+		}
+
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		private static TParent? ParentOrSelf<TParent>(this SyntaxNode? node, bool includeSelf)
+		where TParent : SyntaxNode
+		{
+			SyntaxNode? curNode = includeSelf 
+				? node 
+				: node?.Parent;
 
 			while (curNode != null)
 			{

--- a/src/Samples/PX.Objects.HackathonDemo/PX.Objects.HackathonDemo/Graph/Static fields and properties in graph/POCustomOrderEntry.cs
+++ b/src/Samples/PX.Objects.HackathonDemo/PX.Objects.HackathonDemo/Graph/Static fields and properties in graph/POCustomOrderEntry.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections;
+using PX.Data;
+using PX.Objects;
+
+namespace PX.Objects.HackathonDemo.StaticGraphMembers
+{
+	using POOrder = PX.Objects.PO.POOrder;
+
+	public class POCustomOrderEntry : PXGraph<POCustomOrderEntry, POOrder>
+    {
+		public static int Field = 1;
+
+		public static int Property { get; set; } = 1;
+
+		public static readonly int ReadonlyField = 1;
+
+		public static int ReadonlyProperty { get; } = 1;
+
+		public static PXSelect<POOrder> CustomOrders;
+
+		public static readonly PXSelect<POOrder,
+								  Where<POOrder.orderNbr, Equal<Current<POOrder.orderNbr>>,
+									And<POOrder.orderType, Equal<Current<POOrder.orderType>>>>> CurrentOrder;
+
+		public static readonly PXAction<POOrder> ReleaseOrder;
+
+		[PXButton]
+		[PXUIField]
+		public virtual void releaseOrder()
+		{
+			
+		}
+	}
+}

--- a/src/Samples/PX.Objects.HackathonDemo/PX.Objects.HackathonDemo/PX.Objects.HackathonDemo.csproj
+++ b/src/Samples/PX.Objects.HackathonDemo/PX.Objects.HackathonDemo/PX.Objects.HackathonDemo.csproj
@@ -126,6 +126,7 @@
     <Compile Include="CallsToInternalAPI\InternalAPI.cs" />
     <Compile Include="CallsToInternalAPI\GraphUsingInternalApi.cs" />
     <Compile Include="Graph\Start row reset for paging\LEPMaint.cs" />
+    <Compile Include="Graph\Static fields and properties in graph\POCustomOrderEntry.cs" />
     <Compile Include="Graph\View Order\DAC\ARTran.cs" />
     <Compile Include="Graph\View Order\DAC\SOTran.cs" />
     <Compile Include="Graph\View Order\DAC\SOInvoice.cs" />


### PR DESCRIPTION
Overview:
- implemented check that graph does not contain static:
           - views
           - actions
           - mutable fields
           - mutable properties
- added two code fixes:
           - remove static modifier from the static graph member
           - only for static mutable fields and properties - make them read only
- added new helpers to determine if symbol or syntax node is read only
- added helper to work with diagnostic properties passed to code fixes
- changed logging of the unobserved task exceptions in Visual Studio. Filter out timeout exceptions to reduce contention for VS UI thread. 
- added unit tests
- added example to the demo solution         