### PR TITLE
Bugfix/atr 675 dev fix bug in am rule formula engine

### DIFF
--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXGraphCreationForBqlQueries/PXGraphCreationForBqlQueriesAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXGraphCreationForBqlQueries/PXGraphCreationForBqlQueriesAnalyzer.cs
@@ -97,7 +97,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXGraphCreationForBqlQueries
 				.Where(t => t.Type != null && t.Type.IsPXGraphOrExtension(pxContext));
 
 			// External service graph fields and properties
-			HashSet<ISymbol>? usedServiceGraphFieldsAndProperties = 
+			HashSet<ISymbol>? usedServiceGraphFieldsAndProperties =
 				GetUsedGraphFieldsAndPropertiesFromExternalService(dataFlow, body, isInsideStaticCodeElement, semanticModel, pxContext, cancellation);
 
 			// ReSharper disable once ImpureMethodCallOnReadonlyValueField
@@ -208,8 +208,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXGraphCreationForBqlQueries
 
 			foreach (var subNode in nodesToVisit)
 			{
-				var symbolInfo = semanticModel.GetSymbolInfo(subNode, cancellation);
-				var symbol = symbolInfo.Symbol ?? symbolInfo.CandidateSymbols.FirstOrDefault();
+				var symbol = semanticModel.GetSymbolOrFirstCandidate(subNode, cancellation);
 
 				if (symbol != null && existingGraphs.Contains(symbol))
 				{
@@ -244,7 +243,9 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXGraphCreationForBqlQueries
 
 			var localVar = context.SemanticModel.GetSymbolOrFirstCandidate(graphArgSyntax, context.CancellationToken) as ILocalSymbol;
 
-			//Do not report and do not suggest to change the graph if it is used somewhere else to avoid disruptive side effects in the business logic
+			// Do not report and do not suggest to change the graph if it is used somewhere else to avoid disruptive side effects in the business logic
+			// This includes fields and properties that store graph or a graph extension. The analysis of type members that store graphs
+			//  goes outside of method boundaries. We can't predict side effects in the business logic cuased by the change of a graph stored as type member
 			if (localVar == null || availableGraphUsages.ContainsKey(localVar))  
 				return;
 

--- a/src/Acuminator/Acuminator.Tests/Acuminator.Tests.csproj
+++ b/src/Acuminator/Acuminator.Tests/Acuminator.Tests.csproj
@@ -270,6 +270,7 @@
     <EmbeddedResource Include="Tests\StaticAnalysis\PXGraphCreationForBqlQueries\Sources\ExternalService_SingleQueryWithGraphCreation.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\PXGraphCreationForBqlQueries\Sources\ExternalService_TwoQueryWithGraphCreation.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\PXGraphCreationForBqlQueries\Sources\ExternalService_TwoQueriesReuseGraphField.cs" />
+    <EmbeddedResource Include="Tests\StaticAnalysis\PXGraphCreationForBqlQueries\Sources\ExternalService_TwoQueries_UseDifferentGraphFields.cs" />
     <Compile Include="Tests\StaticAnalysis\SuppressionDiagnostics\MultipleSuppressionCodeFixTests.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\SuppressionDiagnostics\Sources\Dac\SuppressMuiltipleDiagnostics_One.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\SuppressionDiagnostics\Sources\Dac\DAC_Without_XML_Description.cs" />

--- a/src/Acuminator/Acuminator.Tests/Acuminator.Tests.csproj
+++ b/src/Acuminator/Acuminator.Tests/Acuminator.Tests.csproj
@@ -269,6 +269,7 @@
     <EmbeddedResource Include="Tests\StaticAnalysis\PXGraphCreationForBqlQueries\Sources\CustomerMaint_CheckGraphContext.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\PXGraphCreationForBqlQueries\Sources\ExternalService_SingleQueryWithGraphCreation.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\PXGraphCreationForBqlQueries\Sources\ExternalService_TwoQueryWithGraphCreation.cs" />
+    <EmbeddedResource Include="Tests\StaticAnalysis\PXGraphCreationForBqlQueries\Sources\ExternalService_TwoQueriesReuseGraphField.cs" />
     <Compile Include="Tests\StaticAnalysis\SuppressionDiagnostics\MultipleSuppressionCodeFixTests.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\SuppressionDiagnostics\Sources\Dac\SuppressMuiltipleDiagnostics_One.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\SuppressionDiagnostics\Sources\Dac\DAC_Without_XML_Description.cs" />

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreationForBqlQueries/PXGraphCreationDuringInitializationTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreationForBqlQueries/PXGraphCreationDuringInitializationTests.cs
@@ -109,6 +109,12 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.PXGraphCreationForBqlQueries
 			await VerifyCSharpDiagnosticAsync(source, dacSource, graphSource);
 
 		[Theory]
+		[EmbeddedFileData("ExternalService_TwoQueriesReuseGraphField.cs", "Customer.cs")]
+		public async Task TwoQueries_ReusingSameGraphInArgument_ShouldNotShowDiagnostic(string source, string dacSource) =>
+			await VerifyCSharpDiagnosticAsync(source, dacSource);
+
+
+		[Theory]
 	    [EmbeddedFileData("InstanceIsUsedOutsideBql.cs", "Customer.cs", "CustomerMaint.cs")]
 	    public async Task InstanceIsUsedOutsideBql_ShouldNotShowDiagnostic(string source, string dacSource, string graphSource) =>
 		    await VerifyCSharpDiagnosticAsync(source, dacSource, graphSource);

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreationForBqlQueries/PXGraphCreationDuringInitializationTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreationForBqlQueries/PXGraphCreationDuringInitializationTests.cs
@@ -110,7 +110,12 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.PXGraphCreationForBqlQueries
 
 		[Theory]
 		[EmbeddedFileData("ExternalService_TwoQueriesReuseGraphField.cs", "Customer.cs")]
-		public async Task TwoQueries_ReusingSameGraphInArgument_ShouldNotShowDiagnostic(string source, string dacSource) =>
+		public async Task TwoQueries_ReusingSameGraph_InArguments_ShouldNotShowDiagnostic(string source, string dacSource) =>
+			await VerifyCSharpDiagnosticAsync(source, dacSource);
+
+		[Theory]
+		[EmbeddedFileData("ExternalService_TwoQueries_UseDifferentGraphFields.cs", "Customer.cs")]
+		public async Task TwoQueries_UseDifferentGraphFields_InArguments_ShouldNotShowDiagnostic(string source, string dacSource) =>
 			await VerifyCSharpDiagnosticAsync(source, dacSource);
 
 

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreationForBqlQueries/Sources/ExternalService_TwoQueriesReuseGraphField.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreationForBqlQueries/Sources/ExternalService_TwoQueriesReuseGraphField.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using PX.Data;
+
+namespace PX.Objects
+{
+	public class CustomerService
+	{
+		public PXGraph Graph { get; }
+
+		public CustomerService(PXGraph graph)
+		{
+			Graph = graph;
+		}
+
+		public Customer SelectCustomer()
+		{
+			Customer customer1 = PXSelect<Customer>.Select(Graph);    // Do not report diagnostic
+			Customer customer2 = PXSelect<Customer>.Select(Graph);    // Do not report diagnostic
+
+			return customer1 ?? customer2;
+		}
+	}
+}

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreationForBqlQueries/Sources/ExternalService_TwoQueries_UseDifferentGraphFields.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreationForBqlQueries/Sources/ExternalService_TwoQueries_UseDifferentGraphFields.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using PX.Data;
+
+namespace PX.Objects
+{
+	public class CustomerService
+	{
+		public PXGraph Graph1 { get; }
+
+		public PXGraph Graph2 { get; }
+
+		public CustomerService(PXGraph graph)
+		{
+			Graph1 = graph;
+			Graph2 = graph;
+		}
+
+		public Customer SelectCustomer()
+		{
+			Customer customer1 = PXSelect<Customer>.Select(Graph1);    // Do not report diagnostic
+			Customer customer2 = PXSelect<Customer>.Select(Graph2);    // Do not report diagnostic
+
+			return customer1 ?? customer2;
+		}
+	}
+}


### PR DESCRIPTION
This PR is not related to others, the branch is created directly from the dev branch. 
It can be merged independently.

Overview:
This PR fixes the bug introduced by the new changes to PX1072 diagnostic added in ATR-675 item. 
The PX1072 diagnostic checks if there available graphs that can be reused in a current context instead of creation of a new graph. 

All existing unit test cases operated with graphs created in a method or passed as parameters. Thus, the usages of graphs stored as fields or properties was actually not tested and not supported. Because of this there was a false alert discovered in the AM module in the `RuleFormulaEngine` class.  This PR adds such support:

- The diagnostic should not advice changes in the business logic that can potentially bring undesired side effects to the business logic. Therefore, the diagnostic should not consider graphs stored as fields and properties as available for re-usage.
- At the same time the diagnostic should not consider BQL Select/Search call sites that use graphs stored as fields and properties as potential candidates for a change of a graph. Basically, we now exclude everything related to graphs stored as fields and properties from the analysis to play safe.
- New unit tests were added to test the changes in the analysis


