### PR TITLE
Bugfix/atr 139 dev do not analyze const fields and fix nre

### DIFF
--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/StaticFieldOrPropertyInGraph/StaticFieldOrPropertyInGraphAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/StaticFieldOrPropertyInGraph/StaticFieldOrPropertyInGraphAnalyzer.cs
@@ -32,9 +32,9 @@ namespace Acuminator.Analyzers.StaticAnalysis.StaticFieldOrPropertyInGraph
 			symbolContext.CancellationToken.ThrowIfCancellationRequested();
 
 			var graphStaticFieldsAndProperties = from member in graphOrExtension.Symbol.GetMembers()
-												 where member.IsStatic && member.CanBeReferencedByName && !member.IsImplicitlyDeclared &&
+												 where member.IsStatic && member.IsExplicitlyDeclared() &&
 													   graphOrExtension.Symbol.Equals(member.ContainingType) &&
-													   member is IPropertySymbol or IFieldSymbol
+													   member is IPropertySymbol or IFieldSymbol { IsConst: false }
 												 select member;
 
 			foreach (ISymbol staticFieldOrProperty in graphStaticFieldsAndProperties)

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/StaticFieldOrPropertyInGraph/StaticFieldOrPropertyInGraphAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/StaticFieldOrPropertyInGraph/StaticFieldOrPropertyInGraphAnalyzer.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading;
 
 using Acuminator.Analyzers.StaticAnalysis.PXGraph;
+using Acuminator.Utilities.Common;
 using Acuminator.Utilities.DiagnosticSuppression;
 using Acuminator.Utilities.Roslyn.Semantic;
 using Acuminator.Utilities.Roslyn.Semantic.PXGraph;
@@ -74,8 +75,9 @@ namespace Acuminator.Analyzers.StaticAnalysis.StaticFieldOrPropertyInGraph
 			var fieldOrPropertyNode = staticFieldOrProperty.GetSyntax(cancellation);
 			var fieldOrPropertyDeclaration = fieldOrPropertyNode?.ParentOrSelf<MemberDeclarationSyntax>();
 			var staticModifier = fieldOrPropertyDeclaration?.GetModifiers()
-															.FirstOrDefault(modifier => modifier.IsKind(SyntaxKind.StaticKeyword));	
-			if (staticModifier != null)
+															.FirstOrDefault(modifier => modifier.IsKind(SyntaxKind.StaticKeyword));
+
+			if (staticModifier != null && staticModifier != default(SyntaxToken))
 				return staticModifier.Value.GetLocation();
 
 			return !staticFieldOrProperty.Locations.IsDefaultOrEmpty

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/StaticFieldOrPropertyInGraph/Sources/GraphWithStaticMembers.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/StaticFieldOrPropertyInGraph/Sources/GraphWithStaticMembers.cs
@@ -29,5 +29,8 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.StaticFieldOrPropertyInGraph.Sou
 		{
 			
 		}
+
+
+		public const int Constant = 5;			// Should not be reported
 	}
 }

--- a/src/Acuminator/Acuminator.Utilities/Common/EnumerableExtensions.cs
+++ b/src/Acuminator/Acuminator.Utilities/Common/EnumerableExtensions.cs
@@ -189,6 +189,29 @@ namespace Acuminator.Utilities.Common
 		}
 
 		/// <summary>
+		/// FirstOrDefault method for <see cref="SyntaxTokenList"/>. This is an optimization method which allows to avoid boxing.
+		/// </summary>
+		/// <param name="source">The <see cref="SyntaxTokenList"/> to act on.</param>
+		/// <param name="predicate">The predicate.</param>
+		/// <returns/>
+		[DebuggerStepThrough]
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static SyntaxToken FirstOrDefault(this SyntaxTokenList source, Func<SyntaxToken, bool> predicate)
+		{
+			predicate.ThrowOnNull(nameof(predicate));
+
+			for (int i = 0; i < source.Count; i++)
+			{
+				SyntaxToken token = source[i];
+
+				if (predicate(token))
+					 return token;
+			}
+
+			return default;
+		}
+
+		/// <summary>
 		/// Where method for <see cref="SyntaxList{TNode}"/>. This is an optimization method which allows to avoid boxing.
 		/// </summary>
 		/// <typeparam name="TNode">Type of the syntax node.</typeparam>


### PR DESCRIPTION
Overview:
- Fixed an NRE thrown by analyzer when graph has const graph fields. Const fields are considered static by Roslyn.
- Added const field to unit test sources
- Added helper method