### PR TITLE
Bugfix/atr 690 dev generation of global suppression file fails vs2022

### DIFF
--- a/src/Acuminator/Acuminator.Analyzers/Resources.Designer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/Resources.Designer.cs
@@ -196,51 +196,6 @@ namespace Acuminator.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to class.
-        /// </summary>
-        public static string PX1007Class {
-            get {
-                return ResourceManager.GetString("PX1007Class", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to DAC property.
-        /// </summary>
-        public static string PX1007DacProperty {
-            get {
-                return ResourceManager.GetString("PX1007DacProperty", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to entity.
-        /// </summary>
-        public static string PX1007DefaultEntity {
-            get {
-                return ResourceManager.GetString("PX1007DefaultEntity", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to delegate.
-        /// </summary>
-        public static string PX1007Delegate {
-            get {
-                return ResourceManager.GetString("PX1007Delegate", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to enumeration.
-        /// </summary>
-        public static string PX1007Enum {
-            get {
-                return ResourceManager.GetString("PX1007Enum", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Add a description.
         /// </summary>
         public static string PX1007FixAddDescription {
@@ -259,25 +214,7 @@ namespace Acuminator.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to interface.
-        /// </summary>
-        public static string PX1007Interface {
-            get {
-                return ResourceManager.GetString("PX1007Interface", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to struct.
-        /// </summary>
-        public static string PX1007Struct {
-            get {
-                return ResourceManager.GetString("PX1007Struct", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to The {0} DAC, DAC extension, or DAC property should have a description in the summary XML tag.
+        ///   Looks up a localized string similar to The DAC, DAC extension, or DAC property should have a description in the summary XML tag.
         /// </summary>
         public static string PX1007Title {
             get {

--- a/src/Acuminator/Acuminator.Analyzers/Resources.resx
+++ b/src/Acuminator/Acuminator.Analyzers/Resources.resx
@@ -163,7 +163,7 @@
     <value>Exclude the class from the API Reference</value>
   </data>
   <data name="PX1007Title" xml:space="preserve">
-    <value>The {0} DAC, DAC extension, or DAC property should have a description in the summary XML tag</value>
+    <value>The DAC, DAC extension, or DAC property should have a description in the summary XML tag</value>
   </data>
   <data name="PX1008Title" xml:space="preserve">
     <value>The reference to {0} is captured in the {1} delegate and will cause synchronous execution of the delegate. It may lead to random bugs and data consistency issues.</value>
@@ -494,27 +494,6 @@
   </data>
   <data name="SuppressDiagnosticWithCommentNonNestedCodeActionTitle" xml:space="preserve">
     <value>Suppress the {0} diagnostic with Acuminator in a comment</value>
-  </data>
-  <data name="PX1007Class" xml:space="preserve">
-    <value>class</value>
-  </data>
-  <data name="PX1007Delegate" xml:space="preserve">
-    <value>delegate</value>
-  </data>
-  <data name="PX1007Enum" xml:space="preserve">
-    <value>enumeration</value>
-  </data>
-  <data name="PX1007Interface" xml:space="preserve">
-    <value>interface</value>
-  </data>
-  <data name="PX1007Struct" xml:space="preserve">
-    <value>struct</value>
-  </data>
-  <data name="PX1007DefaultEntity" xml:space="preserve">
-    <value>entity</value>
-  </data>
-  <data name="PX1007DacProperty" xml:space="preserve">
-    <value>DAC property</value>
   </data>
   <data name="PX1019Title" xml:space="preserve">
     <value>A DAC property field with the AutoNumber attribute must have the string type</value>

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PublicClassXmlComment/XmlCommentsWalker.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PublicClassXmlComment/XmlCommentsWalker.cs
@@ -148,7 +148,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.PublicClassXmlComment
 
 			if (reportDiagnostic)
 			{
-				ReportDiagnostic(_syntaxContext, typeDeclaration, typeDeclaration.Identifier.GetLocation(), thisDeclarationParseResult);
+				ReportDiagnostic(_syntaxContext, typeDeclaration.Identifier.GetLocation(), thisDeclarationParseResult);
 			}
 		}
 
@@ -180,7 +180,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.PublicClassXmlComment
 
 			if (reportDiagnostic)
 			{
-				ReportDiagnostic(_syntaxContext, memberDeclaration, identifier.GetLocation(), thisDeclarationParseResult);
+				ReportDiagnostic(_syntaxContext, identifier.GetLocation(), thisDeclarationParseResult);
 			}
 		}
 
@@ -279,30 +279,16 @@ namespace Acuminator.Analyzers.StaticAnalysis.PublicClassXmlComment
 			!content.IsNullOrEmpty() &&
 			 content.Any(char.IsLetterOrDigit);
 
-		private void ReportDiagnostic(SyntaxNodeAnalysisContext syntaxContext, MemberDeclarationSyntax memberDeclaration,
-									  Location location, XmlCommentParseResult parseResult)
+		private void ReportDiagnostic(SyntaxNodeAnalysisContext syntaxContext, Location location, XmlCommentParseResult parseResult)
 		{
 			syntaxContext.CancellationToken.ThrowIfCancellationRequested();
 
-			var memberCategory = GetMemberCategory(memberDeclaration);
 			var properties = ImmutableDictionary<string, string>.Empty
 																.Add(XmlAnalyzerConstants.XmlCommentParseResultKey, parseResult.ToString());
-			var noXmlCommentDiagnostic = Diagnostic.Create(Descriptors.PX1007_PublicClassXmlComment, location, properties, memberCategory);
+			var noXmlCommentDiagnostic = Diagnostic.Create(Descriptors.PX1007_PublicClassXmlComment, location, properties);
 
 			syntaxContext.ReportDiagnosticWithSuppressionCheck(noXmlCommentDiagnostic, _codeAnalysisSettings);
 		}
-
-		private LocalizableString GetMemberCategory(MemberDeclarationSyntax memberDeclaration) =>
-			 memberDeclaration switch
-			 {
-				 ClassDeclarationSyntax _     => nameof(Resources.PX1007Class).GetLocalized(),
-				 PropertyDeclarationSyntax _  => nameof(Resources.PX1007DacProperty).GetLocalized(),
-				 StructDeclarationSyntax _    => nameof(Resources.PX1007Struct).GetLocalized(),
-				 InterfaceDeclarationSyntax _ => nameof(Resources.PX1007Interface).GetLocalized(),
-				 EnumDeclarationSyntax _      => nameof(Resources.PX1007Enum).GetLocalized(),
-				 DelegateDeclarationSyntax _  => nameof(Resources.PX1007Delegate).GetLocalized(),
-				 _                            => nameof(Resources.PX1007DefaultEntity).GetLocalized(),
-			 };
 
 		private bool CheckAttributeNames(IEnumerable<string> attributeNames)
 		{

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PublicClassXmlComment/PublicClassXmlCommentTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PublicClassXmlComment/PublicClassXmlCommentTests.cs
@@ -9,8 +9,6 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using System.Threading.Tasks;
 using Xunit;
 
-using Resources = Acuminator.Analyzers.Resources;
-
 namespace Acuminator.Tests.Tests.StaticAnalysis.PublicClassXmlComment
 {
 	public class PublicClassXmlCommentTests : CodeFixVerifier

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PublicClassXmlComment/PublicClassXmlCommentTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PublicClassXmlComment/PublicClassXmlCommentTests.cs
@@ -29,21 +29,21 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.PublicClassXmlComment
 		public async Task PublicClass_WithoutDescription(string source) =>
 			await VerifyCSharpDiagnosticAsync(
 				source,
-				Descriptors.PX1007_PublicClassXmlComment.CreateFor(11, 15, messageArgs: nameof(Resources.PX1007Class).GetLocalized()));
+				Descriptors.PX1007_PublicClassXmlComment.CreateFor(11, 15));
 
 		[Theory]
 		[EmbeddedFileData("WithoutSummary.cs")]
 		public async Task PublicClass_WithoutSummary(string source) =>
 			await VerifyCSharpDiagnosticAsync(
 				source,
-				Descriptors.PX1007_PublicClassXmlComment.CreateFor(12, 15, messageArgs: nameof(Resources.PX1007Class).GetLocalized()));
+				Descriptors.PX1007_PublicClassXmlComment.CreateFor(12, 15));
 
 		[Theory]
 		[EmbeddedFileData("WithEmptySummary.cs")]
 		public async Task PublicClass_WithEmptySummary(string source) =>
 			await VerifyCSharpDiagnosticAsync(
 				source,
-				Descriptors.PX1007_PublicClassXmlComment.CreateFor(14, 15, messageArgs: nameof(Resources.PX1007Class).GetLocalized()));
+				Descriptors.PX1007_PublicClassXmlComment.CreateFor(14, 15));
 
 		[Theory]
 		[EmbeddedFileData("NonPublic.cs")]
@@ -64,9 +64,9 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.PublicClassXmlComment
 		[EmbeddedFileData("DAC_ExcludedWithNested.cs")]
 		public async Task ExcludedWithNested_PublicClasses_WithoutDescription_DoesntReportDiagnostic(string source) =>
 			await VerifyCSharpDiagnosticAsync(source,
-				Descriptors.PX1007_PublicClassXmlComment.CreateFor(18, 15, messageArgs: nameof(Resources.PX1007Class).GetLocalized()),
-				Descriptors.PX1007_PublicClassXmlComment.CreateFor(27, 16, messageArgs: nameof(Resources.PX1007Class).GetLocalized()),
-				Descriptors.PX1007_PublicClassXmlComment.CreateFor(39, 16, messageArgs: nameof(Resources.PX1007Class).GetLocalized()));
+				Descriptors.PX1007_PublicClassXmlComment.CreateFor(18, 15),
+				Descriptors.PX1007_PublicClassXmlComment.CreateFor(27, 16),
+				Descriptors.PX1007_PublicClassXmlComment.CreateFor(39, 16));
 
 		[Theory]
 		[EmbeddedFileData("WithoutDescription.cs", "WithoutDescription_AddDescription.cs")]
@@ -103,9 +103,9 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.PublicClassXmlComment
 		public async Task PublicDac_WithoutDescription(string source) =>
 			await VerifyCSharpDiagnosticAsync(
 				source,
-				Descriptors.PX1007_PublicClassXmlComment.CreateFor(22, 17, messageArgs: nameof(Resources.PX1007DacProperty).GetLocalized()),
-				Descriptors.PX1007_PublicClassXmlComment.CreateFor(32, 17, messageArgs: nameof(Resources.PX1007DacProperty).GetLocalized()),
-				Descriptors.PX1007_PublicClassXmlComment.CreateFor(43, 17, messageArgs: nameof(Resources.PX1007DacProperty).GetLocalized()));
+				Descriptors.PX1007_PublicClassXmlComment.CreateFor(22, 17),
+				Descriptors.PX1007_PublicClassXmlComment.CreateFor(32, 17),
+				Descriptors.PX1007_PublicClassXmlComment.CreateFor(43, 17));
 
 		[Theory]
 		[EmbeddedFileData("DAC_AddDescription.cs")]
@@ -148,14 +148,14 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.PublicClassXmlComment
 		public async Task PublicPartialHelper_SingleWithoutDescription(string source) =>
 			await VerifyCSharpDiagnosticAsync(
 				source,
-				Descriptors.PX1007_PublicClassXmlComment.CreateFor(10, 23, messageArgs: nameof(Resources.PX1007Class).GetLocalized()));
+				Descriptors.PX1007_PublicClassXmlComment.CreateFor(10, 23));
 
 		[Theory]
 		[EmbeddedFileData(@"Partial\WithoutComment.cs", @"Partial\WithBadComment.cs")]
 		public async Task PublicPartialHelper_BadCommentOnOtherDeclaration(string source, string badCommentSource) =>
 			await VerifyCSharpDiagnosticAsync(
 				source, badCommentSource,
-				Descriptors.PX1007_PublicClassXmlComment.CreateFor(10, 23, messageArgs: nameof(Resources.PX1007Class).GetLocalized()));
+				Descriptors.PX1007_PublicClassXmlComment.CreateFor(10, 23));
 
 		[Theory]
 		[EmbeddedFileData(@"Partial\WithoutComment.cs", @"Partial\WithComment.cs")]

--- a/src/Acuminator/Acuminator.Utilities/DiagnosticSuppression/BuildAction/ICustomBuildActionSetter.cs
+++ b/src/Acuminator/Acuminator.Utilities/DiagnosticSuppression/BuildAction/ICustomBuildActionSetter.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#nullable enable
+
+using System;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 

--- a/src/Acuminator/Acuminator.Vsix/Acuminator.Vsix.csproj
+++ b/src/Acuminator/Acuminator.Vsix/Acuminator.Vsix.csproj
@@ -423,6 +423,7 @@
     <Compile Include="Coloriser\Roslyn\Utils\RoslynVSEditorExtensions.cs" />
     <Compile Include="Commands\BQL Fixer\AngleBracesBqlRewriter.cs" />
     <Compile Include="Commands\BQL Fixer\FixBqlCommand.cs" />
+    <Compile Include="Commands\DiagnosticSuppression\BuildAction\VsixBuildActionSetterVS2022.cs" />
     <Compile Include="Commands\DiagnosticSuppression\Diagnostic Service\DiagnosticDataLocation.cs" />
     <Compile Include="Commands\DiagnosticSuppression\Diagnostic Service\DiagnosticData.cs" />
     <Compile Include="Commands\DiagnosticSuppression\Base\SuppressDiagnosticCommandBase.cs" />

--- a/src/Acuminator/Acuminator.Vsix/Acuminator.Vsix.csproj
+++ b/src/Acuminator/Acuminator.Vsix/Acuminator.Vsix.csproj
@@ -427,7 +427,7 @@
     <Compile Include="Commands\DiagnosticSuppression\Diagnostic Service\DiagnosticData.cs" />
     <Compile Include="Commands\DiagnosticSuppression\Base\SuppressDiagnosticCommandBase.cs" />
     <Compile Include="Commands\DiagnosticSuppression\Diagnostic Service\RoslynDTOWrapperBase.cs" />
-    <Compile Include="Commands\DiagnosticSuppression\VsixBuildActionSetter.cs" />
+    <Compile Include="Commands\DiagnosticSuppression\BuildAction\VsixBuildActionSetterVS2019.cs" />
     <Compile Include="Commands\DiagnosticSuppression\VsixIOErrorProcessor.cs" />
     <Compile Include="Commands\DiagnosticSuppression\Suppression File\SuppressDiagnosticInSuppressionFileCommand.cs" />
     <Compile Include="Commands\DiagnosticSuppression\Diagnostic Service\RoslynDiagnosticService.cs" />

--- a/src/Acuminator/Acuminator.Vsix/AcuminatorVSPackage.cs
+++ b/src/Acuminator/Acuminator.Vsix/AcuminatorVSPackage.cs
@@ -361,7 +361,7 @@ namespace Acuminator.Vsix
         {
             SuppressionManager.InitOrReset(_vsWorkspace, generateSuppressionBase: false, 
 										   errorProcessorFabric: () => new VsixIOErrorProcessor(),
-										   buildActionSetterFabric: () => new VsixBuildActionSetter());
+										   buildActionSetterFabric: () => new VsixBuildActionSetterVS2019());
         }
 
         private async System.Threading.Tasks.Task InitializeCodeAnalysisSettingsAsync()

--- a/src/Acuminator/Acuminator.Vsix/AcuminatorVSPackage.cs
+++ b/src/Acuminator/Acuminator.Vsix/AcuminatorVSPackage.cs
@@ -361,7 +361,9 @@ namespace Acuminator.Vsix
         {
             SuppressionManager.InitOrReset(_vsWorkspace, generateSuppressionBase: false, 
 										   errorProcessorFabric: () => new VsixIOErrorProcessor(),
-										   buildActionSetterFabric: () => new VsixBuildActionSetterVS2019());
+										   buildActionSetterFabric: () => SharedVsSettings.VSVersion.VS2022OrNewer 
+																			? new VsixBuildActionSetterVS2022() 
+																			: new VsixBuildActionSetterVS2019());
         }
 
         private async System.Threading.Tasks.Task InitializeCodeAnalysisSettingsAsync()

--- a/src/Acuminator/Acuminator.Vsix/Commands/DiagnosticSuppression/BuildAction/VsixBuildActionSetterVS2019.cs
+++ b/src/Acuminator/Acuminator.Vsix/Commands/DiagnosticSuppression/BuildAction/VsixBuildActionSetterVS2019.cs
@@ -8,11 +8,13 @@ using Microsoft.VisualStudio.Threading;
 using Acuminator.Utilities.DiagnosticSuppression.BuildAction;
 
 using ThreadHelper = Microsoft.VisualStudio.Shell.ThreadHelper;
+using Acuminator.Utilities;
+using Acuminator.Vsix.Logger;
 
 namespace Acuminator.Vsix.DiagnosticSuppression
 {
 	/// <summary>
-	/// A helper to set Build Action for newly added suppression file in VS 2019 or older.
+	/// A helper to set Build Action for newly added suppression file in VS 2019 or older that can use VS COM API directy.
 	/// </summary>
 	public class VsixBuildActionSetterVS2019 : ICustomBuildActionSetter
 	{
@@ -20,6 +22,9 @@ namespace Acuminator.Vsix.DiagnosticSuppression
 		{
 			roslynSuppressionFilePath.ThrowOnNullOrWhiteSpace(nameof(roslynSuppressionFilePath));
 			buildActionToSet.ThrowOnNullOrWhiteSpace(nameof(buildActionToSet));
+
+			if (SharedVsSettings.VSVersion.VS2022OrNewer)
+				return false;
 
 			try
 			{
@@ -29,8 +34,9 @@ namespace Acuminator.Vsix.DiagnosticSuppression
 				return ThreadHelper.JoinableTaskFactory.Run(() => SetBuildActionAsync(roslynSuppressionFilePath, buildActionToSet));
 				#pragma warning restore VSTHRD104 
 			}
-			catch
+			catch (Exception ex)
 			{
+				AcuminatorLogger.LogException(ex);
 				return false;
 			}
 		}
@@ -72,8 +78,9 @@ namespace Acuminator.Vsix.DiagnosticSuppression
 				buildActionProperty.Value = buildActionToSet;
 				return true;
 			}
-			catch (Exception)
+			catch (Exception ex)
 			{
+				AcuminatorLogger.LogException(ex);
 				return false;
 			}		
 		}

--- a/src/Acuminator/Acuminator.Vsix/Commands/DiagnosticSuppression/BuildAction/VsixBuildActionSetterVS2019.cs
+++ b/src/Acuminator/Acuminator.Vsix/Commands/DiagnosticSuppression/BuildAction/VsixBuildActionSetterVS2019.cs
@@ -12,9 +12,9 @@ using ThreadHelper = Microsoft.VisualStudio.Shell.ThreadHelper;
 namespace Acuminator.Vsix.DiagnosticSuppression
 {
 	/// <summary>
-	/// A helper to set Build Action for newly added suppression file.
+	/// A helper to set Build Action for newly added suppression file in VS 2019 or older.
 	/// </summary>
-	public class VsixBuildActionSetter : ICustomBuildActionSetter
+	public class VsixBuildActionSetterVS2019 : ICustomBuildActionSetter
 	{
 		public bool SetBuildAction(string roslynSuppressionFilePath, string buildActionToSet)
 		{

--- a/src/Acuminator/Acuminator.Vsix/Commands/DiagnosticSuppression/BuildAction/VsixBuildActionSetterVS2019.cs
+++ b/src/Acuminator/Acuminator.Vsix/Commands/DiagnosticSuppression/BuildAction/VsixBuildActionSetterVS2019.cs
@@ -1,7 +1,7 @@
-﻿using System;
-using System.Runtime.CompilerServices;
+﻿#nullable enable
+
+using System;
 using System.Threading.Tasks;
-using System.Windows;
 using Acuminator.Utilities.Common;
 using Acuminator.Vsix.Utilities;
 using Microsoft.VisualStudio.Threading;
@@ -47,13 +47,13 @@ namespace Acuminator.Vsix.DiagnosticSuppression
 			await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
 #pragma warning disable VSTHRD010 // Invoke single-threaded types on Main thread
-			EnvDTE.DTE dte = await AcuminatorVSPackage.Instance.GetServiceAsync<EnvDTE.DTE>();
+			EnvDTE.DTE? dte = await AcuminatorVSPackage.Instance.GetServiceAsync<EnvDTE.DTE>();
 
 			if (dte == null)
 				return false;
 #pragma warning restore VSTHRD010 // Invoke single-threaded types on Main thread
 
-			EnvDTE.ProjectItem suppressionFileDteItem = dte.Solution.FindProjectItem(roslynSuppressionFilePath);
+			EnvDTE.ProjectItem? suppressionFileDteItem = dte.Solution.FindProjectItem(roslynSuppressionFilePath);
 
 			if (!TrySetBuildActionWithProjectItem(suppressionFileDteItem, buildActionToSet))
 				return false;
@@ -63,14 +63,14 @@ namespace Acuminator.Vsix.DiagnosticSuppression
 		}
 
 		#pragma warning disable VSTHRD010 // Invoke single-threaded types on Main thread
-		private bool TrySetBuildActionWithProjectItem(EnvDTE.ProjectItem suppressionFileDteItem, string buildActionToSet)
+		private bool TrySetBuildActionWithProjectItem(EnvDTE.ProjectItem? suppressionFileDteItem, string buildActionToSet)
 		{
 			if (suppressionFileDteItem == null)
 				return false;
 
 			try
 			{
-				EnvDTE.Property buildActionProperty = suppressionFileDteItem.Properties.Item("ItemType");
+				EnvDTE.Property? buildActionProperty = suppressionFileDteItem.Properties.Item("ItemType");
 
 				if (buildActionProperty == null)
 					return false;

--- a/src/Acuminator/Acuminator.Vsix/Commands/DiagnosticSuppression/BuildAction/VsixBuildActionSetterVS2019.cs
+++ b/src/Acuminator/Acuminator.Vsix/Commands/DiagnosticSuppression/BuildAction/VsixBuildActionSetterVS2019.cs
@@ -46,20 +46,26 @@ namespace Acuminator.Vsix.DiagnosticSuppression
 			var oldScheduler = TaskScheduler.Current;
 			await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
+			try
+			{
 #pragma warning disable VSTHRD010 // Invoke single-threaded types on Main thread
-			EnvDTE.DTE? dte = await AcuminatorVSPackage.Instance.GetServiceAsync<EnvDTE.DTE>();
+				EnvDTE.DTE? dte = await AcuminatorVSPackage.Instance.GetServiceAsync<EnvDTE.DTE>();
 
-			if (dte == null)
-				return false;
+				if (dte == null)
+					return false;
 #pragma warning restore VSTHRD010 // Invoke single-threaded types on Main thread
 
-			EnvDTE.ProjectItem? suppressionFileDteItem = dte.Solution.FindProjectItem(roslynSuppressionFilePath);
+				EnvDTE.ProjectItem? suppressionFileDteItem = dte.Solution.FindProjectItem(roslynSuppressionFilePath);
 
-			if (!TrySetBuildActionWithProjectItem(suppressionFileDteItem, buildActionToSet))
-				return false;
-
-			await oldScheduler;  //Return to the old scheduler
-			return true;
+				if (!TrySetBuildActionWithProjectItem(suppressionFileDteItem, buildActionToSet))
+					return false;
+			
+				return true;
+			}
+			finally
+			{
+				await oldScheduler;  //Return to the old scheduler
+			}
 		}
 
 		#pragma warning disable VSTHRD010 // Invoke single-threaded types on Main thread

--- a/src/Acuminator/Acuminator.Vsix/Commands/DiagnosticSuppression/BuildAction/VsixBuildActionSetterVS2022.cs
+++ b/src/Acuminator/Acuminator.Vsix/Commands/DiagnosticSuppression/BuildAction/VsixBuildActionSetterVS2022.cs
@@ -1,0 +1,118 @@
+﻿#nullable enable
+
+using System;
+using System.Threading.Tasks;
+using Acuminator.Utilities.Common;
+using Acuminator.Vsix.Utilities;
+using Microsoft.VisualStudio.Threading;
+using Acuminator.Utilities.DiagnosticSuppression.BuildAction;
+
+using ThreadHelper = Microsoft.VisualStudio.Shell.ThreadHelper;
+using Acuminator.Utilities;
+using Acuminator.Vsix.Logger;
+using System.Linq;
+using System.Reflection;
+
+namespace Acuminator.Vsix.DiagnosticSuppression
+{
+	/// <summary>
+	/// A helper to set Build Action for newly added suppression file in VS 2022 or newer that can't use VS COM API directy.
+	/// </summary>
+	public class VsixBuildActionSetterVS2022 : ICustomBuildActionSetter
+	{
+		public bool SetBuildAction(string roslynSuppressionFilePath, string buildActionToSet)
+		{
+			roslynSuppressionFilePath.ThrowOnNullOrWhiteSpace(nameof(roslynSuppressionFilePath));
+			buildActionToSet.ThrowOnNullOrWhiteSpace(nameof(buildActionToSet));
+
+			if (!SharedVsSettings.VSVersion.VS2022OrNewer)
+				return false;
+
+			try
+			{
+				#pragma warning disable VSTHRD104 // Offer async methods 
+				// Justification: need to use sync API since consumer is code action operation which require synchronous execution
+				// and located in the Utilities, so it can't use ThreadHelper.JoinableTaskFactory itself
+				return ThreadHelper.JoinableTaskFactory.Run(() => SetBuildActionAsync(roslynSuppressionFilePath, buildActionToSet));
+				#pragma warning restore VSTHRD104 
+			}
+			catch (Exception ex)
+			{
+				AcuminatorLogger.LogException(ex);
+				return false;
+			}
+		}
+
+		private async Task<bool> SetBuildActionAsync(string roslynSuppressionFilePath, string buildActionToSet)
+		{
+			var oldScheduler = TaskScheduler.Current;
+
+			try
+			{
+				await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+				dynamic? dte = GetDTE();
+
+				if (dte == null)
+					return false;
+
+				dynamic? suppressionFileDteItem = dte.Solution?.FindProjectItem(roslynSuppressionFilePath);
+
+				if (!TrySetBuildActionWithProjectItem(suppressionFileDteItem, buildActionToSet))
+					return false;
+
+				return true;
+			}
+			finally
+			{
+				await oldScheduler;  //Return to the old scheduler
+			}		
+		}
+
+		private bool TrySetBuildActionWithProjectItem(dynamic? suppressionFileDteItem, string buildActionToSet)
+		{
+			if (suppressionFileDteItem == null)
+				return false;
+
+			try
+			{
+				dynamic? buildActionProperty = suppressionFileDteItem.Properties?.Item("ItemType");
+
+				if (buildActionProperty == null)
+					return false;
+
+				buildActionProperty.Value = buildActionToSet;
+				return true;
+			}
+			catch (Exception ex)
+			{
+				AcuminatorLogger.LogException(ex);
+				return false;
+			}		
+		}
+
+		private static dynamic? GetDTE()
+		{
+			Assembly? interopAssembly = GetInteropAssembly();
+
+			if (interopAssembly == null)
+				return null;
+
+			string dteTypeName = typeof(EnvDTE.DTE).FullName;
+			Type? dteType = interopAssembly.ExportedTypes.FirstOrDefault(t => t.FullName == dteTypeName);
+
+			if (dteType == null)
+				return null;
+
+			var serviceProvider = AcuminatorVSPackage.Instance as IServiceProvider;
+			return serviceProvider.GetService(dteType);
+		}
+
+		private static Assembly? GetInteropAssembly()
+		{
+			const string dteAssemblyVS2022 = "Microsoft.VisualStudio.Interop";
+			return AppDomain.CurrentDomain.GetAssemblies()
+										  .FirstOrDefault(assembly => assembly.GetName().Name == dteAssemblyVS2022);
+		}
+	}
+}


### PR DESCRIPTION
Merge after https://github.com/Acumatica/Acuminator/pull/468

This PR fixes broken suppression file generation. The error was in the Build Action setter that sets the build action for the generated suppression file to "Additional files". It used VS COM API to do this task and this API was broken in VS 2022. 
A dynamic binding is used as a workaround to use COM API in VS 2022 and newer.

We didn't found this issue in 3.0.0 release when we migrated Acuminator to VS 2022 since the functionality is rarely used. 