### PR TITLE
Bugfix/atr 697 dev unit test crash

### DIFF
--- a/src/Acuminator/Acuminator.Analyzers/Acuminator.Analyzers.csproj
+++ b/src/Acuminator/Acuminator.Analyzers/Acuminator.Analyzers.csproj
@@ -3,7 +3,7 @@
     <Title>Acumatica.Analyzers</Title>
     <AssemblyTitle>Acumatica.Analyzers</AssemblyTitle>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>3.1.0</Version>
+    <Version>3.2.0</Version>
     <RepositoryUrl>https://github.com/Acumatica/Acuminator</RepositoryUrl>
     <Copyright>Copyright © 2017-2022 Acumatica Ltd.</Copyright>
     <LangVersion>9.0</LangVersion>

--- a/src/Acuminator/Acuminator.Tests/Helpers/EmbeddedFileDataAttribute.cs
+++ b/src/Acuminator/Acuminator.Tests/Helpers/EmbeddedFileDataAttribute.cs
@@ -21,28 +21,28 @@ namespace Acuminator.Tests.Helpers
 		private readonly string[] _fileNames;
 
 		public EmbeddedFileDataAttribute(string fileName, bool overloadParam = true,
-			[CallerFilePath] string testFilePath = null)
+			[CallerFilePath] string? testFilePath = null)
 			: this(new[] { fileName }, testFilePath)
 		{
 		}
 
 		public EmbeddedFileDataAttribute(string fileName1, string fileName2, bool overloadParam = true,
-			[CallerFilePath] string testFilePath = null)
+			[CallerFilePath] string? testFilePath = null)
 			: this(new[] { fileName1, fileName2 }, testFilePath)
 		{
 		}
 
 		public EmbeddedFileDataAttribute(string fileName1, string fileName2, string fileName3, bool overloadParam = true,
-			[CallerFilePath] string testFilePath = null)
+			[CallerFilePath] string? testFilePath = null)
 			: this(new[] { fileName1, fileName2, fileName3 }, testFilePath)
 		{
 		}
 		public EmbeddedFileDataAttribute(string fileName, string[] internalCodeFileNames, bool overloadParam = true,
-			[CallerFilePath] string testFilePath = null)
+			[CallerFilePath] string? testFilePath = null)
 			: this(new[] { fileName }, testFilePath, internalCodeFileNames)
 		{ }
 
-		protected EmbeddedFileDataAttribute(string[] fileNames, string testFilePath, string[] externalCodeFileNames = null)
+		protected EmbeddedFileDataAttribute(string[] fileNames, string? testFilePath, string[] externalCodeFileNames = null)
 		{
 			if (fileNames.IsNullOrEmpty())
 				throw new ArgumentNullException(nameof(fileNames));

--- a/src/Acuminator/Acuminator.Tests/Helpers/EmbeddedFileDataAttribute.cs
+++ b/src/Acuminator/Acuminator.Tests/Helpers/EmbeddedFileDataAttribute.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#nullable enable
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -45,18 +47,19 @@ namespace Acuminator.Tests.Helpers
 			if (fileNames.IsNullOrEmpty())
 				throw new ArgumentNullException(nameof(fileNames));
 
-			foreach (string fileName in fileNames)
+			foreach (string? fileName in fileNames)
 			{
-				if (String.IsNullOrWhiteSpace(fileName))
+				if (fileName.IsNullOrWhiteSpace())
 					// ReSharper disable once LocalizableElement
 					throw new ArgumentException("File name cannot be empty", nameof(fileNames));
 			}
+
 			if (!externalCodeFileNames.IsNullOrEmpty())
 			{
-				foreach (string internalCodeFileName in externalCodeFileNames)
+				foreach (string? externalCodeFileName in externalCodeFileNames)
 				{
-					if (String.IsNullOrWhiteSpace(internalCodeFileName))
-						throw new ArgumentException("File name cannot be empty", nameof(internalCodeFileName));
+					if (externalCodeFileName.IsNullOrWhiteSpace())
+						throw new ArgumentException("File name cannot be empty", nameof(externalCodeFileName));
 				}
 			}
 			
@@ -70,9 +73,9 @@ namespace Acuminator.Tests.Helpers
 			yield return _fileNames.Select(ReadFile).ToArray<object>();
 		}
 
-		private static string GetPrefixFromTestFilePath(string testFilePath)
+		private static string GetPrefixFromTestFilePath(string? testFilePath)
 		{
-			string folderFullPath = testFilePath.IsNullOrWhiteSpace()
+			string? folderFullPath = testFilePath.IsNullOrWhiteSpace()
 				? null
 				: Path.GetDirectoryName(testFilePath);
 
@@ -102,11 +105,11 @@ namespace Acuminator.Tests.Helpers
 				if (stream == null)
 					throw new InvalidOperationException($"Can't find the source text with Resource ID \"{resourceID}\" for the file {fileName}");
 		
-					using (var reader = new StreamReader(stream))
-					{
-						return reader.ReadToEnd();
-					}
-				}
+				using (var reader = new StreamReader(stream))
+				{
+					return reader.ReadToEnd();
+				}			
+			}
 		}
 
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Acuminator/Acuminator.Tests/Helpers/EmbeddedFileDataAttribute.cs
+++ b/src/Acuminator/Acuminator.Tests/Helpers/EmbeddedFileDataAttribute.cs
@@ -99,16 +99,14 @@ namespace Acuminator.Tests.Helpers
 
 			using (var stream = assembly.GetManifestResourceStream($"{_prefix}.{resourceID}"))
 			{
-				if (stream != null)
-				{
+				if (stream == null)
+					throw new InvalidOperationException($"Can't find the source text with Resource ID \"{resourceID}\" for the file {fileName}");
+		
 					using (var reader = new StreamReader(stream))
 					{
 						return reader.ReadToEnd();
 					}
 				}
-			}
-
-			return null;
 		}
 
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Acuminator/Acuminator.Tests/Helpers/EmbeddedFileDataWithParamsAttribute.cs
+++ b/src/Acuminator/Acuminator.Tests/Helpers/EmbeddedFileDataWithParamsAttribute.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿#nullable enable
+
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
@@ -12,24 +14,24 @@ namespace Acuminator.Tests.Helpers
 		private readonly object[] _args;
 
 		public EmbeddedFileDataWithParamsAttribute(string fileName, object[] args,
-			[CallerFilePath] string testFilePath = null)
+			[CallerFilePath] string? testFilePath = null)
 			: this(new[] { fileName }, args, testFilePath)
 		{
 		}
 
 		public EmbeddedFileDataWithParamsAttribute(string fileName1, string fileName2, object[] args,
-			[CallerFilePath] string testFilePath = null)
+			[CallerFilePath] string? testFilePath = null)
 			: this(new[] { fileName1, fileName2 }, args, testFilePath)
 		{
 		}
 
 		public EmbeddedFileDataWithParamsAttribute(string fileName1, string fileName2, string fileName3, object[] args,
-			[CallerFilePath] string testFilePath = null)
+			[CallerFilePath] string? testFilePath = null)
 			: this(new[] { fileName1, fileName2, fileName3 }, args, testFilePath)
 		{
 		}
 
-		protected EmbeddedFileDataWithParamsAttribute(string[] fileNames, object[] args, string testFilePath)
+		protected EmbeddedFileDataWithParamsAttribute(string[] fileNames, object[] args, string? testFilePath)
 			: base(fileNames, testFilePath)
 		{
 			_args = args;

--- a/src/Acuminator/Acuminator.Tests/Properties/AssemblyInfo.cs
+++ b/src/Acuminator/Acuminator.Tests/Properties/AssemblyInfo.cs
@@ -12,8 +12,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCopyright("Copyright © 2017-2022 Acumatica Ltd.")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
-[assembly: AssemblyVersion("3.1.0")]
-[assembly: AssemblyFileVersion("3.1.0")]
+[assembly: AssemblyVersion("3.2.0")]
+[assembly: AssemblyFileVersion("3.2.0")]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/SuppressionDiagnostics/MultipleSuppressionCodeFixTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/SuppressionDiagnostics/MultipleSuppressionCodeFixTests.cs
@@ -1,4 +1,8 @@
-﻿using Acuminator.Analyzers.StaticAnalysis;
+﻿#nullable enable
+
+using System.Threading.Tasks;
+
+using Acuminator.Analyzers.StaticAnalysis;
 using Acuminator.Analyzers.StaticAnalysis.ConstructorInDac;
 using Acuminator.Analyzers.StaticAnalysis.Dac;
 using Acuminator.Analyzers.StaticAnalysis.DacExtensionDefaultAttribute;
@@ -17,7 +21,9 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.SuppressionDiagnostics
 		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer() =>
 			new DacAnalyzersAggregator(
 				CodeAnalysisSettings.Default
-				.WithIsvSpecificAnalyzersEnabled(),
+									.WithIsvSpecificAnalyzersEnabled()
+									.WithStaticAnalysisEnabled()
+									.WithRecursiveAnalysisEnabled(),
 				new ForbiddenFieldsInDacAnalyzer(),
 				new DacExtensionDefaultAttributeAnalyzer());
 
@@ -26,32 +32,32 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.SuppressionDiagnostics
 		[Theory]
 		[EmbeddedFileData(@"Dac\SuppressMuiltipleDiagnostics_All.cs",
 			@"Dac\SuppressMuiltipleDiagnostics_All_Suppressed.cs")]
-		public virtual void SuppressMuiltipleDiagnostics_All_CodeFix(string actual, string expected) =>
-			VerifyCSharpFix(actual, expected);
+		public virtual Task SuppressMuiltipleDiagnostics_All_CodeFix(string actual, string expected) => 
+			VerifyCSharpFixAsync(actual, expected);
 
 		[Theory]
 		[EmbeddedFileData(@"Dac\SuppressMuiltipleDiagnostics_One.cs",
 		@"Dac\SuppressMuiltipleDiagnostics_One_Suppressed.cs")]
-		public virtual void SuppressMuiltipleDiagnostics_One_CodeFix(string actual, string expected) =>
-			VerifyCSharpFix(actual, expected);
+		public virtual Task SuppressMuiltipleDiagnostics_One_CodeFix(string actual, string expected) =>
+			VerifyCSharpFixAsync(actual, expected);
 
 		[Theory]
 		[EmbeddedFileData(@"Dac\SuppressMuiltipleDiagnostics_All.cs")]
-		public virtual void ShowAllUnsuppressedDiagnostics(string source) =>
-			VerifyCSharpDiagnostic(source,
+		public virtual Task ShowAllUnsuppressedDiagnostics(string source) =>
+			VerifyCSharpDiagnosticAsync(source,
 				Descriptors.PX1027_ForbiddenFieldsInDacDeclaration.CreateFor(line: 13, column: 25,  messageArgs: "companyMask"),
 				Descriptors.PX1030_DefaultAttibuteToExistingRecordsOnDAC.CreateFor(line: 14, column: 4),
 				Descriptors.PX1027_ForbiddenFieldsInDacDeclaration.CreateFor(line: 16, column: 17, messageArgs : "CompanyMask"));
 
 		[Theory]
 		[EmbeddedFileData(@"Dac\SuppressMuiltipleDiagnostics_One.cs")]
-		public virtual void ShowUnsuppressedDiagnostic(string source) =>
-			VerifyCSharpDiagnostic(source,
+		public virtual Task ShowUnsuppressedDiagnostic(string source) =>
+			VerifyCSharpDiagnosticAsync(source,
 				Descriptors.PX1030_DefaultAttibuteToExistingRecordsOnDAC.CreateFor(line: 16, column: 4));
 
 		[Theory]
 		[EmbeddedFileData(@"Dac\SuppressMuiltipleDiagnostics_One_Suppressed.cs")]
-		public virtual void SuppressMultipleDiagnostics(string source) =>
-			VerifyCSharpDiagnostic(source);
+		public virtual Task SuppressMultipleDiagnostics(string source) =>
+			VerifyCSharpDiagnosticAsync(source);
 	}
 }

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/SuppressionDiagnostics/SuppressionCommentTriviaCodeFixTest.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/SuppressionDiagnostics/SuppressionCommentTriviaCodeFixTest.cs
@@ -1,4 +1,7 @@
-﻿using Acuminator.Analyzers.StaticAnalysis;
+﻿#nullable enable
+
+using System.Threading.Tasks;
+
 using Acuminator.Analyzers.StaticAnalysis.BqlParameterMismatch;
 using Acuminator.Tests.Helpers;
 using Acuminator.Tests.Verification;
@@ -19,51 +22,51 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.SuppressionDiagnostics
 
 		[Theory]
 		[EmbeddedFileData(@"BqlParameterMismatch\StaticCall_Suppressed.cs")]
-		public virtual void StaticCalls_Suppressed(string source) =>
-			VerifyCSharpDiagnostic(source);
+		public virtual Task StaticCalls_Suppressed(string source) =>
+			VerifyCSharpDiagnosticAsync(source);
 
 
 		[Theory]
 		[EmbeddedFileData(@"BqlParameterMismatch\StaticCall.cs", 
 						  @"BqlParameterMismatch\StaticCall_Suppressed.cs")]
-		public virtual void StaticCalls_CodeFix(string actual, string expected) =>
-			VerifyCSharpFix(actual, expected);
+		public virtual Task StaticCalls_CodeFix(string actual, string expected) =>
+			VerifyCSharpFixAsync(actual, expected);
 
 		[Theory]
 		[EmbeddedFileData(@"BqlParameterMismatch\StaticCallWithCustomPredicate_Suppressed.cs")]
-		public virtual void StaticCall_WithCustomPredicates_Suppressed(string source) =>
-			VerifyCSharpDiagnostic(source);
+		public virtual Task StaticCall_WithCustomPredicates_Suppressed(string source) =>
+			VerifyCSharpDiagnosticAsync(source);
 
 		[Theory]
 		[EmbeddedFileData(@"BqlParameterMismatch\StaticCallWithCustomPredicate.cs",
 						  @"BqlParameterMismatch\StaticCallWithCustomPredicate_Suppressed.cs")]
-		public virtual void StaticCall_WithCustomPredicates_CodeFix(string actual, string expected) =>
-			VerifyCSharpFix(actual, expected);
+		public virtual Task StaticCall_WithCustomPredicates_CodeFix(string actual, string expected) =>
+			VerifyCSharpFixAsync(actual, expected);
 
 		[Theory]
 		[EmbeddedFileData(@"BqlParameterMismatch\InheritanceCall_Suppressed.cs")]
-		public virtual void InheritanceCalls_InstanceAndStatic_Suppressed(string source) => 
-			VerifyCSharpDiagnostic(source);
+		public virtual Task InheritanceCalls_InstanceAndStatic_Suppressed(string source) => 
+			VerifyCSharpDiagnosticAsync(source);
 
 		[Theory]
 		[EmbeddedFileData(@"BqlParameterMismatch\InheritanceCall.cs",
 						  @"BqlParameterMismatch\InheritanceCall_Suppressed.cs")]
-		public virtual void InheritanceCalls_InstanceAndStatic_CodeFix(string actual, string expected) =>
-			VerifyCSharpFix(actual, expected);
+		public virtual Task InheritanceCalls_InstanceAndStatic_CodeFix(string actual, string expected) =>
+			VerifyCSharpFixAsync(actual, expected);
 
 		[Theory]
 		[EmbeddedFileData(@"BqlParameterMismatch\PXUpdateCall_Suppressed.cs", @"BqlParameterMismatch\SOOrder.cs")]
-		public virtual void PXUpdateCalls_Suppressed(string source, string dacSource) =>
-			VerifyCSharpDiagnostic(new[] { source, dacSource });
+		public virtual Task PXUpdateCalls_Suppressed(string source, string dacSource) =>
+			VerifyCSharpDiagnosticAsync(new[] { source, dacSource });
 		
 		[Theory]
 		[EmbeddedFileData(@"BqlParameterMismatch\SearchCall_Suppressed.cs", @"BqlParameterMismatch\SOOrder.cs")]
-		public virtual void SearchCalls_Suppressed(string source, string dacSource) =>
-			VerifyCSharpDiagnostic(new[] { source, dacSource });
+		public virtual Task SearchCalls_Suppressed(string source, string dacSource) =>
+			VerifyCSharpDiagnosticAsync(new[] { source, dacSource });
 
 		[Theory]
 		[EmbeddedFileData(@"BqlParameterMismatch\VariableInstanceCall_Suppressed.cs", @"BqlParameterMismatch\SOOrder.cs")]
-		public virtual void VariableInstanceCalls_Suppressed(string source, string dacSource) =>
-			VerifyCSharpDiagnostic(new[] { source, dacSource });
+		public virtual Task VariableInstanceCalls_Suppressed(string source, string dacSource) =>
+			VerifyCSharpDiagnosticAsync(new[] { source, dacSource });
 	}
 }

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/SuppressionDiagnostics/SuppressionOnDacCodeFixTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/SuppressionDiagnostics/SuppressionOnDacCodeFixTests.cs
@@ -26,10 +26,9 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.SuppressionDiagnostics
 		protected override CodeFixProvider GetCSharpCodeFixProvider() => new SuppressDiagnosticTestCodeFix();
 
 		[Theory]
-		[EmbeddedFileData(@"Dac\ForbiddenFields_Suppressed.cs")]
+		[EmbeddedFileData(@"Dac\ForbiddenFieldsSuppressComment_Expected.cs")]
 		public virtual void DacForbiddenFields_Suppressed(string source) =>
-			VerifyCSharpDiagnosticAsync(source,
-				Descriptors.PX1027_ForbiddenFieldsInDacDeclaration.CreateFor(17, 17, "CompanyID"));
+			VerifyCSharpDiagnosticAsync(source);
 
 		[Theory]
 		[EmbeddedFileData(@"Dac\WithConstructor_Unsuppressed.cs")]

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/SuppressionDiagnostics/SuppressionOnDacCodeFixTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/SuppressionDiagnostics/SuppressionOnDacCodeFixTests.cs
@@ -1,12 +1,18 @@
-﻿using Acuminator.Analyzers.StaticAnalysis;
+﻿#nullable enable
+
+using System.Threading.Tasks;
+
+using Acuminator.Analyzers.StaticAnalysis;
 using Acuminator.Analyzers.StaticAnalysis.ConstructorInDac;
 using Acuminator.Analyzers.StaticAnalysis.Dac;
 using Acuminator.Analyzers.StaticAnalysis.ForbiddenFieldsInDac;
 using Acuminator.Tests.Helpers;
 using Acuminator.Tests.Verification;
 using Acuminator.Utilities;
+
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Diagnostics;
+
 using Xunit;
 
 namespace Acuminator.Tests.Tests.StaticAnalysis.SuppressionDiagnostics
@@ -27,26 +33,26 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.SuppressionDiagnostics
 
 		[Theory]
 		[EmbeddedFileData(@"Dac\ForbiddenFieldsSuppressComment_Expected.cs")]
-		public virtual void DacForbiddenFields_Suppressed(string source) =>
+		public virtual Task DacForbiddenFields_Suppressed(string source) =>
 			VerifyCSharpDiagnosticAsync(source);
 
 		[Theory]
 		[EmbeddedFileData(@"Dac\WithConstructor_Unsuppressed.cs")]
-		public virtual void DacWithConstructor_SuppressSomeCases(string source) =>
-			VerifyCSharpDiagnostic(source,
+		public virtual Task DacWithConstructor_SuppressSomeCases(string source) =>
+			VerifyCSharpDiagnosticAsync(source,
 				Descriptors.PX1028_ConstructorInDacDeclaration.CreateFor(line: 18, column: 10),
 				Descriptors.PX1028_ConstructorInDacDeclaration.CreateFor(line: 95, column: 10));
 
 		[Theory]
 		[EmbeddedFileData(@"Dac\ForbiddenFields.cs",
 			@"Dac\ForbiddenFieldsSuppressComment_Expected.cs")]
-		public virtual void DacWithForbidden_SuppressComment_CodeFix(string actual, string expected) =>
-			VerifyCSharpFix(actual, expected);
+		public virtual Task DacWithForbidden_SuppressComment_CodeFix(string actual, string expected) =>
+			VerifyCSharpFixAsync(actual, expected);
 
 		[Theory]
 		[EmbeddedFileData(@"Dac\WithConstructor.cs",
 			@"Dac\WithConstructorSuppressComment_Expected.cs")]
-		public virtual void DacWithConstructor_SuppressComment_CodeFix(string actual, string expected) =>
-			VerifyCSharpFix(actual, expected);
+		public virtual Task DacWithConstructor_SuppressComment_CodeFix(string actual, string expected) =>
+			VerifyCSharpFixAsync(actual, expected);
 	}
 }

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/SuppressionDiagnostics/SuppressionOnMissingIsActiveMethodCodeFixTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/SuppressionDiagnostics/SuppressionOnMissingIsActiveMethodCodeFixTests.cs
@@ -1,4 +1,8 @@
-﻿using Acuminator.Analyzers.StaticAnalysis.Dac;
+﻿#nullable enable
+
+using System.Threading.Tasks;
+
+using Acuminator.Analyzers.StaticAnalysis.Dac;
 using Acuminator.Analyzers.StaticAnalysis.NoIsActiveMethodForExtension;
 using Acuminator.Tests.Helpers;
 using Acuminator.Tests.Verification;
@@ -21,7 +25,7 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.SuppressionDiagnostics
 
 		[Theory]
 		[EmbeddedFileData(@"Dac\DacExtension_WithoutIsActive.cs", @"Dac\DacExtension_WithoutIsActive_Expected.cs")]
-		public virtual void DacExtension_WithoutIsActiveMethod_SuppressComment_CodeFix(string actual, string expected) =>
-			VerifyCSharpFix(actual, expected);
+		public virtual Task DacExtension_WithoutIsActiveMethod_SuppressComment_CodeFix(string actual, string expected) =>
+			VerifyCSharpFixAsync(actual, expected);
 	}
 }

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/SuppressionDiagnostics/SuppressionOnMissingXmlCommentCodeFixTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/SuppressionDiagnostics/SuppressionOnMissingXmlCommentCodeFixTests.cs
@@ -1,4 +1,8 @@
-﻿using Acuminator.Analyzers.StaticAnalysis.PublicClassXmlComment;
+﻿#nullable enable
+
+using System.Threading.Tasks;
+
+using Acuminator.Analyzers.StaticAnalysis.PublicClassXmlComment;
 using Acuminator.Tests.Helpers;
 using Acuminator.Tests.Verification;
 using Acuminator.Utilities;
@@ -22,7 +26,7 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.SuppressionDiagnostics
 
 		[Theory]
 		[EmbeddedFileData(@"Dac\DAC_Without_XML_Description.cs", @"Dac\DAC_Without_XML_Description_Expected.cs")]
-		public virtual void DacWithoutXMLDescription_SuppressComment_CodeFix(string actual, string expected) =>
-			VerifyCSharpFix(actual, expected);
+		public virtual Task DacWithoutXMLDescription_SuppressComment_CodeFix(string actual, string expected) =>
+			VerifyCSharpFixAsync(actual, expected);
 	}
 }

--- a/src/Acuminator/Acuminator.Utilities/Acuminator.Utilities.csproj
+++ b/src/Acuminator/Acuminator.Utilities/Acuminator.Utilities.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>3.1.0</Version>
+    <Version>3.2.0</Version>
     <Copyright>Copyright © 2017-2022 Acumatica Ltd.</Copyright>
     <NeutralLanguage>en</NeutralLanguage>
     <Description>Acuminator.Utilities lib</Description>

--- a/src/Acuminator/Acuminator.Vsix/AcuminatorVSPackage.cs
+++ b/src/Acuminator/Acuminator.Vsix/AcuminatorVSPackage.cs
@@ -128,6 +128,10 @@ namespace Acuminator.Vsix
 		/// <returns/>
 		public static async System.Threading.Tasks.Task ForceLoadPackageAsync()
 		{
+			// In unit tests this can be null
+			if (ThreadHelper.JoinableTaskFactory == null)
+				return;
+
 			await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
 			IVsShell shell = await VS.GetServiceAsync<SVsShell, IVsShell>();

--- a/src/Acuminator/Acuminator.Vsix/AcuminatorVSPackage.cs
+++ b/src/Acuminator/Acuminator.Vsix/AcuminatorVSPackage.cs
@@ -69,7 +69,7 @@ namespace Acuminator.Vsix
 		private const string SettingsCategoryName = SharedConstants.PackageName;
 
 		public const string PackageName = SharedConstants.PackageName;
-		public const string PackageVersion = "3.1.0";
+		public const string PackageVersion = "3.2.0";
 
 		/// <summary>
 		/// AcuminatorVSPackage GUID string.

--- a/src/Acuminator/Acuminator.Vsix/Properties/AssemblyInfo.cs
+++ b/src/Acuminator/Acuminator.Vsix/Properties/AssemblyInfo.cs
@@ -9,5 +9,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 [assembly: ComVisible(false)]
-[assembly: AssemblyVersion("3.1.0")]
-[assembly: AssemblyFileVersion("3.1.0")]
+[assembly: AssemblyVersion("3.2.0")]
+[assembly: AssemblyFileVersion("3.2.0")]

--- a/src/Acuminator/Acuminator.Vsix/source.extension.vsixmanifest
+++ b/src/Acuminator/Acuminator.Vsix/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="Acumatica.Acuminator.778b19d1-1d5e-4fcb-8edb-eb103feeab7c" Version="3.1.0" Language="en-US" Publisher="Acumatica" />
+        <Identity Id="Acumatica.Acuminator.778b19d1-1d5e-4fcb-8edb-eb103feeab7c" Version="3.2.0" Language="en-US" Publisher="Acumatica" />
         <DisplayName>Acuminator</DisplayName>
         <Description xml:space="preserve">Acuminator is a Visual Studio extension that simplifies development with Acumatica Framework.  Acuminator provides the following functionality to boost developer productivity:
 - Static code analysis diagnostics, code fixes, and refactorings


### PR DESCRIPTION
Overview:
- Added error throwing when there is no test source file for the path specified in the test
- Fixed test without file
- Enhanced error processing for forced package load, fixed NRE
- Fixed async tests + added async to old tests