### PR TITLE
ATR-714: modified test sources to check constants declared in DACs

### DIFF
--- a/src/Acuminator/Acuminator.Tests/Acuminator.Tests.csproj
+++ b/src/Acuminator/Acuminator.Tests/Acuminator.Tests.csproj
@@ -529,6 +529,7 @@
     <EmbeddedResource Include="Tests\StaticAnalysis\ViewDeclarationOrder\Sources\ViewDeclarationOrderWithGraphExtension.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\ViewDeclarationOrder\Sources\ViewDeclarationOrderWithGraphInheritance_OneCache.cs" />
     <EmbeddedResource Include="Tests\Utilities\AttributeInformation\Sources\PropertyIsDBBoundFieldInheritedFromPXObjects.cs" />
+    <EmbeddedResource Include="Tests\StaticAnalysis\UnderscoresInDac\Sources\DacWithUnderscores_Expected.cs" />
     <Compile Include="Tests\StaticAnalysis\ViewDeclarationOrder\ViewDeclarationOrder_CheckForVersionTests.cs" />
     <Compile Include="Tests\Utilities\CodeAnalysisSettingsSerialization\CodeAnalysisSettingsSerializationTests.cs" />
     <Compile Include="Tests\Utilities\Version\PackageVersionTests.cs" />
@@ -606,7 +607,6 @@
     <EmbeddedResource Include="Tests\StaticAnalysis\UnderscoresInDac\Sources\DacWithUnderscores.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\UnderscoresInDac\Sources\DacExtensionWithUnderscores.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\UnderscoresInDac\Sources\DacExtensionWithUnderscores_Expected.cs" />
-    <EmbeddedResource Include="Tests\StaticAnalysis\UnderscoresInDac\Sources\DacWithUnderscores_Expected.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\ForbiddenFieldsInDac\Sources\DacForbiddenFields.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\ForbiddenFieldsInDac\Sources\DacForbiddenFields_Expected.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\ConstructorInDac\Sources\DacWithConstructor_Expected.cs" />

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/UnderscoresInDac/Sources/DacWithUnderscores.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/UnderscoresInDac/Sources/DacWithUnderscores.cs
@@ -53,5 +53,8 @@ namespace PX.Objects.HackathonDemo
 		{
 		}
 		#endregion
+
+		// Check that there is no alert for constant fields
+		public const int DASHBOARD_TYPE = 7; 
 	}
 }

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/UnderscoresInDac/Sources/DacWithUnderscores_Expected.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/UnderscoresInDac/Sources/DacWithUnderscores_Expected.cs
@@ -53,5 +53,8 @@ namespace PX.Objects.HackathonDemo
 		{
 		}
 		#endregion
+
+		// Check that there is no alert for constant fields
+		public const int DASHBOARD_TYPE = 7; 
 	}
 }


### PR DESCRIPTION
There is no bug. The bug was created after an old false alert suppression in the suppression file. The issue is no longer present. 
This PR updates test sources to check for constants with underscores declared in DAC