### PR TITLE
Bugfix/atr 715 dev px1050 false alert px exception constructor with format

### DIFF
--- a/src/Acuminator/Acuminator.Tests/Acuminator.Tests.csproj
+++ b/src/Acuminator/Acuminator.Tests/Acuminator.Tests.csproj
@@ -529,6 +529,7 @@
     <EmbeddedResource Include="Tests\StaticAnalysis\ViewDeclarationOrder\Sources\ViewDeclarationOrderWithGraphExtension.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\ViewDeclarationOrder\Sources\ViewDeclarationOrderWithGraphInheritance_OneCache.cs" />
     <EmbeddedResource Include="Tests\Utilities\AttributeInformation\Sources\PropertyIsDBBoundFieldInheritedFromPXObjects.cs" />
+    <EmbeddedResource Include="Tests\StaticAnalysis\UnderscoresInDac\Sources\DacWithUnderscores_Expected.cs" />
     <Compile Include="Tests\StaticAnalysis\ViewDeclarationOrder\ViewDeclarationOrder_CheckForVersionTests.cs" />
     <Compile Include="Tests\Utilities\CodeAnalysisSettingsSerialization\CodeAnalysisSettingsSerializationTests.cs" />
     <Compile Include="Tests\Utilities\Version\PackageVersionTests.cs" />
@@ -606,7 +607,6 @@
     <EmbeddedResource Include="Tests\StaticAnalysis\UnderscoresInDac\Sources\DacWithUnderscores.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\UnderscoresInDac\Sources\DacExtensionWithUnderscores.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\UnderscoresInDac\Sources\DacExtensionWithUnderscores_Expected.cs" />
-    <EmbeddedResource Include="Tests\StaticAnalysis\UnderscoresInDac\Sources\DacWithUnderscores_Expected.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\ForbiddenFieldsInDac\Sources\DacForbiddenFields.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\ForbiddenFieldsInDac\Sources\DacForbiddenFields_Expected.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\ConstructorInDac\Sources\DacWithConstructor_Expected.cs" />

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/Localization/LocalizationExceptionTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/Localization/LocalizationExceptionTests.cs
@@ -27,9 +27,14 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.Localization
 		public async Task Localization_PXException_WithHardcodedMessageArgument(string source)
 		{
 			await VerifyCSharpDiagnosticAsync(source,
-				Descriptors.PX1050_HardcodedStringInLocalizationMethod.CreateFor(9, 45),
-				Descriptors.PX1050_HardcodedStringInLocalizationMethod.CreateFor(16, 75),
-				Descriptors.PX1050_HardcodedStringInLocalizationMethod.CreateFor(24, 20));
+				Descriptors.PX1050_HardcodedStringInLocalizationMethod.CreateFor(10, 45),
+				Descriptors.PX1050_HardcodedStringInLocalizationMethod.CreateFor(17, 75),
+				Descriptors.PX1050_HardcodedStringInLocalizationMethod.CreateFor(22, 36),
+				Descriptors.PX1050_HardcodedStringInLocalizationMethod.CreateFor(30, 67),
+				Descriptors.PX1053_ConcatenationPriorLocalization.CreateFor(35, 36),
+				Descriptors.PX1053_ConcatenationPriorLocalization.CreateFor(43, 67),
+				Descriptors.PX1050_HardcodedStringInLocalizationMethod.CreateFor(66, 20),
+				Descriptors.PX1053_ConcatenationPriorLocalization.CreateFor(72, 11));
 		}
 
 		[Theory]

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/Localization/Sources/LocalizationExceptionWithHardcodedStrings.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/Localization/Sources/LocalizationExceptionWithHardcodedStrings.cs
@@ -1,4 +1,5 @@
-﻿using PX.Data;
+﻿using PX.Common;
+using PX.Data;
 
 namespace Acuminator.Tests.Sources
 {
@@ -15,9 +16,50 @@ namespace Acuminator.Tests.Sources
 
             throw new PXArgumentException(nameof(ExceptionsLocalization), "Usernames cannot contain commas.");
         }
-    }
 
-    public class DetailNonLocalizableBypassedException : PXException
+		public void CheckUserName_Bad(string userName)
+		{
+			PXException e = new PXException("Username {0} starts with PX prefix.", userName);
+
+			if (userName.StartsWith("PX"))
+			{
+				throw e;
+			}
+
+			if (userName.Contains(","))
+				throw new PXArgumentException(nameof(ExceptionsLocalization), "Username {0} contains comma.", userName);
+		}
+
+		public void CheckUserName_StringFormatBad(string userName)
+		{
+			PXException e = new PXException(string.Format(Messages.ErrorPXPrefixFormatMsg, userName));
+
+			if (userName.StartsWith("PX"))
+			{
+				throw e;
+			}
+
+			if (userName.Contains(","))
+				throw new PXArgumentException(nameof(ExceptionsLocalization), string.Format(Messages.ErrorCommaFormatMsg, userName));
+		}
+
+		public void CheckUserName_Good(string userName)
+		{
+			PXException e = new PXException(Messages.ErrorPXPrefixFormatMsg, userName);
+
+			if (userName.StartsWith("PX"))
+			{
+				throw e;
+			}
+
+			if (userName.Contains(","))
+				throw new PXArgumentException(nameof(ExceptionsLocalization), Messages.ErrorCommaFormatMsg, userName);
+		}		
+	}
+
+	// Acuminator disable once PX1063 ExceptionWithoutSerializationConstructor [Justification]
+	// Acuminator disable once PX1064 ExceptionWithNewFieldsAndNoGetObjectDataOverride [Justification]
+	public class DetailNonLocalizableBypassedException : PXException
     {
         public object ItemToBypass { get; }
         public DetailNonLocalizableBypassedException(object itemToBypass)
@@ -25,5 +67,18 @@ namespace Acuminator.Tests.Sources
         {
             ItemToBypass = itemToBypass;
         }
-    }
+
+		public DetailNonLocalizableBypassedException(string userName)
+			: base(string.Format(Messages.ErrorCommaFormatMsg, userName))
+		{
+			ItemToBypass = userName;
+		}
+	}
+
+	[PXLocalizable]
+	public static class Messages
+	{
+		public const string ErrorPXPrefixFormatMsg = "Username {0} starts with PX prefix.";
+		public const string ErrorCommaFormatMsg = "Username {0} contains comma.";
+	}
 }

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/UnderscoresInDac/Sources/DacWithUnderscores.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/UnderscoresInDac/Sources/DacWithUnderscores.cs
@@ -53,5 +53,8 @@ namespace PX.Objects.HackathonDemo
 		{
 		}
 		#endregion
+
+		// Check that there is no alert for constant fields
+		public const int DASHBOARD_TYPE = 7; 
 	}
 }

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/UnderscoresInDac/Sources/DacWithUnderscores_Expected.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/UnderscoresInDac/Sources/DacWithUnderscores_Expected.cs
@@ -53,5 +53,8 @@ namespace PX.Objects.HackathonDemo
 		{
 		}
 		#endregion
+
+		// Check that there is no alert for constant fields
+		public const int DASHBOARD_TYPE = 7; 
 	}
 }


### PR DESCRIPTION
Merge after https://github.com/Acumatica/Acuminator/pull/478

Not a bug, the described behavior is expected. PR updates unit tests