### PR TITLE
Bugfix/atr 724 dev support pxentityattribute

### DIFF
--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Constants/TypeFullNames.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Constants/TypeFullNames.cs
@@ -13,8 +13,10 @@
 		internal const string AutoNumberAttribute = "PX.Objects.CS.AutoNumberAttribute";
 		internal const string NumberingSequence = "PX.Objects.CS.NumberingSequence";
 
+		internal const string PXEntityAttribute = "PX.Data.PXEntityAttribute";
 		internal const string PeriodIDAttribute = "PX.Objects.GL.PeriodIDAttribute";
 		internal const string AcctSubAttribute = "PX.Objects.GL.AcctSubAttribute";
+		internal const string UnboundAccountAttribute = "PX.Objects.GL.UnboundAccountAttribute";
 		internal const string PXDBCalcedAttribute = "PX.Data.PXDBCalcedAttribute";
 		internal const string PXDBScalarAttribute = "PX.Data.PXDBScalarAttribute";
 		internal const string PXDBUserPasswordAttribute = "PX.Data.PXDBUserPasswordAttribute";

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/PXFieldAttributes/AttributeInformation.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/PXFieldAttributes/AttributeInformation.cs
@@ -73,6 +73,12 @@ namespace Acuminator.Utilities.Roslyn.PXFieldAttributes
 			if (context.FieldAttributes.AcctSubAttribute != null)
 				types.Add(context.FieldAttributes.AcctSubAttribute, true);
 
+			if (context.FieldAttributes.PXEntityAttribute != null)
+				types.Add(context.FieldAttributes.PXEntityAttribute, true);
+
+			if (context.FieldAttributes.UnboundAccountAttribute != null)
+				types.Add(context.FieldAttributes.UnboundAccountAttribute, false);
+
 			return types;
 		}
 			

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/PXFieldAttributes/AttributeInformation.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/PXFieldAttributes/AttributeInformation.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#nullable enable
+
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -29,7 +31,7 @@ namespace Acuminator.Utilities.Roslyn.PXFieldAttributes
 		public PXContext Context { get; }
 
 		public ImmutableHashSet<ITypeSymbol> BoundBaseTypes { get; }
-		public ImmutableDictionary<ITypeSymbol,bool> TypesContainingIsDBField { get; }
+		public ImmutableArray<(ITypeSymbol AttributeType, bool IsDbFieldDefaultValue)> TypesContainingIsDBField { get; }
 
 		private const string IsDBField = "IsDBField";
 		private const string NonDB = "NonDB";
@@ -38,7 +40,9 @@ namespace Acuminator.Utilities.Roslyn.PXFieldAttributes
 		{
 			Context = pxContext.CheckIfNull(nameof(pxContext));
 			BoundBaseTypes = GetBoundBaseTypes(Context).ToImmutableHashSet();
-			TypesContainingIsDBField = GetTypesContainingIsDBField(Context).ToImmutableDictionary();
+			TypesContainingIsDBField = GetTypesContainingIsDBField(Context)
+											.OrderBy(typeWithValue => typeWithValue.AttributeType, TypeSymbolsByHierachyComparer.Instance)
+											.ToImmutableArray();
 
 			_eventSubscriberAttribute = Context.AttributeTypes.PXEventSubscriberAttribute;
 			_dynamicAggregateAttribute = Context.AttributeTypes.PXDynamicAggregateAttribute;
@@ -63,23 +67,19 @@ namespace Acuminator.Utilities.Roslyn.PXFieldAttributes
 			return types;
 		}
 
-		private static Dictionary<ITypeSymbol, bool> GetTypesContainingIsDBField(PXContext context)
+		private static IEnumerable<(ITypeSymbol AttributeType, bool IsDbFieldDefaultValue)> GetTypesContainingIsDBField(PXContext context)
 		{
-			var types = new Dictionary<ITypeSymbol, bool>();
-
 			if (context.FieldAttributes.PeriodIDAttribute != null)
-				types.Add(context.FieldAttributes.PeriodIDAttribute, true);
+				yield return (context.FieldAttributes.PeriodIDAttribute, true);
 
 			if (context.FieldAttributes.AcctSubAttribute != null)
-				types.Add(context.FieldAttributes.AcctSubAttribute, true);
-
-			if (context.FieldAttributes.PXEntityAttribute != null)
-				types.Add(context.FieldAttributes.PXEntityAttribute, true);
+				yield return (context.FieldAttributes.AcctSubAttribute, true);
 
 			if (context.FieldAttributes.UnboundAccountAttribute != null)
-				types.Add(context.FieldAttributes.UnboundAccountAttribute, false);
+				yield return (context.FieldAttributes.UnboundAccountAttribute, false);
 
-			return types;
+			if (context.FieldAttributes.PXEntityAttribute != null)
+				yield return (context.FieldAttributes.PXEntityAttribute, true);		
 		}
 			
 
@@ -139,7 +139,7 @@ namespace Acuminator.Utilities.Roslyn.PXFieldAttributes
 				{
 					aggregatedAttribute.GetBaseTypes()
 									   .TakeWhile(baseType => !baseType.Equals(_eventSubscriberAttribute))
-									   .ForEach(baseType => results.Add(baseType));
+									   .ForEach(baseType => results.Add(baseType!));
 				}
 
 				if (IsAggregatorAttribute(aggregatedAttribute))
@@ -203,12 +203,13 @@ namespace Acuminator.Utilities.Roslyn.PXFieldAttributes
 			switch (isDbPropertyAttributeArgs.Count)
 			{
 				case 0:     //Case when there is IsDBField property but it isn't set explicitly in attribute's declaration
-					ITypeSymbol typeFromRegister = TypesContainingIsDBField.Keys.FirstOrDefault(t => IsAttributeDerivedFromClass(attribute.AttributeClass, t));
+					var (typeFromRegister, defaultIsDbFieldValue) = 
+						TypesContainingIsDBField.FirstOrDefault(typeWithValue => IsAttributeDerivedFromClass(attribute.AttributeClass, typeWithValue.AttributeType));
 
 					// Query hard-coded register with attributes which has IsDBField property with some initial assigned value
 					bool? dbFieldPreInitializedValue = typeFromRegister != null
-						? TypesContainingIsDBField[typeFromRegister]
-						: (bool?)null;
+						? defaultIsDbFieldValue
+						: null;
 
 					return dbFieldPreInitializedValue == null
 						? GetBoundTypeFromStandardBoundTypeAttributes(attribute)

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/PXFieldAttributes/TypeSymbolsByHierachyComparer.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/PXFieldAttributes/TypeSymbolsByHierachyComparer.cs
@@ -1,0 +1,49 @@
+﻿#nullable enable
+
+using System;
+using System.Collections.Generic;
+
+using Acuminator.Utilities.Common;
+using Acuminator.Utilities.Roslyn.Semantic;
+
+using Microsoft.CodeAnalysis;
+
+namespace Acuminator.Utilities.Roslyn.PXFieldAttributes
+{
+	/// <summary>
+	/// A type symbols comparer that compares them by their position in class hierarhy and makes sure that derived types go before their base types. 
+	/// Does not work for interfaces.
+	/// </summary>
+	internal class TypeSymbolsByHierachyComparer : IComparer<ITypeSymbol>
+	{
+		public static TypeSymbolsByHierachyComparer Instance { get; } = new TypeSymbolsByHierachyComparer();
+
+		private TypeSymbolsByHierachyComparer()
+		{ }
+
+		/// <summary>
+		/// Compares two type symbols objects to determine their relative ordering.<br/>
+		/// If <paramref name="x"/> is derived from <paramref name="y"/> returns <c>-1</c> to make <paramref name="x"/> go before <paramref name="y"/>.<br/>
+		/// If <paramref name="y"/> is derived from <paramref name="x"/> returns <c>1</c> to make <paramref name="x"/> go after <paramref name="y"/>.<br/>
+		/// If <paramref name="x"/> and <paramref name="y"/> are not related returns <c>0</c>.<br/>
+		/// </summary>
+		/// <param name="x">First type symbol to be compared.</param>
+		/// <param name="y">Second type symbol to be compared.</param>
+		/// <returns>
+		/// If <paramref name="x"/> is derived from <paramref name="y"/> returns <c>-1</c> to make <paramref name="x"/> go before <paramref name="y"/>.<br/>
+		/// If <paramref name="y"/> is derived from <paramref name="x"/> returns <c>1</c> to make <paramref name="x"/> go after <paramref name="y"/>.<br/>
+		/// If <paramref name="x"/> and <paramref name="y"/> are not related returns <c>0</c>.<br/>
+		/// </returns>
+		public int Compare(ITypeSymbol x, ITypeSymbol y)
+		{
+			if (x.Equals(y))
+				return 0;
+			else if (x.InheritsFrom(y))
+				return -1;
+			else if (y.InheritsFrom(x))
+				return 1;
+			else
+				return 0;
+		}
+	}
+}

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/Symbols/Attributes/FieldAttributeSymbols.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/Symbols/Attributes/FieldAttributeSymbols.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.CodeAnalysis;
+﻿#nullable enable
+
+using Microsoft.CodeAnalysis;
 using Acuminator.Utilities.Roslyn.Constants;
 
 namespace Acuminator.Utilities.Roslyn.Semantic.Symbols
@@ -60,8 +62,10 @@ namespace Acuminator.Utilities.Roslyn.Semantic.Symbols
 
 		#region DBBound  attributes defined by IsDBField 
 
-		public INamedTypeSymbol PeriodIDAttribute => Compilation.GetTypeByMetadataName(TypeFullNames.PeriodIDAttribute);
-		public INamedTypeSymbol AcctSubAttribute => Compilation.GetTypeByMetadataName(TypeFullNames.AcctSubAttribute);
+		public INamedTypeSymbol? PeriodIDAttribute => Compilation.GetTypeByMetadataName(TypeFullNames.PeriodIDAttribute);
+		public INamedTypeSymbol? AcctSubAttribute => Compilation.GetTypeByMetadataName(TypeFullNames.AcctSubAttribute);
+		public INamedTypeSymbol? PXEntityAttribute => Compilation.GetTypeByMetadataName(TypeFullNames.PXEntityAttribute);
+		public INamedTypeSymbol? UnboundAccountAttribute => Compilation.GetTypeByMetadataName(TypeFullNames.UnboundAccountAttribute);
 
 		#endregion
 	}


### PR DESCRIPTION
Overview:
- Added `PXEntityAttribute`  and `UnboundAccountAttribute`  to the hard-coded register of attributes with `IsDBField` property
- Added ordering of the hard-coded register of attributes  by type's hierarchy
- Reworked logic deducing the default `IsDBField` value to rely on the proper order of types in the attributes registry