### PR TITLE
Bugfix/atr 708 dev px1018 false alert

### DIFF
--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/NoIsActiveMethodForExtension/NoIsActiveMethodForExtensionAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/NoIsActiveMethodForExtension/NoIsActiveMethodForExtensionAnalyzer.cs
@@ -50,7 +50,8 @@ namespace Acuminator.Analyzers.StaticAnalysis.NoIsActiveMethodForExtension
 		public bool ShouldAnalyze(PXContext pxContext, PXGraphSemanticModel graphExtension) =>
 			graphExtension?.Type == GraphType.PXGraphExtension &&
 			graphExtension.IsActiveMethodInfo == null &&
-			!graphExtension.Symbol.IsAbstract && !graphExtension.Symbol.IsStatic && !graphExtension.Symbol.IsGenericType;
+			!graphExtension.Symbol.IsAbstract && !graphExtension.Symbol.IsStatic && !graphExtension.Symbol.IsGenericType &&
+			!graphExtension.ConfiguresWorkflow;
 
 		public void Analyze(SymbolAnalysisContext symbolContext, PXContext pxContext, PXGraphSemanticModel graphExtension)
 		{

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/NoPrimaryViewForPrimaryDac/NoPrimaryViewForPrimaryDacAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/NoPrimaryViewForPrimaryDac/NoPrimaryViewForPrimaryDacAnalyzer.cs
@@ -23,7 +23,8 @@ namespace Acuminator.Analyzers.StaticAnalysis.NoPrimaryViewForPrimaryDac
 			ImmutableArray.Create(Descriptors.PX1018_NoPrimaryViewForPrimaryDac);
 
 		public override bool ShouldAnalyze(PXContext pxContext, PXGraphSemanticModel graph) => 
-			base.ShouldAnalyze(pxContext, graph) && graph.Type == GraphType.PXGraph;
+			base.ShouldAnalyze(pxContext, graph) && graph.Type == GraphType.PXGraph &&
+			!graph.Symbol.IsAbstract;
 
 		public override void Analyze(SymbolAnalysisContext context, PXContext pxContext, PXGraphSemanticModel graph)
 		{

--- a/src/Acuminator/Acuminator.Tests/Acuminator.Tests.csproj
+++ b/src/Acuminator/Acuminator.Tests/Acuminator.Tests.csproj
@@ -274,6 +274,7 @@
     <EmbeddedResource Include="Tests\StaticAnalysis\NoIsActiveMethodForExtension\Sources\GraphExtension_WithIsActive.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\NoIsActiveMethodForExtension\Sources\GraphExtension_WithoutIsActive.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\NoIsActiveMethodForExtension\Sources\DAC_MappedCacheExtension.cs" />
+    <EmbeddedResource Include="Tests\StaticAnalysis\NoIsActiveMethodForExtension\Sources\WorkflowGraphExtension_WithoutIsActive.cs" />
     <Compile Include="Tests\StaticAnalysis\NonPublicExtensions\NonPublicGraphExtensionsTests.cs" />
     <Compile Include="Tests\StaticAnalysis\NonPublicExtensions\NonPublicDacExtensionsTests.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\NonPublicExtensions\Sources\NonPublicDacExtension_Expected.cs" />

--- a/src/Acuminator/Acuminator.Tests/Acuminator.Tests.csproj
+++ b/src/Acuminator/Acuminator.Tests/Acuminator.Tests.csproj
@@ -297,6 +297,8 @@
     <EmbeddedResource Include="Tests\StaticAnalysis\StaticFieldOrPropertyInGraph\Sources\CodeFix\GraphWithStaticAction_RemoveStaticFix.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\StaticFieldOrPropertyInGraph\Sources\CodeFix\GraphWithStaticProperty_ReadOnlyFix_Expected.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\StaticFieldOrPropertyInGraph\Sources\CodeFix\GraphWithStaticProperty_ReadOnlyFix.cs" />
+    <EmbeddedResource Include="Tests\StaticAnalysis\NoPrimaryViewForPrimaryDac\Sources\AbstractGraphNoPrimaryViewForPrimaryDac.cs" />
+    <EmbeddedResource Include="Tests\StaticAnalysis\NoPrimaryViewForPrimaryDac\Sources\GenericGraphNoPrimaryViewForPrimaryDac.cs" />
     <Compile Include="Tests\StaticAnalysis\StaticFieldOrPropertyInGraph\StaticFieldOrPropertyInGraphTests.cs" />
     <Compile Include="Tests\StaticAnalysis\SuppressionDiagnostics\MultipleSuppressionCodeFixTests.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\SuppressionDiagnostics\Sources\Dac\SuppressMuiltipleDiagnostics_One.cs" />

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/ChangesInPXCache/Sources/PXGraph/PXGraphExtensionChangesPXCacheInInitializationMethod.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/ChangesInPXCache/Sources/PXGraph/PXGraphExtensionChangesPXCacheInInitializationMethod.cs
@@ -3,8 +3,8 @@ using PX.SM;
 
 namespace Acuminator.Tests.Tests.StaticAnalysis.PXGraphLongOperationDuringInitialization.Sources
 {
-    public class SMAccessExt : PXGraphExtension<SMAccessPersonalMaint>
-    {
+    public class SMAccessExtDerived : SMAccessExtBase
+	{
         public override void Initialize()
         {
             int count = Base.Identities.Select().Count;
@@ -21,4 +21,11 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.PXGraphLongOperationDuringInitia
             }
         }
     }
+
+	public class SMAccessExtBase : PXGraphExtension<SMAccessPersonalMaint>
+	{
+		public override void Initialize()
+		{
+		}
+	}
 }

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/NoIsActiveMethodForExtension/NoIsActiveMethodForGraphExtensionTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/NoIsActiveMethodForExtension/NoIsActiveMethodForGraphExtensionTests.cs
@@ -33,5 +33,10 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.NoIsActiveMethodForExtension
         [EmbeddedFileData("GraphExtension_WithIsActive.cs")]
         public async Task GraphExtension_WithIsActive_ShouldNotShowDiagnostic(string actual) =>
 			await VerifyCSharpDiagnosticAsync(actual);
+
+		[Theory]
+		[EmbeddedFileData("WorkflowGraphExtension_WithoutIsActive.cs")]
+		public async Task WorkflowGraphExtension_WithoutIsActive_ShouldNotShowDiagnostic(string actual) =>
+			await VerifyCSharpDiagnosticAsync(actual);
 	}
 }

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/NoIsActiveMethodForExtension/Sources/WorkflowGraphExtension_WithoutIsActive.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/NoIsActiveMethodForExtension/Sources/WorkflowGraphExtension_WithoutIsActive.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using PX.Data;
+using PX.Data.WorkflowAPI;
+using PX.Objects.SO;
+
+namespace Acuminator.Tests.Tests.StaticAnalysis.NoIsActiveMethodForExtension.Sources
+{
+	public class SOOrderEntryWorkflow : SOOrderEntryWorkflowBase
+	{
+		protected override void Configure(WorkflowContext<SOOrderEntry, SOOrder> workflowContext) => 
+			base.Configure(workflowContext);
+	}
+
+	public class SOOrderEntryWorkflowBase : PXGraphExtension<SOOrderEntry>
+	{
+		public override void Configure(PXScreenConfiguration configuration)
+		{
+			var workflowContext = configuration.GetScreenConfigurationContext<SOOrderEntry, SOOrder>();
+			Configure(workflowContext);
+		}
+
+		protected virtual void Configure(WorkflowContext<SOOrderEntry, SOOrder> workflowContext)
+		{
+
+		}
+	}
+
+	public class SOOrderEntry : PXGraph<SOOrderEntry>
+	{
+
+	}
+}

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/NoPrimaryViewForPrimaryDac/NoPrimaryViewForPrimaryDacTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/NoPrimaryViewForPrimaryDac/NoPrimaryViewForPrimaryDacTests.cs
@@ -33,6 +33,12 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.NoPrimaryViewForPrimaryDac
 				Descriptors.PX1018_NoPrimaryViewForPrimaryDac.CreateFor(line: 23, column: 15));
 
 		[Theory]
+		[EmbeddedFileData("GenericGraphNoPrimaryViewForPrimaryDac.cs")]
+		public virtual Task GenericGraphs_WithInheritance_WithoutPrimaryView_NoDiagnostics(string source) => 
+			VerifyCSharpDiagnosticAsync(source,
+				Descriptors.PX1018_NoPrimaryViewForPrimaryDac.CreateFor(line: 23, column: 69));
+
+		[Theory]
 		[EmbeddedFileData("HasPrimaryViewForPrimaryDac.cs")]
 		public virtual Task WithPrimaryView_NoDiagnostics(string source) => VerifyCSharpDiagnosticAsync(source);
 
@@ -44,11 +50,7 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.NoPrimaryViewForPrimaryDac
 
 		[Theory]
 		[EmbeddedFileData("HasPrimaryViewForPrimaryDacFluentBQL.cs")]
-		public virtual Task WithPrimaryView_FluentBql_NoDiagnostics(string source) => VerifyCSharpDiagnosticAsync(source);
-
-		[Theory]
-		[EmbeddedFileData("GenericGraphNoPrimaryViewForPrimaryDac.cs")]
-		public virtual Task GenericGraphs_WithInheritance_WithoutPrimaryView_NoDiagnostics(string source) => VerifyCSharpDiagnosticAsync(source);
+		public virtual Task WithPrimaryView_FluentBql_NoDiagnostics(string source) => VerifyCSharpDiagnosticAsync(source);	
 
 		[Theory]
 		[EmbeddedFileData("AbstractGraphNoPrimaryViewForPrimaryDac.cs")]

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/NoPrimaryViewForPrimaryDac/NoPrimaryViewForPrimaryDacTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/NoPrimaryViewForPrimaryDac/NoPrimaryViewForPrimaryDacTests.cs
@@ -45,5 +45,13 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.NoPrimaryViewForPrimaryDac
 		[Theory]
 		[EmbeddedFileData("HasPrimaryViewForPrimaryDacFluentBQL.cs")]
 		public virtual Task WithPrimaryView_FluentBql_NoDiagnostics(string source) => VerifyCSharpDiagnosticAsync(source);
+
+		[Theory]
+		[EmbeddedFileData("GenericGraphNoPrimaryViewForPrimaryDac.cs")]
+		public virtual Task GenericGraphs_WithInheritance_WithoutPrimaryView_NoDiagnostics(string source) => VerifyCSharpDiagnosticAsync(source);
+
+		[Theory]
+		[EmbeddedFileData("AbstractGraphNoPrimaryViewForPrimaryDac.cs")]
+		public virtual Task AbstractGraphs_WithInheritance_WithoutPrimaryView_NoDiagnostics(string source) => VerifyCSharpDiagnosticAsync(source);
 	}
 }

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/NoPrimaryViewForPrimaryDac/NoPrimaryViewForPrimaryDacTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/NoPrimaryViewForPrimaryDac/NoPrimaryViewForPrimaryDacTests.cs
@@ -1,11 +1,18 @@
-﻿using Acuminator.Analyzers.StaticAnalysis;
+﻿#nullable enable
+
+using System;
+using System.Threading.Tasks;
+
+using Acuminator.Analyzers.StaticAnalysis;
 using Acuminator.Analyzers.StaticAnalysis.NoPrimaryViewForPrimaryDac;
 using Acuminator.Analyzers.StaticAnalysis.PXGraph;
 using Acuminator.Tests.Helpers;
 using Acuminator.Tests.Verification;
 using Acuminator.Utilities;
+
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
+
 using Xunit;
 
 namespace Acuminator.Tests.Tests.StaticAnalysis.NoPrimaryViewForPrimaryDac
@@ -20,23 +27,23 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.NoPrimaryViewForPrimaryDac
 			
 		[Theory]
 		[EmbeddedFileData("NoPrimaryViewForPrimaryDac.cs")]
-		public virtual void WithoutPrimaryView(string source) =>
-			VerifyCSharpDiagnostic(source,
+		public virtual Task WithoutPrimaryView(string source) =>
+			VerifyCSharpDiagnosticAsync(source,
 				Descriptors.PX1018_NoPrimaryViewForPrimaryDac.CreateFor(line: 17, column: 56),
 				Descriptors.PX1018_NoPrimaryViewForPrimaryDac.CreateFor(line: 23, column: 15));
 
 		[Theory]
 		[EmbeddedFileData("HasPrimaryViewForPrimaryDac.cs")]
-		public virtual void WithPrimaryView_NoDiagnostics(string source) => VerifyCSharpDiagnostic(source);
+		public virtual Task WithPrimaryView_NoDiagnostics(string source) => VerifyCSharpDiagnosticAsync(source);
 
 		[Theory]
 		[EmbeddedFileData("NoPrimaryViewForPrimaryDacFluentBQL.cs")]
-		public virtual void WithoutPrimaryView_FluentBql(string source) =>
-			VerifyCSharpDiagnostic(source,
+		public virtual Task WithoutPrimaryView_FluentBql(string source) =>
+			VerifyCSharpDiagnosticAsync(source,
 				Descriptors.PX1018_NoPrimaryViewForPrimaryDac.CreateFor(line: 18, column: 68));
 
 		[Theory]
 		[EmbeddedFileData("HasPrimaryViewForPrimaryDacFluentBQL.cs")]
-		public virtual void WithPrimaryView_FluentBql_NoDiagnostics(string source) => VerifyCSharpDiagnostic(source);
+		public virtual Task WithPrimaryView_FluentBql_NoDiagnostics(string source) => VerifyCSharpDiagnosticAsync(source);
 	}
 }

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/NoPrimaryViewForPrimaryDac/Sources/AbstractGraphNoPrimaryViewForPrimaryDac.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/NoPrimaryViewForPrimaryDac/Sources/AbstractGraphNoPrimaryViewForPrimaryDac.cs
@@ -17,7 +17,7 @@ namespace PX.Objects.HackathonDemo
 
 	public class ARInvoiceEntry : InvoiceEntryBase
 	{
-		PXSelect<ARInvoice> Invoices;
+		public PXSelect<ARInvoice> Invoices;
 	}
 
 	public class SOInvoiceEntry : ARInvoiceEntry

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/NoPrimaryViewForPrimaryDac/Sources/AbstractGraphNoPrimaryViewForPrimaryDac.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/NoPrimaryViewForPrimaryDac/Sources/AbstractGraphNoPrimaryViewForPrimaryDac.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using PX.Data;
+
+namespace PX.Objects.HackathonDemo
+{
+	[PXCacheName("ARInvoice")]
+	public class ARInvoice : IBqlTable { }
+
+	public abstract class InvoiceEntryBase : PXGraph<InvoiceEntryBase, ARInvoice>
+	{
+	}
+
+	public class ARInvoiceEntry : InvoiceEntryBase
+	{
+		PXSelect<ARInvoice> Invoices;
+	}
+
+	public class SOInvoiceEntry : ARInvoiceEntry
+	{
+
+	}
+}

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/NoPrimaryViewForPrimaryDac/Sources/GenericGraphNoPrimaryViewForPrimaryDac.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/NoPrimaryViewForPrimaryDac/Sources/GenericGraphNoPrimaryViewForPrimaryDac.cs
@@ -20,7 +20,7 @@ namespace PX.Objects.HackathonDemo
 	{
 	}
 
-	public class ARInvoiceEntryBase<TGraph> : InvoiceEntryBase<TGraph, ARInvoice>	// The only place to show diagnostic since there are no DAC type parameters and no view for ARInvoice
+	public class ARInvoiceEntryBase<TGraph> : InvoiceEntryBase<TGraph, ARInvoice>	// The only place to show alert since there is no primary DAC as a type parameter and no view for ARInvoice
 	where TGraph : PXGraph, new()
 	{
 
@@ -30,6 +30,14 @@ namespace PX.Objects.HackathonDemo
 	{
 		public PXSelect<ARInvoice> Invoices;
 	}
+
+	public class APInvoiceEntryBase<TDac> : InvoiceEntryBase<APInvoiceEntryBase<TDac>, TDac>	// No alert since primary DAC is a generic type parameter
+	where TDac : class, IBqlTable, new()
+	{
+
+	}
+
+	//------------------------------------------------------------------------------------------
 
 	public class OrderEntryBaseWithView<TGraph, TSomeType, TDac> : PXGraph<TGraph, TDac>
 	where TGraph : PXGraph, new()

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/NoPrimaryViewForPrimaryDac/Sources/GenericGraphNoPrimaryViewForPrimaryDac.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/NoPrimaryViewForPrimaryDac/Sources/GenericGraphNoPrimaryViewForPrimaryDac.cs
@@ -20,7 +20,7 @@ namespace PX.Objects.HackathonDemo
 	{
 	}
 
-	public class ARInvoiceEntryBase<TGraph> : InvoiceEntryBase<TGraph, ARInvoice>
+	public class ARInvoiceEntryBase<TGraph> : InvoiceEntryBase<TGraph, ARInvoice>	// The only place to show diagnostic since there are no DAC type parameters and no view for ARInvoice
 	where TGraph : PXGraph, new()
 	{
 
@@ -31,7 +31,7 @@ namespace PX.Objects.HackathonDemo
 		public PXSelect<ARInvoice> Invoices;
 	}
 
-	public class OrderEntryBaseWithView<TGraph, TSomeType, TDac> : PXGraph<TGraph, TSomeType, TDac>
+	public class OrderEntryBaseWithView<TGraph, TSomeType, TDac> : PXGraph<TGraph, TDac>
 	where TGraph : PXGraph, new()
 	where TDac : class, IBqlTable, new()
 	{

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/NoPrimaryViewForPrimaryDac/Sources/GenericGraphNoPrimaryViewForPrimaryDac.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/NoPrimaryViewForPrimaryDac/Sources/GenericGraphNoPrimaryViewForPrimaryDac.cs
@@ -28,14 +28,14 @@ namespace PX.Objects.HackathonDemo
 
 	public class ARInvoiceEntry : ARInvoiceEntryBase<ARInvoiceEntry>
 	{
-		PXSelect<ARInvoice> Invoices;
+		public PXSelect<ARInvoice> Invoices;
 	}
 
 	public class OrderEntryBaseWithView<TGraph, TSomeType, TDac> : PXGraph<TGraph, TSomeType, TDac>
 	where TGraph : PXGraph, new()
 	where TDac : class, IBqlTable, new()
 	{
-		PXSelect<TDac> Orders;
+		public PXSelect<TDac> Orders;
 	}
 
 	public class SOOrderEntryBase<TDac> : OrderEntryBaseWithView<SOOrderEntryBase<TDac>, int, TDac>

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/NoPrimaryViewForPrimaryDac/Sources/GenericGraphNoPrimaryViewForPrimaryDac.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/NoPrimaryViewForPrimaryDac/Sources/GenericGraphNoPrimaryViewForPrimaryDac.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using PX.Data;
+
+namespace PX.Objects.HackathonDemo
+{
+	[PXCacheName("ARInvoice")]
+	public class ARInvoice : IBqlTable { }
+
+	[PXCacheName("SOOrder")]
+	public class SOOrder : IBqlTable { }
+
+	public class InvoiceEntryBase<TGraph, TDac> : PXGraph<TGraph, TDac>
+	where TGraph : PXGraph, new()
+	where TDac : class, IBqlTable, new()
+	{
+	}
+
+	public class ARInvoiceEntryBase<TGraph> : InvoiceEntryBase<TGraph, ARInvoice>
+	where TGraph : PXGraph, new()
+	{
+
+	}
+
+	public class ARInvoiceEntry : ARInvoiceEntryBase<ARInvoiceEntry>
+	{
+		PXSelect<ARInvoice> Invoices;
+	}
+
+	public class OrderEntryBaseWithView<TGraph, TSomeType, TDac> : PXGraph<TGraph, TSomeType, TDac>
+	where TGraph : PXGraph, new()
+	where TDac : class, IBqlTable, new()
+	{
+		PXSelect<TDac> Orders;
+	}
+
+	public class SOOrderEntryBase<TDac> : OrderEntryBaseWithView<SOOrderEntryBase<TDac>, int, TDac>
+	where TDac : class, IBqlTable, new()
+	{
+		
+	}
+
+	public class SOOrderEntry : SOOrderEntryBase<SOOrder>
+	{
+	}
+
+	public class OtherSOOrderEntry : OrderEntryBaseWithView<OtherSOOrderEntry, object, SOOrder>
+	{
+	}
+}

--- a/src/Acuminator/Acuminator.Utilities/Common/EnumerableExtensions.cs
+++ b/src/Acuminator/Acuminator.Utilities/Common/EnumerableExtensions.cs
@@ -395,6 +395,28 @@ namespace Acuminator.Utilities.Common
 			return -1;
 		}
 
+		/// <summary>
+		/// An <see cref="IReadOnlyCollection{T}"/> extension method that converts a source to an immutable array a bit more optimally.
+		/// </summary>
+		/// <typeparam name="T">Generic type parameter.</typeparam>
+		/// <param name="source">The source to act on.</param>
+		/// <returns>
+		/// Source as an <see cref="ImmutableArray{T}"/>
+		/// </returns>
+		[DebuggerStepThrough]
+		public static ImmutableArray<T> ToImmutableArray<T>(this IReadOnlyCollection<T> source)
+		{
+			source.ThrowOnNull(nameof(source));
+
+			if (source.Count == 0)
+				return ImmutableArray<T>.Empty;
+
+			var builder = ImmutableArray.CreateBuilder<T>(initialCapacity: source.Count);
+			builder.AddRange(source);
+
+			return builder.ToImmutable();
+		}
+
 		[DebuggerStepThrough]
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static int FindIndex<TNode>(this SeparatedSyntaxList<TNode> source, Func<TNode, bool> condition)
@@ -473,5 +495,7 @@ namespace Acuminator.Utilities.Common
 
 			return false;
 		}
+
+
 	}
 }

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Constants/DelegateNames.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Constants/DelegateNames.cs
@@ -89,5 +89,10 @@ namespace Acuminator.Utilities.Roslyn.Constants
 			public const string ReflectionSerializer_GetObjectData      = "GetObjectData";
 			public const string ReflectionSerializer_RestoreObjectProps = "RestoreObjectProps";
 		}
+
+		internal static class Workflow
+		{
+			public const string Configure = "Configure";
+		}
 	}
 }

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Constants/TypeFullNames.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Constants/TypeFullNames.cs
@@ -211,5 +211,10 @@
 			public const string ReflectionSerializer = "PX.Common.ReflectionSerializer";
 			public const string PXReflectionSerializer = "PX.Common.PXReflectionSerializer";
 		}
+
+		internal static class Workflow
+		{
+			public const string PXScreenConfiguration = "PX.Data.WorkflowAPI.PXScreenConfiguration";
+		}
 	}
 }

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/PrimaryDacFinder/PrimaryDacFinder.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/PrimaryDacFinder/PrimaryDacFinder.cs
@@ -67,7 +67,7 @@ namespace Acuminator.Utilities.Roslyn.PrimaryDacFinder
 
 			bool isGraph = graphOrGraphExtension.InheritsFrom(pxContext.PXGraph.Type);
 
-			if (!isGraph && !graphOrGraphExtension.InheritsFrom(pxContext.PXGraphExtensionType))
+			if (!isGraph && !graphOrGraphExtension.InheritsFrom(pxContext.PXGraphExtension.Type))
 				return null;
 
 			PXGraphSemanticModel graphSemanticModel = PXGraphSemanticModel.InferModels(pxContext, graphOrGraphExtension, 

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/CodeResolvingUtils.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/CodeResolvingUtils.cs
@@ -295,7 +295,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic
             typeSymbol.ThrowOnNull(nameof(typeSymbol));
             pxContext.ThrowOnNull(nameof(pxContext));
 
-            return typeSymbol.InheritsFromOrEquals(pxContext.PXGraphExtensionType);
+            return typeSymbol.InheritsFromOrEquals(pxContext.PXGraphExtension.Type);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/IMethodSymbolExtensions.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/IMethodSymbolExtensions.cs
@@ -103,7 +103,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic
 			{
 				IMethodSymbol current = includeThis ? methodSymbol : methodSymbol.OverriddenMethod;
 
-				while (current?.IsOverride == true)
+				while (current != null)
 				{
 					yield return current;
 					current = current.OverriddenMethod;
@@ -149,7 +149,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic
 			{
 				IPropertySymbol current = includeThis ? propertySymbol : propertySymbol.OverriddenProperty;
 
-				while (current?.IsOverride == true)
+				while (current != null)
 				{
 					yield return current;
 					current = current.OverriddenProperty;

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/IMethodSymbolExtensions.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/IMethodSymbolExtensions.cs
@@ -82,8 +82,13 @@ namespace Acuminator.Utilities.Roslyn.Semantic
 		/// <returns>
 		/// The overrides of <paramref name="methodSymbol"/>.
 		/// </returns>
-		public static IEnumerable<IMethodSymbol> GetOverrides(this IMethodSymbol methodSymbol) =>
-			GetOverridesImpl(methodSymbol.CheckIfNull(nameof(methodSymbol)), includeThis: false);
+		public static IEnumerable<IMethodSymbol> GetOverrides(this IMethodSymbol methodSymbol)
+		{
+			if (methodSymbol.CheckIfNull(nameof(methodSymbol)).IsOverride)
+				return GetOverridesImpl(methodSymbol, includeThis: false);
+			else
+				return Enumerable.Empty<IMethodSymbol>();
+		}
 
 		private static IEnumerable<IMethodSymbol> GetOverridesImpl(IMethodSymbol methodSymbol, bool includeThis)
 		{
@@ -123,8 +128,13 @@ namespace Acuminator.Utilities.Roslyn.Semantic
 		/// <returns>
 		/// The overrides of <paramref name="propertySymbol"/>.
 		/// </returns>
-		public static IEnumerable<IPropertySymbol> GetOverrides(this IPropertySymbol propertySymbol) =>
-			GetOverridesImpl(propertySymbol.CheckIfNull(nameof(propertySymbol)), includeThis: false);
+		public static IEnumerable<IPropertySymbol> GetOverrides(this IPropertySymbol propertySymbol)
+		{
+			if (propertySymbol.CheckIfNull(nameof(propertySymbol)).IsOverride)
+				return GetOverridesImpl(propertySymbol, includeThis: false);
+			else
+				return Enumerable.Empty<IPropertySymbol>();
+		}
 
 		private static IEnumerable<IPropertySymbol> GetOverridesImpl(IPropertySymbol propertySymbol, bool includeThis)
 		{

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/ITypeSymbolExtensions.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/ITypeSymbolExtensions.cs
@@ -257,6 +257,12 @@ namespace Acuminator.Utilities.Roslyn.Semantic
 				throw new ArgumentException("Invalid interface type", nameof(interfaceType));
 			}
 
+			// Interface types themselves are not included into AllInterfaces set, they do not implement themselves from Roslyn POV.
+			// However, for simplicity in Acuminator analysis we can assume equality of type and interfaceType as a special case of type implementing interfaceType interface.
+			// Therefore, we need to check type if it's an interface if it equals to the interfaceType
+			if (type.TypeKind == TypeKind.Interface && type.Equals(interfaceType))
+				return true;
+
 			return type.AllInterfaces.Any(t => t.Equals(interfaceType));
 		}
 

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/PXContext.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/PXContext.cs
@@ -139,8 +139,8 @@ namespace Acuminator.Utilities.Roslyn.Semantic
 			_attributes                  = new Lazy<AttributeSymbols>(() => new AttributeSymbols(Compilation));
 			_systemTypes                 = new Lazy<SystemTypeSymbols>(() => new SystemTypeSymbols(Compilation));
             _localizationMethods         = new Lazy<LocalizationSymbols>(() => new LocalizationSymbols(Compilation));
-            _pxGraph                     = new Lazy<PXGraphSymbols>(() => new PXGraphSymbols(Compilation));
-			_pxGraphExtensionSymbols     = new Lazy<PXGraphExtensionSymbols>(() => new PXGraphExtensionSymbols(Compilation));
+            _pxGraph                     = new Lazy<PXGraphSymbols>(() => new PXGraphSymbols(this));
+			_pxGraphExtensionSymbols     = new Lazy<PXGraphExtensionSymbols>(() => new PXGraphExtensionSymbols(this));
             _pxCache                     = new Lazy<PXCacheSymbols>(() => new PXCacheSymbols(Compilation));
 			_pxAction                    = new Lazy<PXActionSymbols>(() => new PXActionSymbols(Compilation));
 			_pxDatabase                  = new Lazy<PXDatabaseSymbols>(() => new PXDatabaseSymbols(Compilation));

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/PXContext.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/PXContext.cs
@@ -89,7 +89,9 @@ namespace Acuminator.Utilities.Roslyn.Semantic
 		private readonly Lazy<ImmutableHashSet<IMethodSymbol>> _uiPresentationLogicMethods;
 		public ImmutableHashSet<IMethodSymbol> UiPresentationLogicMethods => _uiPresentationLogicMethods.Value;
 
-		public INamedTypeSymbol PXGraphExtensionType => Compilation.GetTypeByMetadataName(TypeFullNames.PXGraphExtension);
+		private readonly Lazy<PXGraphExtensionSymbols> _pxGraphExtensionSymbols;
+		public PXGraphExtensionSymbols PXGraphExtension => _pxGraphExtensionSymbols.Value;
+
 		public INamedTypeSymbol PXCacheExtensionType => Compilation.GetTypeByMetadataName(TypeFullNames.PXCacheExtension);
 		public INamedTypeSymbol PXMappedCacheExtensionType => Compilation.GetTypeByMetadataName(TypeFullNames.PXMappedCacheExtension);
 		public INamedTypeSymbol PXLongOperation => Compilation.GetTypeByMetadataName(TypeFullNames.PXLongOperation);
@@ -113,9 +115,6 @@ namespace Acuminator.Utilities.Roslyn.Semantic
         public INamedTypeSymbol IPXLocalizableList => Compilation.GetTypeByMetadataName(TypeFullNames.IPXLocalizableList);
 		public INamedTypeSymbol PXConnectionScope => Compilation.GetTypeByMetadataName(TypeFullNames.PXConnectionScope);
 
-        public IMethodSymbol PXGraphExtensionInitializeMethod => PXGraphExtensionType.GetMembers(DelegateNames.Initialize)
-                                                                 .OfType<IMethodSymbol>()
-                                                                 .First();
         public ImmutableArray<IMethodSymbol> StartOperation => PXLongOperation.GetMembers(DelegateNames.StartOperation)
                                                                .OfType<IMethodSymbol>()
                                                                .ToImmutableArray();
@@ -130,25 +129,26 @@ namespace Acuminator.Utilities.Roslyn.Semantic
 			Compilation = compilation;
 			IsPlatformReferenced = compilation.GetTypeByMetadataName(TypeFullNames.PXGraph) != null;
 
-			_bql = new Lazy<BQLSymbols>(() => new BQLSymbols(Compilation));
-			_bqlTypes = new Lazy<BqlDataTypeSymbols>(() => new BqlDataTypeSymbols(Compilation));
-			_events = new Lazy<EventSymbols>(() => new EventSymbols(Compilation));
-			_fieldAttributes = new Lazy<FieldAttributeSymbols>(() => new FieldAttributeSymbols(Compilation));
-			_systemActionTypes = new Lazy<PXSystemActionSymbols>(() => new PXSystemActionSymbols(Compilation));
-			_attributes = new Lazy<AttributeSymbols>(() => new AttributeSymbols(Compilation));
-			_systemTypes = new Lazy<SystemTypeSymbols>(() => new SystemTypeSymbols(Compilation));
-            _localizationMethods = new Lazy<LocalizationSymbols>(() => new LocalizationSymbols(Compilation));
-            _pxGraph = new Lazy<PXGraphSymbols>(() => new PXGraphSymbols(Compilation));
-            _pxCache = new Lazy<PXCacheSymbols>(() => new PXCacheSymbols(Compilation));
-			_pxAction = new Lazy<PXActionSymbols>(() => new PXActionSymbols(Compilation));
-			_pxDatabase = new Lazy<PXDatabaseSymbols>(() => new PXDatabaseSymbols(Compilation));
-			_pxView = new Lazy<PXViewSymbols>(() => new PXViewSymbols(Compilation));
-			_exceptions = new Lazy<ExceptionSymbols>(() => new ExceptionSymbols(Compilation));
-			_serialization = new Lazy<SerializationSymbols>(() => new SerializationSymbols(Compilation));
-            _pxSelectBaseGeneric = new Lazy<PXSelectBaseGenericSymbols>(() => new PXSelectBaseGenericSymbols(Compilation));
-            _pxSelectBase = new Lazy<PXSelectBaseSymbols>(() => new PXSelectBaseSymbols(Compilation));
-			_pxSelectExtensionSymbols = new Lazy<PXSelectExtensionSymbols>(() => new PXSelectExtensionSymbols(Compilation));
-            _pxProcessingBase = new Lazy<PXProcessingBaseSymbols>(() => new PXProcessingBaseSymbols(Compilation));
+			_bql                         = new Lazy<BQLSymbols>(() => new BQLSymbols(Compilation));
+			_bqlTypes                    = new Lazy<BqlDataTypeSymbols>(() => new BqlDataTypeSymbols(Compilation));
+			_events                      = new Lazy<EventSymbols>(() => new EventSymbols(Compilation));
+			_fieldAttributes             = new Lazy<FieldAttributeSymbols>(() => new FieldAttributeSymbols(Compilation));
+			_systemActionTypes           = new Lazy<PXSystemActionSymbols>(() => new PXSystemActionSymbols(Compilation));
+			_attributes                  = new Lazy<AttributeSymbols>(() => new AttributeSymbols(Compilation));
+			_systemTypes                 = new Lazy<SystemTypeSymbols>(() => new SystemTypeSymbols(Compilation));
+            _localizationMethods         = new Lazy<LocalizationSymbols>(() => new LocalizationSymbols(Compilation));
+            _pxGraph                     = new Lazy<PXGraphSymbols>(() => new PXGraphSymbols(Compilation));
+			_pxGraphExtensionSymbols     = new Lazy<PXGraphExtensionSymbols>(() => new PXGraphExtensionSymbols(Compilation));
+            _pxCache                     = new Lazy<PXCacheSymbols>(() => new PXCacheSymbols(Compilation));
+			_pxAction                    = new Lazy<PXActionSymbols>(() => new PXActionSymbols(Compilation));
+			_pxDatabase                  = new Lazy<PXDatabaseSymbols>(() => new PXDatabaseSymbols(Compilation));
+			_pxView                      = new Lazy<PXViewSymbols>(() => new PXViewSymbols(Compilation));
+			_exceptions                  = new Lazy<ExceptionSymbols>(() => new ExceptionSymbols(Compilation));
+			_serialization               = new Lazy<SerializationSymbols>(() => new SerializationSymbols(Compilation));
+            _pxSelectBaseGeneric         = new Lazy<PXSelectBaseGenericSymbols>(() => new PXSelectBaseGenericSymbols(Compilation));
+            _pxSelectBase                = new Lazy<PXSelectBaseSymbols>(() => new PXSelectBaseSymbols(Compilation));
+			_pxSelectExtensionSymbols    = new Lazy<PXSelectExtensionSymbols>(() => new PXSelectExtensionSymbols(Compilation));
+            _pxProcessingBase            = new Lazy<PXProcessingBaseSymbols>(() => new PXProcessingBaseSymbols(Compilation));
             _referentialIntegritySymbols = new Lazy<PXReferentialIntegritySymbols>(() => new PXReferentialIntegritySymbols(Compilation));
 
 			_uiPresentationLogicMethods = new Lazy<ImmutableHashSet<IMethodSymbol>>(GetUiPresentationLogicMethods);

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/PXContext.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/PXContext.cs
@@ -121,6 +121,8 @@ namespace Acuminator.Utilities.Roslyn.Semantic
 
 		public INamedTypeSymbol IImplementType => Compilation.GetTypeByMetadataName(TypeFullNames.IImplementType);
 
+		public INamedTypeSymbol? PXScreenConfiguration => Compilation.GetTypeByMetadataName(TypeFullNames.Workflow.PXScreenConfiguration);
+
 		public PXContext(Compilation compilation, CodeAnalysisSettings? codeAnalysisSettings)
 		{
 			compilation.ThrowOnNull(nameof(compilation));

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/PXGraph/Infos/ConfigureMethodInfo.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/PXGraph/Infos/ConfigureMethodInfo.cs
@@ -34,16 +34,23 @@ namespace Acuminator.Utilities.Roslyn.Semantic.PXGraph
 		}
 
 		/// <summary>
-		/// Collects info about Configure method overrides from a graph extension symbol and creates <see cref="ConfigureMethodInfo"/> DTO.
+		/// Collects info about Configure method overrides from a graph or graph extension symbol and creates <see cref="ConfigureMethodInfo"/> DTO.
 		/// </summary>
-		/// <param name="graphExtension">The graph extension.</param>
+		/// <remarks>
+		/// We collect only Configure method overrides from the class hierarchy because:<br/>
+		/// - PXOverride mechanism is not supported by the workflow mechanism. Thus, it's no use to check chained extensions, <bt/>  
+		/// they can't affect workflow configuration done by the base extension or graph
+		/// - Graph and graph extension overrides of Configure method can be considered independently.<br/>  
+		/// Therefore, for graph extension base graph's Configure method overrides are not included into results
+		/// </remarks>
+		/// <param name="graphOrGraphExtension">The graph or graph extension.</param>
 		/// <param name="pxContext">The Acumatica context.</param>
 		/// <param name="cancellationToken">A token that allows processing to be cancelled.</param>
 		/// <param name="declarationOrder">(Optional) The declaration order.</param>
 		/// <returns>
-		/// A collection of <see cref="ConfigureMethodInfo"/> DTOs if the graph extension contains one or several Configure method, otherwise an empty collection.
+		/// A collection of <see cref="ConfigureMethodInfo"/> DTOs if the graph / graph extension contains one or several Configure method, otherwise an empty collection.
 		/// </returns>
-		internal static IReadOnlyCollection<ConfigureMethodInfo> GetConfigureMethodInfos(INamedTypeSymbol graphExtension, PXContext pxContext, 
+		internal static IReadOnlyCollection<ConfigureMethodInfo> GetConfigureMethodInfos(INamedTypeSymbol graphOrGraphExtension, PXContext pxContext, 
 																						 CancellationToken cancellationToken, int? declarationOrder = null)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
@@ -51,7 +58,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic.PXGraph
 			if (pxContext?.PXGraphExtension.Configure == null)
 				return Array.Empty<ConfigureMethodInfo>();
 
-			ImmutableArray<ISymbol> configureTypeMembers = graphExtension.GetMembers(DelegateNames.Workflow.Configure);
+			ImmutableArray<ISymbol> configureTypeMembers = graphOrGraphExtension.GetMembers(DelegateNames.Workflow.Configure);
 
 			if (configureTypeMembers.IsDefaultOrEmpty)
 				return Array.Empty<ConfigureMethodInfo>();

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/PXGraph/Infos/ConfigureMethodInfo.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/PXGraph/Infos/ConfigureMethodInfo.cs
@@ -1,0 +1,83 @@
+﻿#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+
+using Acuminator.Utilities.Common;
+using Acuminator.Utilities.Roslyn.Constants;
+
+using Microsoft.CodeAnalysis;
+
+namespace Acuminator.Utilities.Roslyn.Semantic.PXGraph
+{
+	/// <summary>
+	/// Information about the Configure special method in graph extensions.
+	/// </summary>
+	/// <remarks>
+	/// <see cref="ConfigureMethodInfo"/> is derived from <see cref="SymbolItem{T}"/> insted of <see cref="NodeSymbolItem{N, S}"/>.
+	/// This way the class does not keep any information about syntax nodes.<br/>
+	/// This is done intentionally to support a scenario when Configure method is overriden in a customization with no access to source code with base overrides.
+	/// </remarks>
+	public class ConfigureMethodInfo : SymbolItem<IMethodSymbol>
+	{
+		/// <summary>
+		/// The Configure method declaration order to place it second after IsActiveForGraph&lt;TGraph&gt;.
+		/// </summary>
+		private const int ConfigureDeclarationOrderToPlaceItThird = -1;
+
+		public ConfigureMethodInfo(IMethodSymbol configureMethod, int? declarationOrder = null) :
+							  base(configureMethod, declarationOrder ?? ConfigureDeclarationOrderToPlaceItThird)
+		{
+		}
+
+		/// <summary>
+		/// Collects info about Configure method overrides from a graph extension symbol and creates <see cref="ConfigureMethodInfo"/> DTO.
+		/// </summary>
+		/// <param name="graphExtension">The graph extension.</param>
+		/// <param name="pxContext">The Acumatica context.</param>
+		/// <param name="cancellationToken">A token that allows processing to be cancelled.</param>
+		/// <param name="declarationOrder">(Optional) The declaration order.</param>
+		/// <returns>
+		/// A collection of <see cref="ConfigureMethodInfo"/> DTOs if the graph extension contains one or several Configure method, otherwise an empty collection.
+		/// </returns>
+		internal static IReadOnlyCollection<ConfigureMethodInfo> GetConfigureMethodInfos(INamedTypeSymbol graphExtension, PXContext pxContext, 
+																						 CancellationToken cancellationToken, int? declarationOrder = null)
+		{
+			cancellationToken.ThrowIfCancellationRequested();
+
+			if (pxContext?.PXGraphExtension.Configure == null)
+				return Array.Empty<ConfigureMethodInfo>();
+
+			ImmutableArray<ISymbol> configureTypeMembers = graphExtension.GetMembers(DelegateNames.Workflow.Configure);
+
+			if (configureTypeMembers.IsDefaultOrEmpty)
+				return Array.Empty<ConfigureMethodInfo>();
+
+			var configureCandidates = from method in configureTypeMembers.OfType<IMethodSymbol>()
+									  where !method.IsStatic && method.ReturnsVoid && method.IsOverride && 
+											 method.DeclaredAccessibility == Accessibility.Public && method.Parameters.Length == 1
+									  select method;
+
+			foreach (IMethodSymbol configureMethodCandidate in configureCandidates)
+			{
+				cancellationToken.ThrowIfCancellationRequested();
+
+				var overridesChain = configureMethodCandidate.GetOverridesAndThis().ToList();
+				var originalVirtualMethod = overridesChain[overridesChain.Count - 1];
+
+				if (pxContext.PXGraphExtension.Configure.Equals(originalVirtualMethod))
+				{
+					// Do not include the original PXGraphExtension.Configure method into results
+					return overridesChain.Take(overridesChain.Count - 1)
+										 .Select(configureMethodOverride => new ConfigureMethodInfo(configureMethodOverride, declarationOrder))
+										 .ToList(capacity: overridesChain.Count - 1);
+				} 
+			}
+
+			return Array.Empty<ConfigureMethodInfo>();
+		}
+	}
+}

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/PXGraph/Infos/IsActiveForGraphMethodInfo.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/PXGraph/Infos/IsActiveForGraphMethodInfo.cs
@@ -18,9 +18,9 @@ namespace Acuminator.Utilities.Roslyn.Semantic.PXGraph
 	public class IsActiveForGraphMethodInfo : NodeSymbolItem<MethodDeclarationSyntax, IMethodSymbol>
 	{
 		/// <summary>
-		/// (Immutable) The IsActiveForGraph&lt;TGraph&gt; declaration order to place it second after IsActive .
+		/// The IsActiveForGraph&lt;TGraph&gt; declaration order to place it second after IsActive.
 		/// </summary>
-		private const int IsActiveForGraphDeclarationOrderToPlaceItSecond = -1;
+		private const int IsActiveForGraphDeclarationOrderToPlaceItSecond = -2;
 
 		public IsActiveForGraphMethodInfo(MethodDeclarationSyntax node, IMethodSymbol isActiveForGraphMethod, int? declarationOrder = null) :
 									 base(node, isActiveForGraphMethod, declarationOrder ?? IsActiveForGraphDeclarationOrderToPlaceItSecond)

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/PXGraph/PXGraphSemanticModel.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/PXGraph/PXGraphSemanticModel.cs
@@ -80,10 +80,10 @@ namespace Acuminator.Utilities.Roslyn.Semantic.PXGraph
 		public IsActiveForGraphMethodInfo? IsActiveForGraphMethodInfo { get; }
 
 		/// <summary>
-		/// Gets the PXGraphExtension.Configure method overrides. Extensions that override this method are 
+		/// Gets infos about the Configure method overrides declared in the graph or graph extension's class hierarchy. 
 		/// </summary>
 		/// <value>
-		/// The configure method overrides.
+		/// Infos about Configure method overrides.
 		/// </value>
 		public ImmutableArray<ConfigureMethodInfo> ConfigureMethodOverrides { get; }
 
@@ -345,7 +345,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic.PXGraph
 			if (Type == GraphType.None)
 				return ImmutableArray<ConfigureMethodInfo>.Empty;
 
-			var configureOverrides = ConfigureMethodInfo.GetConfigureMethodInfos(Symbol, PXContext, _cancellation);
+			var configureOverrides = ConfigureMethodInfo.GetConfigureMethodInfos(Symbol, Type, PXContext, _cancellation);
 			return configureOverrides.ToImmutableArray();
 		}
 	}

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/PXGraph/Utils/GraphActionSymbolUtils.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/PXGraph/Utils/GraphActionSymbolUtils.cs
@@ -249,7 +249,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic.PXGraph
 																		AddActionInfoWithOrderDelegate<TInfo> addGraphExtensionActionInfoWithOrder)
 		where TInfo : IOverridableItem<TInfo>
 		{
-			if (!graphExtension.InheritsFrom(pxContext.PXGraphExtensionType))
+			if (!graphExtension.InheritsFrom(pxContext.PXGraphExtension.Type))
 				return new OverridableItemsCollection<TInfo>();
 
 			var graphType = graphExtension.GetGraphFromGraphExtension(pxContext);

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/PXGraph/Utils/GraphSymbolHierarchyUtils.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/PXGraph/Utils/GraphSymbolHierarchyUtils.cs
@@ -61,7 +61,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic.PXGraph
 		{
 			pxContext.ThrowOnNull(nameof(pxContext));
 
-			if (graphExtension == null || !graphExtension.InheritsFrom(pxContext.PXGraphExtensionType))
+			if (graphExtension == null || !graphExtension.InheritsFrom(pxContext.PXGraphExtension.Type))
 				return Enumerable.Empty<ITypeSymbol>();
 
 			INamedTypeSymbol extensionBaseType = graphExtension.GetBaseTypesAndThis()

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/PXGraph/Utils/GraphSymbolUtils.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/PXGraph/Utils/GraphSymbolUtils.cs
@@ -24,7 +24,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic.PXGraph
 		{
 			pxContext.ThrowOnNull(nameof(pxContext));
 
-			if (graphExtension == null || !graphExtension.InheritsFrom(pxContext.PXGraphExtensionType))
+			if (graphExtension == null || !graphExtension.InheritsFrom(pxContext.PXGraphExtension.Type))
 				return null;
 
 			var baseGraphExtensionType = graphExtension.GetBaseTypesAndThis()
@@ -96,7 +96,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic.PXGraph
 			pxContext.ThrowOnNull(nameof(pxContext));
 			bool isGraph = graphOrExtension?.InheritsFrom(pxContext.PXGraph.Type) ?? false;
 
-			if (!isGraph && !graphOrExtension?.InheritsFrom(pxContext.PXGraphExtensionType) != true)
+			if (!isGraph && !graphOrExtension?.InheritsFrom(pxContext.PXGraphExtension.Type) != true)
 				return null;
 
 			ITypeSymbol graph = isGraph
@@ -125,7 +125,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic.PXGraph
 
 			IMethodSymbol initialize = typeSymbol.GetMembers()
 									   .OfType<IMethodSymbol>()
-									   .Where(m => pxContext.PXGraphExtensionInitializeMethod.Equals(m.OverriddenMethod))
+									   .Where(m => pxContext.PXGraphExtension.Initialize.Equals(m.OverriddenMethod))
 									   .FirstOrDefault();
 			if (initialize == null)
 				return (null, null);

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/PXGraph/Utils/GraphSymbolUtils.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/PXGraph/Utils/GraphSymbolUtils.cs
@@ -201,5 +201,22 @@ namespace Acuminator.Utilities.Roslyn.Semantic.PXGraph
 					return false;
 			}
 		}
+
+		internal static IMethodSymbol? GetConfigureMethodFromBaseGraphOrGraphExtension(this INamedTypeSymbol pxGraphOrPXGraphExtension, PXContext pxContext)
+		{
+			var pxScreenConfiguration = pxContext?.PXScreenConfiguration;
+
+			if (pxScreenConfiguration == null)
+				return null;
+
+			var configureMethods = pxGraphOrPXGraphExtension!.GetMembers(DelegateNames.Workflow.Configure);
+
+			if (configureMethods.IsDefaultOrEmpty)
+				return null;
+
+			return configureMethods.OfType<IMethodSymbol>()
+								   .FirstOrDefault(method => method.ReturnsVoid && method.IsVirtual && method.DeclaredAccessibility == Accessibility.Public &&
+															 method.Parameters.Length == 1 && pxScreenConfiguration.Equals(method.Parameters[0].Type));
+		}
 	}
 }

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/PXGraph/Utils/GraphViewSymbolUtils.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/PXGraph/Utils/GraphViewSymbolUtils.cs
@@ -258,7 +258,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic.PXGraph
 																						AddViewInfoWithOrderDelegate<TInfo> addGraphExtensionViewInfo)
 		where TInfo : IOverridableItem<TInfo>
 		{
-			if (!graphExtension.InheritsFrom(pxContext.PXGraphExtensionType))
+			if (!graphExtension.InheritsFrom(pxContext.PXGraphExtension.Type))
 				return new OverridableItemsCollection<TInfo>();
 
 			var graphType = graphExtension.GetGraphFromGraphExtension(pxContext);

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/SharedInfo/IsActiveMethodInfo.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/SharedInfo/IsActiveMethodInfo.cs
@@ -17,7 +17,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic.SharedInfo
 	/// </summary>
 	public class IsActiveMethodInfo : NodeSymbolItem<MethodDeclarationSyntax, IMethodSymbol>
 	{
-		private const int IsActiveDeclarationOrderToPlaceItFirst= -1;
+		private const int IsActiveDeclarationOrderToPlaceItFirst= -3;
 
 		public IsActiveMethodInfo(MethodDeclarationSyntax node, IMethodSymbol isActiveMethod, int? declarationOrder = null) :
 							 base(node, isActiveMethod, declarationOrder ?? IsActiveDeclarationOrderToPlaceItFirst)

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/Symbols/PXGraphExtensionSymbols.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/Symbols/PXGraphExtensionSymbols.cs
@@ -1,0 +1,34 @@
+﻿#nullable enable
+
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+
+using Acuminator.Utilities.Common;
+using Acuminator.Utilities.Roslyn.Constants;
+
+using Microsoft.CodeAnalysis;
+
+namespace Acuminator.Utilities.Roslyn.Semantic.Symbols
+{
+    public class PXGraphExtensionSymbols : SymbolsSetForTypeBase
+	{
+		public IMethodSymbol? Initialize { get; }
+
+		internal PXGraphExtensionSymbols(Compilation compilation) : base(compilation, TypeFullNames.PXGraphExtension)
+        {
+			Type.ThrowOnNull(nameof(Type));
+
+			Initialize = GetMethod(DelegateNames.Initialize);
+        }
+
+		private IMethodSymbol? GetMethod(string methodName)
+		{
+			var methods = Type!.GetMembers(methodName);
+			return methods.IsDefaultOrEmpty
+				? null
+				: methods.OfType<IMethodSymbol>()
+						 .FirstOrDefault();
+		}
+    }
+}

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/Symbols/PXGraphExtensionSymbols.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/Symbols/PXGraphExtensionSymbols.cs
@@ -15,12 +15,32 @@ namespace Acuminator.Utilities.Roslyn.Semantic.Symbols
 	{
 		public IMethodSymbol? Initialize { get; }
 
+		public IMethodSymbol? Configure { get; }
+
 		internal PXGraphExtensionSymbols(Compilation compilation) : base(compilation, TypeFullNames.PXGraphExtension)
         {
 			Type.ThrowOnNull(nameof(Type));
 
 			Initialize = GetMethod(DelegateNames.Initialize);
-        }
+			Configure = GetConfigureMethod();
+		}
+
+		private IMethodSymbol? GetConfigureMethod()
+		{
+			var pxScreenConfiguration = Compilation.GetTypeByMetadataName(TypeFullNames.Workflow.PXScreenConfiguration);
+
+			if (pxScreenConfiguration == null)
+				return null;
+
+			var configureMethods = Type!.GetMembers(DelegateNames.Workflow.Configure);
+
+			if (configureMethods.IsDefaultOrEmpty)
+				return null;
+
+			return configureMethods.OfType<IMethodSymbol>()
+								   .FirstOrDefault(method => method.ReturnsVoid && method.IsVirtual && method.DeclaredAccessibility == Accessibility.Public &&
+															 method.Parameters.Length == 1 && pxScreenConfiguration.Equals(method.Parameters[0].Type));
+		}
 
 		private IMethodSymbol? GetMethod(string methodName)
 		{

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/Symbols/PXGraphSymbols.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/Symbols/PXGraphSymbols.cs
@@ -3,7 +3,9 @@
 using System.Collections.Immutable;
 using System.Linq;
 
+using Acuminator.Utilities.Common;
 using Acuminator.Utilities.Roslyn.Constants;
+using Acuminator.Utilities.Roslyn.Semantic.PXGraph;
 
 using Microsoft.CodeAnalysis;
 
@@ -33,14 +35,20 @@ namespace Acuminator.Utilities.Roslyn.Semantic.Symbols
 													   .OfType<IMethodSymbol>()
 													   .FirstOrDefault(method => method.ReturnsVoid && method.Parameters.Length == 1);
 
-		internal PXGraphSymbols(Compilation compilation) : base(compilation, TypeFullNames.PXGraph)
+		public IMethodSymbol? Configure { get; }
+
+		internal PXGraphSymbols(PXContext pxContext) : base(pxContext.Compilation, TypeFullNames.PXGraph)
         {
-			GenericTypeGraph = compilation.GetTypeByMetadataName(TypeFullNames.PXGraph1);
-			GenericTypeGraphDac = compilation.GetTypeByMetadataName(TypeFullNames.PXGraph2);
-			GenericTypeGraphDacField = compilation.GetTypeByMetadataName(TypeFullNames.PXGraph3);
+			Type.ThrowOnNull(nameof(Type));
+
+			GenericTypeGraph = Compilation.GetTypeByMetadataName(TypeFullNames.PXGraph1);
+			GenericTypeGraphDac = Compilation.GetTypeByMetadataName(TypeFullNames.PXGraph2);
+			GenericTypeGraphDacField = Compilation.GetTypeByMetadataName(TypeFullNames.PXGraph3);
 
 			CreateInstance = Type.GetMethods(DelegateNames.CreateInstance);
-			InstanceCreatedEvents = new InstanceCreatedEventsSymbols(compilation);
-        }
+			InstanceCreatedEvents = new InstanceCreatedEventsSymbols(Compilation);
+
+			Configure = Type.GetConfigureMethodFromBaseGraphOrGraphExtension(pxContext);
+		}
     }
 }

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/Symbols/PXGraphSymbols.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/Symbols/PXGraphSymbols.cs
@@ -1,7 +1,11 @@
-﻿using System.Collections.Immutable;
+﻿#nullable enable
+
+using System.Collections.Immutable;
 using System.Linq;
-using Microsoft.CodeAnalysis;
+
 using Acuminator.Utilities.Roslyn.Constants;
+
+using Microsoft.CodeAnalysis;
 
 namespace Acuminator.Utilities.Roslyn.Semantic.Symbols
 {
@@ -9,7 +13,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic.Symbols
 	{
 		public class InstanceCreatedEventsSymbols : SymbolsSetForTypeBase
 	    {
-			public IMethodSymbol AddHandler { get; }
+			public IMethodSymbol? AddHandler { get; }
 
 		    internal InstanceCreatedEventsSymbols(Compilation compilation) : base(compilation, DelegateNames.InstanceCreatedEvents)
 		    {
@@ -25,9 +29,9 @@ namespace Acuminator.Utilities.Roslyn.Semantic.Symbols
 
 	    public InstanceCreatedEventsSymbols InstanceCreatedEvents { get; }
 
-		public IMethodSymbol InitCacheMapping => Type.GetMembers(DelegateNames.InitCacheMapping)
-													 .OfType<IMethodSymbol>()
-													 .FirstOrDefault(method => method.ReturnsVoid && method.Parameters.Length == 1);
+		public IMethodSymbol? InitCacheMapping => Type?.GetMembers(DelegateNames.InitCacheMapping)
+													   .OfType<IMethodSymbol>()
+													   .FirstOrDefault(method => method.ReturnsVoid && method.Parameters.Length == 1);
 
 		internal PXGraphSymbols(Compilation compilation) : base(compilation, TypeFullNames.PXGraph)
         {


### PR DESCRIPTION
**Merge after https://github.com/Acumatica/Acuminator/pull/484**

Overview:
- added logic to not check with PX1018 graphs if they are abstract or their primary DACs are generic type parameters
- added unit tests to check these cases
- fixed bug in the common helper that checks if type symbol implements an interface symbol
- refactoring, nullable ref types annotation