### PR TITLE
Bugfix/atr 705 dev pxexceptioninfo support

### DIFF
--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/Localization/LocalizationMessageValidator.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/Localization/LocalizationMessageValidator.cs
@@ -23,6 +23,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.Localization
 	{
 		LocalizationMethodCall,
 		PXExceptionConstructorCall,
+		PXExceptionInfoConstructorCall,
 		PXExceptionBaseOrThisConstructorCall
 	}
 

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/Localization/LocalizationPXExceptionAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/Localization/LocalizationPXExceptionAnalyzer.cs
@@ -44,10 +44,15 @@ namespace Acuminator.Analyzers.StaticAnalysis.Localization
 
 		internal override void AnalyzeCompilation(CompilationStartAnalysisContext compilationStartContext, PXContext pxContext)
 		{
-			compilationStartContext.RegisterSyntaxNodeAction(syntaxContext => AnalyzePXExceptionConstructorInvocation(syntaxContext, pxContext),
+			compilationStartContext.RegisterSyntaxNodeAction(syntaxContext => AnalyzeConstructorInvocations(syntaxContext, pxContext),
 															 SyntaxKind.ObjectCreationExpression);
 			compilationStartContext.RegisterSyntaxNodeAction(syntaxContext => AnalyzePXExceptionChainedConstructorCall(syntaxContext, pxContext),
 															 SyntaxKind.ClassDeclaration);
+		}
+
+		private void AnalyzeConstructorInvocations(SyntaxNodeAnalysisContext syntaxContext, PXContext pxContext)
+		{
+			AnalyzePXExceptionConstructorInvocation(syntaxContext, pxContext);
 		}
 
 		private void AnalyzePXExceptionConstructorInvocation(SyntaxNodeAnalysisContext syntaxContext, PXContext pxContext)

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/Localization/LocalizationPXExceptionAndPXexceptionInfoAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/Localization/LocalizationPXExceptionAndPXexceptionInfoAnalyzer.cs
@@ -20,7 +20,16 @@ namespace Acuminator.Analyzers.StaticAnalysis.Localization
 	[DiagnosticAnalyzer(LanguageNames.CSharp)]
 	public class LocalizationPXExceptionAndPXexceptionInfoAnalyzer : PXDiagnosticAnalyzer
 	{
-		private static readonly string[] _messageArgNames = new[] { "message", "format" };
+		private static readonly string[] _pxExceptionMessageArgNames =  
+		{ 
+			"message", 
+			"format" 
+		};
+
+		private static readonly string[] _pxExceptionInfoMessageArgNames =
+		{
+			"messageFormat"
+		};
 
 		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
 			ImmutableArray.Create
@@ -44,27 +53,28 @@ namespace Acuminator.Analyzers.StaticAnalysis.Localization
 
 		internal override void AnalyzeCompilation(CompilationStartAnalysisContext compilationStartContext, PXContext pxContext)
 		{
-			compilationStartContext.RegisterSyntaxNodeAction(syntaxContext => AnalyzeConstructorInvocations(syntaxContext, pxContext),
+			compilationStartContext.RegisterSyntaxNodeAction(syntaxContext => AnalyzePXExceptionAndPXExceptionInfoConstructorInvocations(syntaxContext, pxContext),
 															 SyntaxKind.ObjectCreationExpression);
 			compilationStartContext.RegisterSyntaxNodeAction(syntaxContext => AnalyzePXExceptionChainedConstructorCall(syntaxContext, pxContext),
 															 SyntaxKind.ClassDeclaration);
 		}
 
-		private void AnalyzeConstructorInvocations(SyntaxNodeAnalysisContext syntaxContext, PXContext pxContext)
-		{
-			AnalyzePXExceptionConstructorInvocation(syntaxContext, pxContext);
-		}
-
-		private void AnalyzePXExceptionConstructorInvocation(SyntaxNodeAnalysisContext syntaxContext, PXContext pxContext)
+		private void AnalyzePXExceptionAndPXExceptionInfoConstructorInvocations(SyntaxNodeAnalysisContext syntaxContext, PXContext pxContext)
 		{
 			syntaxContext.CancellationToken.ThrowIfCancellationRequested();
 
 			if (syntaxContext.Node is not ObjectCreationExpressionSyntax constructorCall || constructorCall.ArgumentList?.Arguments.Count is null or 0)
 				return;
 
-			ITypeSymbol? exceptionType = syntaxContext.SemanticModel.GetTypeInfo(constructorCall, syntaxContext.CancellationToken).Type;
+			ITypeSymbol? createdObjectType = syntaxContext.SemanticModel.GetTypeInfo(constructorCall, syntaxContext.CancellationToken).Type;
 
-			if (exceptionType == null || !IsLocalizableException(exceptionType, pxContext))
+			if (createdObjectType == null)
+				return;
+
+			bool isLocalizableException = IsLocalizableException(createdObjectType, pxContext);
+			bool isPXExceptionInfo = createdObjectType.InheritsFromOrEquals(pxContext.Exceptions.PXExceptionInfo);
+
+			if (!isLocalizableException && !isPXExceptionInfo)
 				return;
 
 			var symbol = syntaxContext.SemanticModel.GetSymbolOrFirstCandidate(constructorCall, syntaxContext.CancellationToken);
@@ -72,13 +82,17 @@ namespace Acuminator.Analyzers.StaticAnalysis.Localization
 			if (symbol is not IMethodSymbol constructor)
 				return;
 
-			syntaxContext.CancellationToken.ThrowIfCancellationRequested();
-			ExpressionSyntax? messageExpression = GetMessageExpression(constructor, constructorCall.ArgumentList);
+			var (parameterNamesWithLocalizableData, validationContext) = isLocalizableException
+				? (_pxExceptionMessageArgNames, ValidationContext.PXExceptionConstructorCall)
+				: (_pxExceptionInfoMessageArgNames, ValidationContext.PXExceptionInfoConstructorCall);
+			ExpressionSyntax? messageExpression = GetMessageExpression(constructor, constructorCall.ArgumentList, parameterNamesWithLocalizableData);
 
 			if (messageExpression == null)
 				return;
 
-			var messageValidator = new LocalizationMessageValidator(syntaxContext, pxContext, ValidationContext.PXExceptionConstructorCall);
+			syntaxContext.CancellationToken.ThrowIfCancellationRequested();
+
+			var messageValidator = new LocalizationMessageValidator(syntaxContext, pxContext, validationContext);
 			messageValidator.ValidateMessage(messageExpression, isFormatMethod: false);
 		}
 
@@ -106,7 +120,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.Localization
 				if (symbol is not IMethodSymbol constructorSymbol)
 					continue;
 
-				ExpressionSyntax? messageExpression = GetMessageExpression(constructorSymbol, constructorCall.ArgumentList);
+				ExpressionSyntax? messageExpression = GetMessageExpression(constructorSymbol, constructorCall.ArgumentList, _pxExceptionMessageArgNames);
 
 				if (messageExpression == null)
 					continue;
@@ -116,7 +130,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.Localization
 			}
 		}
 
-		private ExpressionSyntax? GetMessageExpression(IMethodSymbol constructor, ArgumentListSyntax args)
+		private ExpressionSyntax? GetMessageExpression(IMethodSymbol constructor, ArgumentListSyntax args, string[] parametersWithLocalizableText)
 		{
 			var constructorParameters = constructor.Parameters;
 
@@ -132,7 +146,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.Localization
 			{
 				IParameterSymbol mappedParameter = argumentsToParametersMapping.Value.GetMappedParameter(constructor, argIndex);
 
-				if (_messageArgNames.Contains(mappedParameter.Name, StringComparer.Ordinal))
+				if (parametersWithLocalizableText.Contains(mappedParameter.Name, StringComparer.Ordinal))
 				{
 					var argument = args.Arguments[argIndex];
 					return argument.Expression;

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/Localization/LocalizationPXExceptionAndPXexceptionInfoAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/Localization/LocalizationPXExceptionAndPXexceptionInfoAnalyzer.cs
@@ -18,7 +18,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 namespace Acuminator.Analyzers.StaticAnalysis.Localization
 {
 	[DiagnosticAnalyzer(LanguageNames.CSharp)]
-	public class LocalizationPXExceptionAnalyzer : PXDiagnosticAnalyzer
+	public class LocalizationPXExceptionAndPXexceptionInfoAnalyzer : PXDiagnosticAnalyzer
 	{
 		private static readonly string[] _messageArgNames = new[] { "message", "format" };
 
@@ -30,7 +30,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.Localization
 				Descriptors.PX1053_ConcatenationPriorLocalization
 			);
 
-		public LocalizationPXExceptionAnalyzer() : base()
+		public LocalizationPXExceptionAndPXexceptionInfoAnalyzer() : base()
 		{
 		}
 
@@ -38,7 +38,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.Localization
 		/// Constructor for tests.
 		/// </summary>
 		/// <param name="codeAnalysisSettings">The code analysis settings.</param>
-		public LocalizationPXExceptionAnalyzer(CodeAnalysisSettings codeAnalysisSettings) : base(codeAnalysisSettings)
+		public LocalizationPXExceptionAndPXexceptionInfoAnalyzer(CodeAnalysisSettings codeAnalysisSettings) : base(codeAnalysisSettings)
 		{
 		}
 

--- a/src/Acuminator/Acuminator.Tests/Acuminator.Tests.csproj
+++ b/src/Acuminator/Acuminator.Tests/Acuminator.Tests.csproj
@@ -268,6 +268,7 @@
     <EmbeddedResource Include="Tests\StaticAnalysis\Localization\Sources\LocalizationCorrect_MessagePassedFromAnotherPXException.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\Localization\Sources\ExceptionWithConstStringFieldPassedToBaseConstructor.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\Localization\Sources\LocalizationCorrect_MessagePassedFromPXExceptionInfo.cs" />
+    <EmbeddedResource Include="Tests\StaticAnalysis\Localization\Sources\LocalizationPXExceptionInfoWithHardcodedStrings.cs" />
     <Compile Include="Tests\StaticAnalysis\NoIsActiveMethodForExtension\NoIsActiveMethodForDacExtensionTests.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\NoIsActiveMethodForExtension\Sources\DacExtension_WithIsActive.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\NoIsActiveMethodForExtension\Sources\DacExtension_WithoutIsActive.cs" />

--- a/src/Acuminator/Acuminator.Tests/Acuminator.Tests.csproj
+++ b/src/Acuminator/Acuminator.Tests/Acuminator.Tests.csproj
@@ -267,6 +267,7 @@
     <EmbeddedResource Include="Tests\StaticAnalysis\Localization\Sources\LocalizationInterpolationStringInException.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\Localization\Sources\LocalizationCorrect_MessagePassedFromAnotherPXException.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\Localization\Sources\ExceptionWithConstStringFieldPassedToBaseConstructor.cs" />
+    <EmbeddedResource Include="Tests\StaticAnalysis\Localization\Sources\LocalizationCorrect_MessagePassedFromPXExceptionInfo.cs" />
     <Compile Include="Tests\StaticAnalysis\NoIsActiveMethodForExtension\NoIsActiveMethodForDacExtensionTests.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\NoIsActiveMethodForExtension\Sources\DacExtension_WithIsActive.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\NoIsActiveMethodForExtension\Sources\DacExtension_WithoutIsActive.cs" />

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/Localization/LocalizationExceptionTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/Localization/LocalizationExceptionTests.cs
@@ -38,6 +38,17 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.Localization
 		}
 
 		[Theory]
+		[EmbeddedFileData("LocalizationPXExceptionInfoWithHardcodedStrings.cs")]
+		public async Task Localization_PXExceptionInfo_WithHardcodedMessageArgument(string source)
+		{
+			await VerifyCSharpDiagnosticAsync(source,
+				Descriptors.PX1050_HardcodedStringInLocalizationMethod.CreateFor(11, 53),
+				Descriptors.PX1050_HardcodedStringInLocalizationMethod.CreateFor(17, 64),
+				Descriptors.PX1053_ConcatenationPriorLocalization.CreateFor(25, 44),
+				Descriptors.PX1053_ConcatenationPriorLocalization.CreateFor(28, 67));
+		}
+
+		[Theory]
 		[EmbeddedFileData("ExceptionWithConstStringFieldPassedToBaseConstructor.cs")]
 		public async Task Localization_PXException_WithTypeMemberArguments_PassedToBaseConstructor(string source) =>
 			await VerifyCSharpDiagnosticAsync(source,

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/Localization/LocalizationExceptionTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/Localization/LocalizationExceptionTests.cs
@@ -80,6 +80,11 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.Localization
 			await VerifyCSharpDiagnosticAsync(source);
 
 		[Theory]
+		[EmbeddedFileData("LocalizationCorrect_MessagePassedFromPXExceptionInfo.cs")]
+		public async Task MessagePassedFromPXExceptionInfo_Exception(string source) =>
+			await VerifyCSharpDiagnosticAsync(source);
+
+		[Theory]
 		[EmbeddedFileData("LocalizationWithConcatenationInExceptions.cs",
 						  "Messages.cs")]
 		public async Task Localization_PXException_With_Concatenations(string source, string messages)

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/Localization/LocalizationExceptionTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/Localization/LocalizationExceptionTests.cs
@@ -17,7 +17,7 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.Localization
 	public class LocalizationExceptionTests : DiagnosticVerifier
 	{
 		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer() =>
-			new LocalizationPXExceptionAnalyzer(
+			new LocalizationPXExceptionAndPXexceptionInfoAnalyzer(
 				CodeAnalysisSettings.Default.WithStaticAnalysisEnabled()
 											.WithSuppressionMechanismDisabled()
 											.WithRecursiveAnalysisEnabled());

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/Localization/Sources/LocalizationCorrect_MessagePassedFromPXExceptionInfo.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/Localization/Sources/LocalizationCorrect_MessagePassedFromPXExceptionInfo.cs
@@ -1,0 +1,13 @@
+﻿using PX.Data;
+using PX.Objects.Common.Exceptions;
+
+namespace Acuminator.Tests.Tests
+{
+	public class ExceptionHelper
+	{
+		public void ThrowException(PXExceptionInfo exceptionInfo)
+		{
+			throw new PXSetPropertyException(exceptionInfo.MessageFormat, exceptionInfo.ErrorLevel, exceptionInfo.MessageArguments);  //no alert
+		}
+	}
+}

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/Localization/Sources/LocalizationCorrect_MessagePassedFromPXExceptionInfo.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/Localization/Sources/LocalizationCorrect_MessagePassedFromPXExceptionInfo.cs
@@ -10,4 +10,16 @@ namespace Acuminator.Tests.Tests
 			throw new PXSetPropertyException(exceptionInfo.MessageFormat, exceptionInfo.ErrorLevel, exceptionInfo.MessageArguments);  //no alert
 		}
 	}
+
+	// Acuminator disable once PX1063 ExceptionWithoutSerializationConstructor [Justification]
+	// Acuminator disable once PX1064 ExceptionWithNewFieldsAndNoGetObjectDataOverride [Justification]
+	public class DetailNonLocalizableBypassedException : PXException
+	{
+		public object ItemToBypass { get; }
+		public DetailNonLocalizableBypassedException(object item, PXExceptionInfo exceptionInfo)
+			: base(exceptionInfo.MessageFormat)
+		{
+			ItemToBypass = item;
+		}
+	}
 }

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/Localization/Sources/LocalizationPXExceptionInfoWithHardcodedStrings.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/Localization/Sources/LocalizationPXExceptionInfoWithHardcodedStrings.cs
@@ -1,0 +1,46 @@
+﻿using PX.Common;
+using PX.Data;
+using PX.Objects.Common.Exceptions;
+
+namespace Acuminator.Tests.Sources
+{
+    public class LocalizationExceptions
+    {
+        public void ExceptionsLocalization()
+        {
+            PXExceptionInfo e = new PXExceptionInfo("Usernames cannot contain spaces.");
+            throw new PXArgumentException(nameof(ExceptionsLocalization), e.MessageFormat);
+        }
+
+		public void CheckUserName_Bad(string userName)
+		{
+			PXExceptionInfo e = new PXExceptionInfo(PXErrorLevel.Error, "Username {0} starts with PX prefix.", userName);
+
+			if (userName.Contains(","))
+				throw new PXArgumentException(nameof(ExceptionsLocalization), e.MessageFormat, userName);
+		}
+
+		public void CheckUserName_StringFormatBad(string userName)
+		{
+			PXExceptionInfo e = new PXExceptionInfo(string.Format(Messages.ErrorPXPrefixFormatMsg, userName));
+
+			if (userName.Contains(","))
+				throw new PXArgumentException(nameof(ExceptionsLocalization), string.Format(e.MessageFormat, e.MessageArguments));
+		}
+
+		public void CheckUserName_Good(string userName)
+		{
+			PXExceptionInfo e = new PXExceptionInfo(Messages.ErrorPXPrefixFormatMsg, userName);
+
+			if (userName.Contains(","))
+				throw new PXArgumentException(nameof(ExceptionsLocalization), e.MessageFormat, userName);
+		}		
+	}
+
+	[PXLocalizable]
+	public static class Messages
+	{
+		public const string ErrorPXPrefixFormatMsg = "Username {0} starts with PX prefix.";
+		public const string ErrorCommaFormatMsg = "Username {0} contains comma.";
+	}
+}

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Constants/PropertyNames.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Constants/PropertyNames.cs
@@ -7,6 +7,8 @@ namespace Acuminator.Utilities.Roslyn.Constants
 		public static class Exception
 		{
 			public const string Message = nameof(System.Exception.Message);
+			public const string MessageFormat = "MessageFormat";
+			public const string MessageArguments = "MessageArguments";
 		}
 	}
 }

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Constants/TypeFullNames.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Constants/TypeFullNames.cs
@@ -204,6 +204,7 @@
 			public const string PXSetupNotEnteredException = "PX.Data.PXSetupNotEnteredException";
 			public const string PXRowPersistedException    = "PX.Data.PXRowPersistedException";
 			public const string PXLockViolationException   = "PX.Data.PXLockViolationException";
+			public const string PXExceptionInfo            = "PX.Objects.Common.Exceptions.PXExceptionInfo";
 		}
 
 		internal static class Serialization

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/Symbols/ExceptionSymbols.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/Symbols/ExceptionSymbols.cs
@@ -9,22 +9,20 @@ namespace Acuminator.Utilities.Roslyn.Semantic.Symbols
 {
     public class ExceptionSymbols : SymbolsSetBase
     {
-        internal ExceptionSymbols(Compilation compilation) : base(compilation)
-        {
-			Exception = Compilation.GetTypeByMetadataName(typeof(Exception).FullName);
-			PXException = Compilation.GetTypeByMetadataName(TypeFullNames.Exceptions.PXException);
-		}
-
 		public INamedTypeSymbol Exception { get; }
 
 		public INamedTypeSymbol PXException { get; }
 
-		public IPropertySymbol? PXExceptionMessage =>
-			PXException.GetMembers(PropertyNames.Exception.Message)
-					   .OfType<IPropertySymbol>()
-					   .FirstOrDefault();
+		public INamedTypeSymbol? PXExceptionInfo { get; }
 
-	    public INamedTypeSymbol PXBaseRedirectException => Compilation.GetTypeByMetadataName(TypeFullNames.Exceptions.PXBaseRedirectException);
+		public IPropertySymbol? PXException_Message { get; }
+
+		public IPropertySymbol? PXExceptionInfo_MessageFormat { get; }
+
+		public IPropertySymbol? PXExceptionInfo_MessageArguments { get; }
+
+
+		public INamedTypeSymbol PXBaseRedirectException => Compilation.GetTypeByMetadataName(TypeFullNames.Exceptions.PXBaseRedirectException);
 	    public INamedTypeSymbol PXSetupNotEnteredException => Compilation.GetTypeByMetadataName(TypeFullNames.Exceptions.PXSetupNotEnteredException);
 
 		public INamedTypeSymbol PXRowPersistedException => Compilation.GetTypeByMetadataName(TypeFullNames.Exceptions.PXRowPersistedException);
@@ -35,5 +33,21 @@ namespace Acuminator.Utilities.Roslyn.Semantic.Symbols
 		public INamedTypeSymbol ArgumentException => Compilation.GetTypeByMetadataName($"{nameof(System)}.{nameof(System.ArgumentException)}");
 		public INamedTypeSymbol NotSupportedException => Compilation.GetTypeByMetadataName($"{nameof(System)}.{nameof(System.NotSupportedException)}");
 		public INamedTypeSymbol NotImplementedException => Compilation.GetTypeByMetadataName($"{nameof(System)}.{nameof(System.NotImplementedException)}");
+
+		internal ExceptionSymbols(Compilation compilation) : base(compilation)
+		{
+			Exception = Compilation.GetTypeByMetadataName(typeof(Exception).FullName);
+			PXException = Compilation.GetTypeByMetadataName(TypeFullNames.Exceptions.PXException);
+			PXExceptionInfo = Compilation.GetTypeByMetadataName(TypeFullNames.Exceptions.PXExceptionInfo);
+
+			PXException_Message = GetProperty(PXException, PropertyNames.Exception.Message);
+			PXExceptionInfo_MessageFormat = GetProperty(PXExceptionInfo, PropertyNames.Exception.MessageFormat);
+			PXExceptionInfo_MessageArguments = GetProperty(PXExceptionInfo, PropertyNames.Exception.MessageArguments);
+		}
+
+		private IPropertySymbol? GetProperty(INamedTypeSymbol? type, string propertyName) =>
+			type?.GetMembers(propertyName)
+				 .OfType<IPropertySymbol>()
+				 .FirstOrDefault();
 	}
 }


### PR DESCRIPTION
Extra support for `PXExceptionInfo`:
- Check `PXExceptionInfo` constructor calls for passed hard-coded strings
- Do not report `PXExceptionInfo.MessageFormat` property passed to APIs that are checked for localization, such as `PXException` constructor calls
- Added unit tests for these cases
- Refactoring
