### PR TITLE
Bugfix/atr 735 dev px1095 analyze pxdb scalar

### DIFF
--- a/src/Acuminator/Acuminator.Analyzers/Acuminator.Analyzers.csproj
+++ b/src/Acuminator/Acuminator.Analyzers/Acuminator.Analyzers.csproj
@@ -3,7 +3,7 @@
     <Title>Acumatica.Analyzers</Title>
     <AssemblyTitle>Acumatica.Analyzers</AssemblyTitle>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>3.2.0</Version>
+    <Version>3.1.1</Version>
     <RepositoryUrl>https://github.com/Acumatica/Acuminator</RepositoryUrl>
     <Copyright>Copyright © 2017-2022 Acumatica Ltd.</Copyright>
     <LangVersion>9.0</LangVersion>

--- a/src/Acuminator/Acuminator.Analyzers/DiagnosticsShortName.Designer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/DiagnosticsShortName.Designer.cs
@@ -846,9 +846,18 @@ namespace Acuminator.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to NoUnboundTypeAttributeWithPXDBCalced.
         /// </summary>
-        public static string PX1095 {
+        public static string PX1095PXDBCalced {
             get {
-                return ResourceManager.GetString("PX1095", resourceCulture);
+                return ResourceManager.GetString("PX1095PXDBCalced", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to NoUnboundTypeAttributeWithPXDBScalar.
+        /// </summary>
+        public static string PX1095PXDBScalar {
+            get {
+                return ResourceManager.GetString("PX1095PXDBScalar", resourceCulture);
             }
         }
     }

--- a/src/Acuminator/Acuminator.Analyzers/DiagnosticsShortName.resx
+++ b/src/Acuminator/Acuminator.Analyzers/DiagnosticsShortName.resx
@@ -318,7 +318,7 @@
   <data name="PX1094" xml:space="preserve">
     <value>NoPXHiddenOrPXCacheNameOnDac</value>
   </data>
-  <data name="PX1095" xml:space="preserve">
+  <data name="PX1095PXDBCalced" xml:space="preserve">
     <value>NoUnboundTypeAttributeWithPXDBCalced</value>
   </data>
   <data name="PX1007" xml:space="preserve">
@@ -380,5 +380,8 @@
   </data>
   <data name="PX1064" xml:space="preserve">
     <value>ExceptionWithNewFieldsAndNoGetObjectDataOverride</value>
+  </data>
+  <data name="PX1095PXDBScalar" xml:space="preserve">
+    <value>NoUnboundTypeAttributeWithPXDBScalar</value>
   </data>
 </root>

--- a/src/Acuminator/Acuminator.Analyzers/Resources.Designer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/Resources.Designer.cs
@@ -1660,9 +1660,18 @@ namespace Acuminator.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to A field with the PXDBCalced attribute must have an unbound type attribute, such as PXDate, PXDecimal.
         /// </summary>
-        public static string PX1095Title {
+        public static string PX1095Title_PXDBCalced {
             get {
-                return ResourceManager.GetString("PX1095Title", resourceCulture);
+                return ResourceManager.GetString("PX1095Title_PXDBCalced", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to A field with the PXDBScalar attribute must have an unbound type attribute, such as PXDate, PXDecimal.
+        /// </summary>
+        public static string PX1095Title_PXDBScalar {
+            get {
+                return ResourceManager.GetString("PX1095Title_PXDBScalar", resourceCulture);
             }
         }
         

--- a/src/Acuminator/Acuminator.Analyzers/Resources.resx
+++ b/src/Acuminator/Acuminator.Analyzers/Resources.resx
@@ -468,7 +468,7 @@
   <data name="PX1094PXCacheNameDefaultArgumentValue" xml:space="preserve">
     <value>Enter a cache name for this DAC</value>
   </data>
-  <data name="PX1095Title" xml:space="preserve">
+  <data name="PX1095Title_PXDBCalced" xml:space="preserve">
     <value>A field with the PXDBCalced attribute must have an unbound type attribute, such as PXDate, PXDecimal</value>
   </data>
   <data name="PX1013Fix" xml:space="preserve">
@@ -666,5 +666,8 @@
   </data>
   <data name="PX1063Fix" xml:space="preserve">
     <value>Add a serialization constructor to the exception declaration</value>
+  </data>
+  <data name="PX1095Title_PXDBScalar" xml:space="preserve">
+    <value>A field with the PXDBScalar attribute must have an unbound type attribute, such as PXDate, PXDecimal</value>
   </data>
 </root>

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/Descriptors.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/Descriptors.cs
@@ -408,6 +408,9 @@ namespace Acuminator.Analyzers.StaticAnalysis
 			Rule("PX1094", nameof(Resources.PX1094Title).GetLocalized(), Category.Default, DiagnosticSeverity.Warning, DiagnosticsShortName.PX1094);
 
 		public static DiagnosticDescriptor PX1095_PXDBCalcedMustBeAccompaniedNonDBTypeAttribute { get; } =
-			Rule("PX1095", nameof(Resources.PX1095Title).GetLocalized(), Category.Default, DiagnosticSeverity.Error, DiagnosticsShortName.PX1095);
+			Rule("PX1095", nameof(Resources.PX1095Title_PXDBCalced).GetLocalized(), Category.Default, DiagnosticSeverity.Error, DiagnosticsShortName.PX1095PXDBCalced);
+
+		public static DiagnosticDescriptor PX1095_PXDBScalarMustBeAccompaniedNonDBTypeAttribute { get; } =
+			Rule("PX1095", nameof(Resources.PX1095Title_PXDBScalar).GetLocalized(), Category.Default, DiagnosticSeverity.Error, DiagnosticsShortName.PX1095PXDBScalar);
 	}
 }

--- a/src/Acuminator/Acuminator.Tests/Acuminator.Tests.csproj
+++ b/src/Acuminator/Acuminator.Tests/Acuminator.Tests.csproj
@@ -144,6 +144,8 @@
     <EmbeddedResource Include="Tests\StaticAnalysis\DacKeyFieldDeclaration\Sources\BaseAndDerivedDac.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\DacUiAttributes\Sources\PXMappedCacheExtension.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\DacPropertyAttributes\Sources\DacWithValidAggregatorAttributes.cs" />
+    <EmbeddedResource Include="Tests\StaticAnalysis\DacPropertyAttributes\Sources\DacWithPXDBScalarAndUnboundTypeAttributes.cs" />
+    <EmbeddedResource Include="Tests\StaticAnalysis\DacPropertyAttributes\Sources\DacWithPXDBScalarAndWithoutUnboundTypeAttributes.cs" />
     <Compile Include="Tests\StaticAnalysis\DacReferentialIntegrity\DacForeignKeyDeclaration\DacMissingForeignKeyDeclarationTests.cs" />
     <Compile Include="Tests\StaticAnalysis\DacReferentialIntegrity\DacForeignKeyDeclaration\DacForeignKeyDeclarationTests.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\DacReferentialIntegrity\DacPrimaryKeyDeclaration\Sources\MissingPrimaryKey\SOLine_Without_PrimaryKey_Expected.cs" />

--- a/src/Acuminator/Acuminator.Tests/Properties/AssemblyInfo.cs
+++ b/src/Acuminator/Acuminator.Tests/Properties/AssemblyInfo.cs
@@ -12,8 +12,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCopyright("Copyright © 2017-2022 Acumatica Ltd.")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
-[assembly: AssemblyVersion("3.2.0")]
-[assembly: AssemblyFileVersion("3.2.0")]
+[assembly: AssemblyVersion("3.1.1")]
+[assembly: AssemblyFileVersion("3.1.1")]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/DacPropertyAttributes/DacFieldWithDBCalcedAttributeTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/DacPropertyAttributes/DacFieldWithDBCalcedAttributeTests.cs
@@ -29,6 +29,20 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.DacPropertyAttributes
 			await VerifyCSharpDiagnosticAsync(source, 
 				Descriptors.PX1095_PXDBCalcedMustBeAccompaniedNonDBTypeAttribute.CreateFor(19, 28),
 				Descriptors.PX1095_PXDBCalcedMustBeAccompaniedNonDBTypeAttribute.CreateFor(38, 25),
-				Descriptors.PX1095_PXDBCalcedMustBeAccompaniedNonDBTypeAttribute.CreateFor(49, 25));
+				Descriptors.PX1095_PXDBCalcedMustBeAccompaniedNonDBTypeAttribute.CreateFor(48, 25));
+
+		[Theory]
+		[EmbeddedFileData("DacWithPXDBScalarAndUnboundTypeAttributes.cs")]
+		public async Task DacFieldWithPXDBScalarAndNonDBAttribute_DoesntReportDiagnostic(string source) =>
+			await VerifyCSharpDiagnosticAsync(source);
+
+		[Theory]
+		[EmbeddedFileData("DacWithPXDBScalarAndWithoutUnboundTypeAttributes.cs")]
+		public async Task DacFieldWithPXDBScalarAndWithoutNonDBAttribute_ReportsDiagnostic(string source) =>
+			await VerifyCSharpDiagnosticAsync(source,
+				Descriptors.PX1095_PXDBScalarMustBeAccompaniedNonDBTypeAttribute.CreateFor(20, 23),
+				Descriptors.PX1095_PXDBScalarMustBeAccompaniedNonDBTypeAttribute.CreateFor(35, 25),
+				Descriptors.PX1095_PXDBScalarMustBeAccompaniedNonDBTypeAttribute.CreateFor(44, 27),
+				Descriptors.PX1095_PXDBScalarMustBeAccompaniedNonDBTypeAttribute.CreateFor(53, 25));
 	}
 }

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/DacPropertyAttributes/Sources/DacWithMultipleCalcedOnDbSideAttributes.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/DacPropertyAttributes/Sources/DacWithMultipleCalcedOnDbSideAttributes.cs
@@ -12,7 +12,7 @@ namespace PX.Objects.HackathonDemo
 		#region OrderType
 		public abstract class orderType : IBqlField { }
 
-		[PXDBString(IsKey = true, InputMask = "")]
+		[PXString(IsKey = true, InputMask = "")]
 		[PXDBScalar(typeof(Search<DacWithMultipleSpecialTypeAttributes.orderType>))]
 		[PXDBCalced(typeof(Switch<Case<Where<orderType, Equal<CurrentValue<orderType>>>, True>, False>), typeof(bool))]
 		public string OrderType { get; set; }

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/DacPropertyAttributes/Sources/DacWithMultipleCalcedOnDbSideAttributes_Expected.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/DacPropertyAttributes/Sources/DacWithMultipleCalcedOnDbSideAttributes_Expected.cs
@@ -12,7 +12,7 @@ namespace PX.Objects.HackathonDemo
 		#region OrderType
 		public abstract class orderType : IBqlField { }
 
-		[PXDBString(IsKey = true, InputMask = "")]
+		[PXString(IsKey = true, InputMask = "")]
 		[PXDBScalar(typeof(Search<DacWithMultipleSpecialTypeAttributes.orderType>))]
 		public string OrderType { get; set; }
 		#endregion

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/DacPropertyAttributes/Sources/DacWithPXDBCalcedAndUnboundTypeAttributes.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/DacPropertyAttributes/Sources/DacWithPXDBCalcedAndUnboundTypeAttributes.cs
@@ -59,7 +59,6 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.DacFieldWithDBCalcedAttribute.So
 		#region MaxFinPeriodID
 		public abstract class maxFinPeriodID : PX.Data.BQL.BqlString.Field<maxFinPeriodID> { }
 
-		// Acuminator disable once PX1095 NoUnboundTypeAttributeWithPXDBCalced [Type field define with FinPeriod attribue]
 		[FinPeriodID(IsDBField = false)]
 		[PXDBCalced(typeof(IIf<Where<ARTranPostGL.type, Equal<ARTranPost.type.rgol>>
 			, Null

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/DacPropertyAttributes/Sources/DacWithPXDBCalcedAndWithoutUnboundTypeAttributes.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/DacPropertyAttributes/Sources/DacWithPXDBCalcedAndWithoutUnboundTypeAttributes.cs
@@ -25,12 +25,12 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.DacFieldWithDBCalcedAttribute.So
 
 		[PXDBDate]
 		public virtual DateTime? LastOutgoingActivityDate { get; set; }
+
 		public abstract class lastOutgoingActivityDate : IBqlField { }
 
 		#region MaxFinPeriodID
 		public abstract class maxFinPeriodID : PX.Data.BQL.BqlString.Field<maxFinPeriodID> { }
 
-		// Acuminator disable once PX1095 NoUnboundTypeAttributeWithPXDBCalced [Type field define with FinPeriod attribue]
 		[FinPeriodID(IsDBField = true)]
 		[PXDBCalced(typeof(IIf<Where<ARTranPostGL.type, Equal<ARTranPost.type.rgol>>
 			, Null
@@ -41,7 +41,6 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.DacFieldWithDBCalcedAttribute.So
 		#region MaxFinPeriodID2
 		public abstract class maxFinPeriodID2 : PX.Data.BQL.BqlString.Field<maxFinPeriodID2> { }
 
-		// Acuminator disable once PX1095 NoUnboundTypeAttributeWithPXDBCalced [Type field define with FinPeriod attribue]
 		[FinPeriodID]
 		[PXDBCalced(typeof(IIf<Where<ARTranPostGL.type, Equal<ARTranPost.type.rgol>>
 			, Null

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/DacPropertyAttributes/Sources/DacWithPXDBScalarAndUnboundTypeAttributes.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/DacPropertyAttributes/Sources/DacWithPXDBScalarAndUnboundTypeAttributes.cs
@@ -1,0 +1,57 @@
+﻿using PX.Data;
+using PX.Objects.CA;
+using PX.Objects.AR;
+using PX.Objects.GL;
+
+using System;
+
+namespace Acuminator.Tests.Tests.StaticAnalysis.DacFieldWithDBCalcedAttribute.Sources
+{
+	public class Activity2 : IBqlTable
+	{
+		#region OffsetCashAccountID
+		public abstract class offsetCashAccountID : PX.Data.BQL.BqlInt.Field<offsetCashAccountID> { }
+
+		[PXDBScalar(typeof(Search<CashAccount.cashAccountID,
+				Where<CashAccount.accountID, Equal<CashAccountETDetail.offsetAccountID>,
+				And<CashAccount.subID, Equal<CashAccountETDetail.offsetSubID>,
+				And<CashAccount.branchID, Equal<CashAccountETDetail.offsetBranchID>>>>>))]
+		[PXInt]
+		public virtual int? OffsetCashAccountID
+		{
+			get;
+			set;
+		}
+		#endregion
+
+		#region Descr
+		public abstract class descr : PX.Data.BQL.BqlString.Field<descr> { }
+
+		[PXDBLocalizableString(255, IsUnicode = true, NonDB = true)]
+		[PXDefault("", PersistingCheck = PXPersistingCheck.NullOrBlank)]
+		[PXUIField(DisplayName = "Description", Visibility = PXUIVisibility.SelectorVisible, Enabled = false)]
+		[PXDBScalar(
+			typeof(Search<PaymentMethod.descr>))]
+		public virtual string Descr { get; set; }
+
+		#endregion
+
+		#region CalcRGOL
+		public abstract class calcRGOL : PX.Data.BQL.BqlDecimal.Field<calcRGOL> { }
+
+		[PXDecimal]
+		[PXDBScalar(
+			typeof(Search<ARTranPostGL.rGOLAmt>))]
+		public virtual decimal? CalcRGOL { get; set; }
+		#endregion
+
+		#region MaxFinPeriodID
+		public abstract class maxFinPeriodID : PX.Data.BQL.BqlString.Field<maxFinPeriodID> { }
+
+		[FinPeriodID(IsDBField = false)]
+		[PXDBScalar(
+			typeof(Search<ARTranPostGL.finPeriodID>))]
+		public virtual string MaxFinPeriodID { get; set; }
+		#endregion
+	}
+}

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/DacPropertyAttributes/Sources/DacWithPXDBScalarAndWithoutUnboundTypeAttributes.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/DacPropertyAttributes/Sources/DacWithPXDBScalarAndWithoutUnboundTypeAttributes.cs
@@ -1,0 +1,56 @@
+﻿using PX.Data;
+using PX.Objects.CA;
+using PX.Objects.AR;
+using PX.Objects.GL;
+
+using System;
+
+namespace Acuminator.Tests.Tests.StaticAnalysis.DacFieldWithDBCalcedAttribute.Sources
+{
+	public class Activity : IBqlTable
+	{
+		#region OffsetCashAccountID
+		public abstract class offsetCashAccountID : PX.Data.BQL.BqlInt.Field<offsetCashAccountID> { }
+
+
+		[PXDBScalar(typeof(Search<CashAccount.cashAccountID,
+				Where<CashAccount.accountID, Equal<CashAccountETDetail.offsetAccountID>,
+				And<CashAccount.subID, Equal<CashAccountETDetail.offsetSubID>,
+				And<CashAccount.branchID, Equal<CashAccountETDetail.offsetBranchID>>>>>))]
+		public virtual int? OffsetCashAccountID
+		{
+			get;
+			set;
+		}
+		#endregion
+
+		#region Descr
+		public abstract class descr : PX.Data.BQL.BqlString.Field<descr> { }
+
+		[PXDBLocalizableString(255, IsUnicode = true)]
+		[PXDefault("", PersistingCheck = PXPersistingCheck.NullOrBlank)]
+		[PXUIField(DisplayName = "Description", Visibility = PXUIVisibility.SelectorVisible, Enabled = false)]
+		[PXDBScalar(
+			typeof(Search<PaymentMethod.descr>))]
+		public virtual string Descr { get; set; }
+
+		#endregion
+
+		#region CalcRGOL
+		public abstract class calcRGOL : PX.Data.BQL.BqlDecimal.Field<calcRGOL> { }
+
+		[PXDBScalar(
+			typeof(Search<ARTranPostGL.rGOLAmt>))]
+		public virtual decimal? CalcRGOL { get; set; }
+		#endregion
+
+		#region MaxFinPeriodID
+		public abstract class maxFinPeriodID : PX.Data.BQL.BqlString.Field<maxFinPeriodID> { }
+
+		[FinPeriodID]
+		[PXDBScalar(
+			typeof(Search<ARTranPostGL.finPeriodID>))]
+		public virtual string MaxFinPeriodID { get; set; }
+		#endregion
+	}
+}

--- a/src/Acuminator/Acuminator.Utilities/Acuminator.Utilities.csproj
+++ b/src/Acuminator/Acuminator.Utilities/Acuminator.Utilities.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>3.2.0</Version>
+    <Version>3.1.1</Version>
     <Copyright>Copyright © 2017-2022 Acumatica Ltd.</Copyright>
     <NeutralLanguage>en</NeutralLanguage>
     <Description>Acuminator.Utilities lib</Description>

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/PXFieldAttributes/Enum/DbBoundnessType.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/PXFieldAttributes/Enum/DbBoundnessType.cs
@@ -98,19 +98,17 @@ namespace Acuminator.Utilities.Roslyn.PXFieldAttributes
 			switch (x) 
 			{
 				case DbBoundnessType.NotDefined:
-					return y;
-
 				case DbBoundnessType.Unbound:
-					return y.CombineWithUnbound();
+					return y;		// y can't be NotDefined here
 
 				case DbBoundnessType.DbBound:
 					return y.CombineWithDbBound();
 
 				case DbBoundnessType.PXDBScalar:
-					return y.CombineWithPXDBScalar();
+					return y.CombineWithPXDBCalcedOrDBScalar(isDbScalar: true);
 
 				case DbBoundnessType.PXDBCalced:
-					return y.CombineWithPXDBCalced();
+					return y.CombineWithPXDBCalcedOrDBScalar(isDbScalar: false);
 
 				case DbBoundnessType.Error:
 					return x;
@@ -120,30 +118,6 @@ namespace Acuminator.Utilities.Roslyn.PXFieldAttributes
 					return y == DbBoundnessType.Error
 						? DbBoundnessType.Error
 						: DbBoundnessType.Unknown;
-			}
-		}
-
-		private static DbBoundnessType CombineWithUnbound(this DbBoundnessType y)
-		{
-			switch (y)
-			{
-				case DbBoundnessType.NotDefined:
-				case DbBoundnessType.Unbound:
-					return DbBoundnessType.Unbound;
-
-				case DbBoundnessType.DbBound:
-					return DbBoundnessType.DbBound;
-
-				case DbBoundnessType.PXDBCalced:
-					return DbBoundnessType.PXDBCalced;
-
-				case DbBoundnessType.PXDBScalar:
-				case DbBoundnessType.Error:
-					return DbBoundnessType.Error;
-
-				case DbBoundnessType.Unknown:
-				default:
-					return DbBoundnessType.Unknown;
 			}
 		}
 
@@ -157,12 +131,12 @@ namespace Acuminator.Utilities.Roslyn.PXFieldAttributes
 				return DbBoundnessType.Error;
 		}
 
-		private static DbBoundnessType CombineWithPXDBScalar(this DbBoundnessType y)
+		private static DbBoundnessType CombineWithPXDBCalcedOrDBScalar(this DbBoundnessType y, bool isDbScalar)
 		{
 			switch (y)
 			{
-				case DbBoundnessType.Unbound:
 				case DbBoundnessType.DbBound:
+				case DbBoundnessType.PXDBScalar:		// Multiple calced on DB side attributes should result in error
 				case DbBoundnessType.PXDBCalced:
 				case DbBoundnessType.Error:
 					return DbBoundnessType.Error;
@@ -170,25 +144,11 @@ namespace Acuminator.Utilities.Roslyn.PXFieldAttributes
 				case DbBoundnessType.Unknown:
 					return DbBoundnessType.Unknown;
 
+				case DbBoundnessType.Unbound:
 				default:
-					return DbBoundnessType.PXDBScalar;
-			}
-		}
-
-		private static DbBoundnessType CombineWithPXDBCalced(this DbBoundnessType y)
-		{
-			switch (y)
-			{
-				case DbBoundnessType.DbBound:
-				case DbBoundnessType.PXDBScalar:
-				case DbBoundnessType.Error:
-					return DbBoundnessType.Error;
-
-				case DbBoundnessType.Unknown:
-					return DbBoundnessType.Unknown;
-
-				default:
-					return DbBoundnessType.PXDBCalced;
+					return isDbScalar
+						? DbBoundnessType.PXDBScalar
+						: DbBoundnessType.PXDBCalced;
 			}
 		}
 	}

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/Dac/Infos/DacPropertyInfo.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/Dac/Infos/DacPropertyInfo.cs
@@ -53,7 +53,8 @@ namespace Acuminator.Utilities.Roslyn.Semantic.Dac
 		public ITypeSymbol PropertyType => Symbol.Type;
 
 		/// <value>
-		/// The effective type of the property.
+		/// The effective type of the property. For reference types and non nullable value types it is the same as <see cref="PropertyType"/>. 
+		/// For nulable value types it is the underlying type extracted from nullable. It is <c>T</c> for <see cref="Nullable{T}"/>.
 		/// </value>
 		public ITypeSymbol EffectivePropertyType { get; }
 

--- a/src/Acuminator/Acuminator.Vsix/AcuminatorVSPackage.cs
+++ b/src/Acuminator/Acuminator.Vsix/AcuminatorVSPackage.cs
@@ -69,7 +69,7 @@ namespace Acuminator.Vsix
 		private const string SettingsCategoryName = SharedConstants.PackageName;
 
 		public const string PackageName = SharedConstants.PackageName;
-		public const string PackageVersion = "3.2.0";
+		public const string PackageVersion = "3.1.1";
 
 		/// <summary>
 		/// AcuminatorVSPackage GUID string.

--- a/src/Acuminator/Acuminator.Vsix/Properties/AssemblyInfo.cs
+++ b/src/Acuminator/Acuminator.Vsix/Properties/AssemblyInfo.cs
@@ -9,5 +9,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 [assembly: ComVisible(false)]
-[assembly: AssemblyVersion("3.2.0")]
-[assembly: AssemblyFileVersion("3.2.0")]
+[assembly: AssemblyVersion("3.1.1")]
+[assembly: AssemblyFileVersion("3.1.1")]

--- a/src/Acuminator/Acuminator.Vsix/source.extension.vsixmanifest
+++ b/src/Acuminator/Acuminator.Vsix/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="Acumatica.Acuminator.778b19d1-1d5e-4fcb-8edb-eb103feeab7c" Version="3.2.0" Language="en-US" Publisher="Acumatica" />
+        <Identity Id="Acumatica.Acuminator.778b19d1-1d5e-4fcb-8edb-eb103feeab7c" Version="3.1.1" Language="en-US" Publisher="Acumatica" />
         <DisplayName>Acuminator</DisplayName>
         <Description xml:space="preserve">Acuminator is a Visual Studio extension that simplifies development with Acumatica Framework.  Acuminator provides the following functionality to boost developer productivity:
 - Static code analysis diagnostics, code fixes, and refactorings


### PR DESCRIPTION
MERGE AFTER https://github.com/Acumatica/Acuminator/pull/488

Overview:
- Set Acuminator version to 3.1.1
- Added for `PXDBScalarAttribute`  the same check for unbound data type attribute that exists for `PXDBCalcedAttribute`
- Updated DB boundness combination rules to correctly combine `PXDBScalar` and `Unbound` DB boundness
- Added separate PX1095 diagnostic descriptor and short name for `PXDBScalarAttribute` and updated the analyzer
- Added optimizations to use already calculated DAC property DB boundness to filter some cases, reused calculated property type from the semantic model
- Added new unit tests and updated existing ones