### PR TITLE
Bugfix/atr 745 dev px1016 false alert

### DIFF
--- a/src/Acuminator/Acuminator.Analyzers/Acuminator.Analyzers.nuspec
+++ b/src/Acuminator/Acuminator.Analyzers/Acuminator.Analyzers.nuspec
@@ -15,7 +15,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Code analyzers that help to find and fix common developer issues related to Acumatica Framework</description>
     <releaseNotes>https://github.com/Acumatica/Acuminator/blob/master/docs/ReleaseNotes.md</releaseNotes>
-    <copyright>Copyright © 2017-2019 Acumatica, Inc.</copyright>
+    <copyright>Copyright © 2017-2023 Acumatica, Inc.</copyright>
     <tags>Acumatica, Acuminator, roslyn</tags>
     <developmentDependency>true</developmentDependency>
   </metadata>

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/NoIsActiveMethodForExtension/NoIsActiveMethodForExtensionAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/NoIsActiveMethodForExtension/NoIsActiveMethodForExtensionAnalyzer.cs
@@ -29,7 +29,8 @@ namespace Acuminator.Analyzers.StaticAnalysis.NoIsActiveMethodForExtension
 		public bool ShouldAnalyze(PXContext pxContext, DacSemanticModel dacExtension) =>
 			dacExtension?.DacType == DacType.DacExtension && 
 			dacExtension.IsActiveMethodInfo == null &&
-			!dacExtension.IsMappedCacheExtension && !dacExtension.Symbol.IsAbstract && !dacExtension.Symbol.IsStatic;
+			!dacExtension.IsMappedCacheExtension && !dacExtension.Symbol.IsAbstract && 
+			!dacExtension.Symbol.IsStatic && !dacExtension.Symbol.IsGenericType;
 
 		public void Analyze(SymbolAnalysisContext symbolContext, PXContext pxContext, DacSemanticModel dacExtension)
 		{

--- a/src/Acuminator/Acuminator.Tests/Acuminator.Tests.csproj
+++ b/src/Acuminator/Acuminator.Tests/Acuminator.Tests.csproj
@@ -280,6 +280,7 @@
     <EmbeddedResource Include="Tests\StaticAnalysis\NoIsActiveMethodForExtension\Sources\GraphExtension_WithoutIsActive.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\NoIsActiveMethodForExtension\Sources\DAC_MappedCacheExtension.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\NoIsActiveMethodForExtension\Sources\WorkflowGraphExtension_WithoutIsActive.cs" />
+    <EmbeddedResource Include="Tests\StaticAnalysis\NoIsActiveMethodForExtension\Sources\GenericGraphExtension_WithoutIsActive.cs" />
     <Compile Include="Tests\StaticAnalysis\NonPublicExtensions\NonPublicGraphExtensionsTests.cs" />
     <Compile Include="Tests\StaticAnalysis\NonPublicExtensions\NonPublicDacExtensionsTests.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\NonPublicExtensions\Sources\NonPublicDacExtension_Expected.cs" />

--- a/src/Acuminator/Acuminator.Tests/Acuminator.Tests.csproj
+++ b/src/Acuminator/Acuminator.Tests/Acuminator.Tests.csproj
@@ -281,6 +281,7 @@
     <EmbeddedResource Include="Tests\StaticAnalysis\NoIsActiveMethodForExtension\Sources\DAC_MappedCacheExtension.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\NoIsActiveMethodForExtension\Sources\WorkflowGraphExtension_WithoutIsActive.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\NoIsActiveMethodForExtension\Sources\GenericGraphExtension_WithoutIsActive.cs" />
+    <EmbeddedResource Include="Tests\StaticAnalysis\NoIsActiveMethodForExtension\Sources\GenericDacExtension_WithoutIsActive.cs" />
     <Compile Include="Tests\StaticAnalysis\NonPublicExtensions\NonPublicGraphExtensionsTests.cs" />
     <Compile Include="Tests\StaticAnalysis\NonPublicExtensions\NonPublicDacExtensionsTests.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\NonPublicExtensions\Sources\NonPublicDacExtension_Expected.cs" />

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/NoIsActiveMethodForExtension/NoIsActiveMethodForDacExtensionTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/NoIsActiveMethodForExtension/NoIsActiveMethodForDacExtensionTests.cs
@@ -36,6 +36,11 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.NoIsActiveMethodForExtension
 		[Theory]
         [EmbeddedFileData("DacExtension_WithIsActive.cs")]
         public async Task DacExtension_WithIsActive_ShouldNotShowDiagnostic(string actual) =>
-			await VerifyCSharpDiagnosticAsync(actual);	
+			await VerifyCSharpDiagnosticAsync(actual);
+
+		[Theory]
+		[EmbeddedFileData("GenericDacExtension_WithoutIsActive.cs")]
+		public async Task GenericDacExtension_WithoutIsActive_ShouldNotShowDiagnostic(string actual) =>
+			await VerifyCSharpDiagnosticAsync(actual);
 	}
 }

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/NoIsActiveMethodForExtension/NoIsActiveMethodForGraphExtensionTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/NoIsActiveMethodForExtension/NoIsActiveMethodForGraphExtensionTests.cs
@@ -38,5 +38,10 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.NoIsActiveMethodForExtension
 		[EmbeddedFileData("WorkflowGraphExtension_WithoutIsActive.cs")]
 		public async Task WorkflowGraphExtension_WithoutIsActive_ShouldNotShowDiagnostic(string actual) =>
 			await VerifyCSharpDiagnosticAsync(actual);
+
+		[Theory]
+		[EmbeddedFileData("GenericGraphExtension_WithoutIsActive.cs")]
+		public async Task GenericGraphExtension_WithoutIsActive_ShouldNotShowDiagnostic(string actual) =>
+			await VerifyCSharpDiagnosticAsync(actual);
 	}
 }

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/NoIsActiveMethodForExtension/Sources/GenericDacExtension_WithoutIsActive.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/NoIsActiveMethodForExtension/Sources/GenericDacExtension_WithoutIsActive.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using PX.Data;
+
+namespace Acuminator.Tests.Tests.StaticAnalysis.NoIsActiveMethodForExtension.Sources
+{
+	public sealed class Ext<TDac> : PXCacheExtension<TDac>
+	where TDac : IBqlTable, new()
+	{
+
+	}
+}

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/NoIsActiveMethodForExtension/Sources/GenericGraphExtension_WithoutIsActive.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/NoIsActiveMethodForExtension/Sources/GenericGraphExtension_WithoutIsActive.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using PX.Data;
+
+namespace Acuminator.Tests.Tests.StaticAnalysis.NoIsActiveMethodForExtension.Sources
+{
+	public class Ext<TGraph> : PXGraphExtension<TGraph>
+	where TGraph : PXGraph, new()
+	{
+
+	}
+}

--- a/src/Acuminator/Acuminator.Vsix/Properties/AssemblyInfo.cs
+++ b/src/Acuminator/Acuminator.Vsix/Properties/AssemblyInfo.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Acuminator")]
-[assembly: AssemblyCopyright("Copyright © 2017-2022 Acumatica Ltd.")]
+[assembly: AssemblyCopyright("Copyright © 2017-2023 Acumatica Ltd.")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 [assembly: ComVisible(false)]


### PR DESCRIPTION
Overview:
- Do not check generic DAC extensions for IsActive
- Added unit tests for PX1016 for generic graph extensions scenario
- updated dates in copyright