### PR TITLE
Bugifx/atr 760 dev suppression on usings

### DIFF
--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/LegacyBqlConstant/LegacyBqlConstantAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/LegacyBqlConstant/LegacyBqlConstantAnalyzer.cs
@@ -19,7 +19,8 @@ namespace Acuminator.Analyzers.StaticAnalysis.LegacyBqlConstant
 
 		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Descriptors.PX1061_LegacyBqlConstant);
 
-		protected override bool ShouldAnalyze(PXContext pxContext) => pxContext.IsAcumatica2019R1_OrGreater;
+		protected override bool ShouldAnalyze(PXContext pxContext) =>
+			base.ShouldAnalyze(pxContext) && pxContext.IsAcumatica2019R1_OrGreater && pxContext.BqlConstantType != null;
 
 		public LegacyBqlConstantAnalyzer() : this(null)
 		{ }

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/SuppressDiagnosticFix.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/SuppressDiagnosticFix.cs
@@ -153,7 +153,7 @@ namespace Acuminator.Analyzers.StaticAnalysis
 
 			SyntaxNode? nodeToPlaceComment = reportedNode;
 
-			while (nodeToPlaceComment is not (StatementSyntax or MemberDeclarationSyntax or null))
+			while (nodeToPlaceComment is not (StatementSyntax or MemberDeclarationSyntax or UsingDirectiveSyntax or null))
 			{
 				nodeToPlaceComment = nodeToPlaceComment.Parent;
 			}

--- a/src/Acuminator/Acuminator.Utilities/DiagnosticSuppression/SuppressionManager.cs
+++ b/src/Acuminator/Acuminator.Utilities/DiagnosticSuppression/SuppressionManager.cs
@@ -322,7 +322,7 @@ namespace Acuminator.Utilities.DiagnosticSuppression
 			{
 				containsComment = CheckSuppressionCommentOnNode(diagnostic, shortName, node, cancellation);
 
-				if (node is (StatementSyntax or MemberDeclarationSyntax) || containsComment)
+				if (node is (StatementSyntax or MemberDeclarationSyntax or UsingDirectiveSyntax) || containsComment)
 					break;
 
 				node = node.Parent;

--- a/src/Acuminator/Acuminator.Utilities/DiagnosticSuppression/SuppressionManager.cs
+++ b/src/Acuminator/Acuminator.Utilities/DiagnosticSuppression/SuppressionManager.cs
@@ -315,14 +315,14 @@ namespace Acuminator.Utilities.DiagnosticSuppression
 			SyntaxNode? root = diagnostic.Location.SourceTree?.GetRoot(cancellation);
 			SyntaxNode? node = root?.FindNode(diagnostic.Location.SourceSpan);
 			bool containsComment = false;
-			string shortName = diagnostic.Descriptor.CustomTags.FirstOrDefault();
+			string? shortName = diagnostic.Descriptor.CustomTags.FirstOrDefault()?.NullIfWhiteSpace();
 
 			// Climb to the hill. Looking for comment on parents nodes.
 			while (node != null && node != root)
 			{
 				containsComment = CheckSuppressionCommentOnNode(diagnostic, shortName, node, cancellation);
 
-				if (node is StatementSyntax || node is MemberDeclarationSyntax || containsComment)
+				if (node is (StatementSyntax or MemberDeclarationSyntax) || containsComment)
 					break;
 
 				node = node.Parent;
@@ -331,16 +331,19 @@ namespace Acuminator.Utilities.DiagnosticSuppression
 			return containsComment;
 		}
 
-		private static bool CheckSuppressionCommentOnNode(Diagnostic diagnostic, string diagnosticShortName, SyntaxNode node, CancellationToken cancellation)
+		private static bool CheckSuppressionCommentOnNode(Diagnostic diagnostic, string? diagnosticShortName, SyntaxNode node, CancellationToken cancellation)
 		{
 			cancellation.ThrowIfCancellationRequested();
-			var successfulMatch = node?.GetLeadingTrivia()
-									   .Where(x => x.IsKind(SyntaxKind.SingleLineCommentTrivia))
-									   .Select(trivia => _suppressPattern.Match(trivia.ToString()))
-									   .FirstOrDefault(match => match.Success &&
-																diagnostic.Id == match.Groups[1].Value &&
-																diagnosticShortName == match.Groups[2].Value);
 
+			var trivias = node.GetLeadingTrivia();
+
+			if (trivias.Count == 0)
+				return false;
+
+			var successfulMatch = trivias.Where(x => x.IsKind(SyntaxKind.SingleLineCommentTrivia))
+										 .Select(trivia => _suppressPattern.Match(trivia.ToString()))
+										 .FirstOrDefault(match => match.Success && diagnostic.Id == match.Groups[1].Value &&
+																  (diagnosticShortName == null || diagnosticShortName == match.Groups[2].Value));
 			return successfulMatch != null;
 		}
 

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/PXContext.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/PXContext.cs
@@ -104,7 +104,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic
 		public INamedTypeSymbol PXAdapterType => Compilation.GetTypeByMetadataName(TypeFullNames.PXAdapter);
 		public INamedTypeSymbol IBqlTableType => Compilation.GetTypeByMetadataName(TypeFullNames.IBqlTable);
 		public INamedTypeSymbol IBqlFieldType => Compilation.GetTypeByMetadataName(TypeFullNames.IBqlField);
-		public INamedTypeSymbol BqlConstantType => Compilation.GetTypeByMetadataName(TypeFullNames.Constant);
+		public INamedTypeSymbol? BqlConstantType => Compilation.GetTypeByMetadataName(TypeFullNames.Constant);
 
 		public INamedTypeSymbol IPXResultsetType => Compilation.GetTypeByMetadataName(TypeFullNames.IPXResultset);
 		public INamedTypeSymbol PXResult => Compilation.GetTypeByMetadataName(TypeFullNames.PXResult);


### PR DESCRIPTION
Merge after https://github.com/Acumatica/Acuminator/pull/497

Overview - ported from CoreCompatibilyzer ability to place suppression comments on using directives + minor performance improvements.

Also fixed a separate NRE thrown on attempt to analyze PX.Common.Std

Destination set to a feature branch for a better review