### PR TITLE
fixed unescaped < and > in XML

### DIFF
--- a/src/Acuminator/Acuminator.Analyzers/Resources.Designer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/Resources.Designer.cs
@@ -196,7 +196,7 @@ namespace Acuminator.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Add an &quot;exclude&quot; tag to exclude this API from the API Reference.
+        ///   Looks up a localized string similar to Add the &lt;exclude/&gt; tag to exclude this API from the API Reference.
         /// </summary>
         public static string PX1007FixAddExcludeTag {
             get {
@@ -205,7 +205,7 @@ namespace Acuminator.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Add an &quot;inheritdoc&quot; tag for the projection DAC property with &quot;cref&quot; attribute referencing the mapped original DAC property.
+        ///   Looks up a localized string similar to Add the &lt;inheritdoc/&gt; tag for the projection DAC property with `cref` attribute referencing the mapped original DAC property.
         /// </summary>
         public static string PX1007FixAddInheritdocTag {
             get {
@@ -214,7 +214,7 @@ namespace Acuminator.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Add a &quot;summary&quot; tag with description generated from the API name.
+        ///   Looks up a localized string similar to Add the &lt;summary&gt; tag with the description generated from the API name.
         /// </summary>
         public static string PX1007FixAddSummaryTag {
             get {
@@ -223,8 +223,8 @@ namespace Acuminator.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Incorrect XML documentation of the projection DAC field property. The &quot;inheritdoc&quot; tag with &quot;cref&quot; attribute should be used for a mapped DAC field property of the projection DAC.
-        ///The &quot;cref&quot; attribute should reference the original DAC field property from the projection field&apos;s mapping:
+        ///   Looks up a localized string similar to Incorrect XML documentation of the projection DAC field property. The &lt;inheritdoc/&gt; tag with `cref` attribute should be used for a mapped DAC field property of the projection DAC.
+        ///The `cref` attribute should reference the original DAC field property from the projection field&apos;s mapping:
         ///
         ////// &lt;inheritdoc cref=&quot;OriginalDac.SomeDacField&quot;/&gt;
         ///[PXDBInt(BqlField = typeof(OriginalDac.someDacField))]
@@ -237,7 +237,7 @@ namespace Acuminator.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The DAC, DAC extension, or DAC property should have a description in the &quot;summary&quot; XML tag or &quot;inheritdoc&quot; XML tag.
+        ///   Looks up a localized string similar to The DAC, DAC extension, or DAC property should have a description in the &lt;summary&gt; tag or &lt;inheritdoc/&gt; tag.
         /// </summary>
         public static string PX1007Title_MissingDescription {
             get {

--- a/src/Acuminator/Acuminator.Analyzers/Resources.resx
+++ b/src/Acuminator/Acuminator.Analyzers/Resources.resx
@@ -160,10 +160,10 @@
     <value>This order of view declarations will cause creation of one cache instance for the following DACs: {0} and {1}</value>
   </data>
   <data name="PX1007FixAddExcludeTag" xml:space="preserve">
-    <value>Add the <exclude/> tag to exclude this API from the API Reference</value>
+    <value>Add the &lt;exclude/&gt; tag to exclude this API from the API Reference</value>
   </data>
   <data name="PX1007Title_MissingDescription" xml:space="preserve">
-    <value>The DAC, DAC extension, or DAC property should have a description in the <summary> tag or <inheritdoc/> tag</value>
+    <value>The DAC, DAC extension, or DAC property should have a description in the &lt;summary&gt; tag or &lt;inheritdoc/&gt; tag</value>
   </data>
   <data name="PX1008Title" xml:space="preserve">
     <value>The reference to {0} is captured in the {1} delegate and will cause synchronous execution of the delegate. It may lead to random bugs and data consistency issues.</value>
@@ -481,7 +481,7 @@
     <value>Only the methods of the PXCache.Persist family can be used to save changes to the database from a RowPersisted event handler</value>
   </data>
   <data name="PX1007FixAddSummaryTag" xml:space="preserve">
-    <value>Add the <summary> tag with the description generated from the API name</value>
+    <value>Add the &lt;summary&gt; tag with the description generated from the API name</value>
   </data>
   <data name="SuppressDiagnosticGroupCodeActionTitle" xml:space="preserve">
     <value>Suppress the {0} diagnostic with Acuminator</value>
@@ -674,7 +674,7 @@
     <value>The signature of the method with the PXOverride attribute must match the overriden method</value>
   </data>
   <data name="PX1007Title_IncorrectProjectionDacFieldDescription" xml:space="preserve">
-    <value>Incorrect XML documentation of the projection DAC field property. The <inheritdoc/> tag with `cref` attribute should be used for a mapped DAC field property of the projection DAC.
+    <value>Incorrect XML documentation of the projection DAC field property. The &lt;inheritdoc/&gt; tag with `cref` attribute should be used for a mapped DAC field property of the projection DAC.
 The `cref` attribute should reference the original DAC field property from the projection field's mapping:
 
 /// &lt;inheritdoc cref="OriginalDac.SomeDacField"/&gt;
@@ -682,6 +682,6 @@ The `cref` attribute should reference the original DAC field property from the p
 public virtual int? SomeDacField{ get; set; }</value>
   </data>
   <data name="PX1007FixAddInheritdocTag" xml:space="preserve">
-    <value>Add the <inheritdoc/> tag for the projection DAC property with `cref` attribute referencing the mapped original DAC property</value>
+    <value>Add the &lt;inheritdoc/&gt; tag for the projection DAC property with `cref` attribute referencing the mapped original DAC property</value>
   </data>
 </root>


### PR DESCRIPTION
Fix for unescaped usage of < and > in resx XML 