### PR TITLE
Bugfix/atr 761 dev add fix all for suppression of px1007

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -1,7 +1,7 @@
 # Acuminator Release Notes
 This document provides information about fixes, enhancements, and key features that are available in Acuminator.
 
-## Acuminator 3.1.2 - 2023-06-06
+## Acuminator 3.1.2 - 2023-06-08
 Acuminator 3.1.2 includes the bug fixes and enhancements described in this section, as well as the features that have been implemented in previous versions.
 
 ### Enhancements
@@ -18,6 +18,7 @@ In Acuminator 3.1.2, the following enhancements have been implemented:
    - The diagnostic now supports the `inheritdoc` tag for DACs, DAC extensions, and their properties. The diagnostic also checks that mapped DAC field properties of projection DACs have the `inheritdoc` tag with the `cref` attribute pointing to the corresponding DAC field property of the original DAC. 
    - A new code fix can generate the `inheritdoc` tag for a mapped DAC property of a projection DAC.
    - Code fixes of the diagnostic can now generate documentation correctly even for a badly formatted code and remove incorrect documentation tags in case of mapped projection DAC field properties. The code fixes also support doc tags declared as empty XML elements such as `<summary/>`.
+   - The Acuminator "Suppress with a local comment" code fix now supports Visual Studio "Fix All" functionality for PX1007 diagnostic. The diagnostic can be suppressed for a whole DAC. This could be useful when you do not plan to write the documentation immediately and want to leave it to the documentation team.
  
 ### Fixed Bugs
 In this version of Acuminator, the following bugs have been fixed:

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -18,7 +18,7 @@ In Acuminator 3.1.2, the following enhancements have been implemented:
    - The diagnostic now supports the `inheritdoc` tag for DACs, DAC extensions, and their properties. The diagnostic also checks that mapped DAC field properties of projection DACs have the `inheritdoc` tag with the `cref` attribute pointing to the corresponding DAC field property of the original DAC. 
    - A new code fix can generate the `inheritdoc` tag for a mapped DAC property of a projection DAC.
    - Code fixes of the diagnostic can now generate documentation correctly even for a badly formatted code and remove incorrect documentation tags in case of mapped projection DAC field properties. The code fixes also support doc tags declared as empty XML elements such as `<summary/>`.
-   - The Acuminator "Suppress with a local comment" code fix now supports Visual Studio "Fix All" functionality for PX1007 diagnostic. The diagnostic can be suppressed for a whole DAC. This could be useful when you do not plan to write the documentation immediately and want to leave it to the documentation team.
+   - The **Suppress with a local comment** code fix of Acuminator now supports the **Fix All** functionality of Visual Studio for the [PX1007](diagnostics/PX1007.md) diagnostic. The diagnostic can be suppressed for a whole DAC. Suppressing the diagnostic could be useful when you do not plan to write the documentation immediately and want to leave it to the documentation team.
  
 ### Fixed Bugs
 In this version of Acuminator, the following bugs have been fixed:

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/SuppressDiagnosticNoFixAll.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/SuppressDiagnosticNoFixAll.cs
@@ -1,0 +1,34 @@
+﻿#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+
+using Acuminator.Utilities.Common;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+
+namespace Acuminator.Analyzers.StaticAnalysis
+{
+	[Shared]
+	[ExportCodeFixProvider(LanguageNames.CSharp)]
+	public class SuppressDiagnosticNoFixAll : SuppressDiagnosticFixBase
+	{
+		public override ImmutableArray<string> FixableDiagnosticIds { get; }
+
+		public SuppressDiagnosticNoFixAll()
+		{
+			FixableDiagnosticIds = AllCollectedFixableDiagnosticIds.Where(id => !DiagnosticIdsWithFixAllEnabled.Contains(id))
+																   .ToImmutableArray();
+		}
+
+		/// <summary>
+		/// Explicitly disable Fix All for diagnostics.
+		/// </summary>
+		/// <returns/>
+		public override FixAllProvider? GetFixAllProvider() => null;
+	}
+}

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/SuppressDiagnosticWithFixAll.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/SuppressDiagnosticWithFixAll.cs
@@ -1,0 +1,30 @@
+﻿#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+
+using Acuminator.Utilities.Common;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+
+namespace Acuminator.Analyzers.StaticAnalysis
+{
+	[Shared]
+	[ExportCodeFixProvider(LanguageNames.CSharp)]
+	public class SuppressDiagnosticWithFixAll : SuppressDiagnosticFixBase
+	{
+		public override ImmutableArray<string> FixableDiagnosticIds { get; }
+
+		public override FixAllProvider? GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+		public SuppressDiagnosticWithFixAll()
+		{
+			FixableDiagnosticIds = AllCollectedFixableDiagnosticIds.Where(id => DiagnosticIdsWithFixAllEnabled.Contains(id))
+																   .ToImmutableArray();
+		}
+	}
+}

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/SuppressDiagnosticWithFixAll.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/SuppressDiagnosticWithFixAll.cs
@@ -17,14 +17,14 @@ namespace Acuminator.Analyzers.StaticAnalysis
 	[ExportCodeFixProvider(LanguageNames.CSharp)]
 	public class SuppressDiagnosticWithFixAll : SuppressDiagnosticFixBase
 	{
-		public override ImmutableArray<string> FixableDiagnosticIds { get; }
-
-		public override FixAllProvider? GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+		public override ImmutableArray<string> FixableDiagnosticIds { get; }	
 
 		public SuppressDiagnosticWithFixAll()
 		{
 			FixableDiagnosticIds = AllCollectedFixableDiagnosticIds.Where(id => DiagnosticIdsWithFixAllEnabled.Contains(id))
 																   .ToImmutableArray();
 		}
+
+		public override FixAllProvider? GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
 	}
 }

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/SuppressionDiagnostics/SuppressDiagnosticTestCodeFix.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/SuppressionDiagnostics/SuppressDiagnosticTestCodeFix.cs
@@ -1,4 +1,6 @@
-﻿using Acuminator.Analyzers.StaticAnalysis;
+﻿using System.Collections.Immutable;
+
+using Acuminator.Analyzers.StaticAnalysis;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
@@ -8,8 +10,12 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.SuppressionDiagnostics
 	/// <summary>
 	/// The test code fix to verify diagnostic suppression with a comment code fix .
 	/// </summary>
-	internal class SuppressDiagnosticTestCodeFix : SuppressDiagnosticFix
+	internal class SuppressDiagnosticTestCodeFix : SuppressDiagnosticFixBase
 	{
+		public override ImmutableArray<string> FixableDiagnosticIds => AllCollectedFixableDiagnosticIds;
+
+		public override FixAllProvider GetFixAllProvider() => null;
+
 		/// <summary>
 		/// Gets code action to register. OVerrides the default method that returns code action with nested code actions. 
 		/// The override returns just one code action with a "suppress with comment" code fix.


### PR DESCRIPTION
Another small enhancement to ease the work with DAC annotation, this one supports the workflow in which the developer suppress the PX1007 diagnostic as to be documented later, and creates a task for the doc team to write the documentation.

Overview:
- Suppress diagnostic code fix is split into two code fixes with a common abstract base class that contains most of the logic. The base code fix collects all existing diagnostics and also contains a list of diagnostics that support Fix All (which is only PX1007 currently).
- The concrete code fixes differ only in the way they support Fix All functionality. The code fix that doesn't support Fix All is registered for all diagnostics except PX1007 and the other code fix is registered for PX1007
- Updated unit tests