### PR TITLE
Bugfix/atr 805 dev forbid database record status dac field name

### DIFF
--- a/docs/Summary.md
+++ b/docs/Summary.md
@@ -36,7 +36,7 @@ Acuminator does not perform static analysis of projects whose names contain `Tes
 | [PX1023](diagnostics/PX1023.md) | The DAC property is marked with multiple field type attributes. | Error | Available |
 | [PX1024](diagnostics/PX1024.md) | The DAC class field must be abstract. | Error | Available |
 | [PX1026](diagnostics/PX1026.md) | Underscores cannot be used in the names of DACs and DAC fields. | Error | Available |
-| [PX1027](diagnostics/PX1027.md) | The `CompanyMask`, `CompanyID`, `Notes`, `Files`, and `DeletedDatabaseRecord` fields cannot be declared in DACs. The name of a DAC field also cannot begin with the `Company` prefix. | Error | Available |
+| [PX1027](diagnostics/PX1027.md) | The `CompanyMask`, `CompanyID`, `Notes`, `Files`, `DatabaseRecordStatus`, and `DeletedDatabaseRecord` fields cannot be declared in DACs. The name of a DAC field also cannot begin with the `Company` prefix. | Error | Available |
 | [PX1028](diagnostics/PX1028.md) | Constructors in DACs are prohibited. | Error | Available |
 | [PX1029](diagnostics/PX1029.md) | `PXGraph` instances cannot be used inside DAC properties. | Error | Unavailable |
 | [PX1030](diagnostics/PX1030.md) | The `PXDefault` attribute of the field is used incorrectly. | Warning (ISV Level 1: Significant) or Error | Available |

--- a/docs/Summary.md
+++ b/docs/Summary.md
@@ -36,7 +36,7 @@ Acuminator does not perform static analysis of projects whose names contain `Tes
 | [PX1023](diagnostics/PX1023.md) | The DAC property is marked with multiple field type attributes. | Error | Available |
 | [PX1024](diagnostics/PX1024.md) | The DAC class field must be abstract. | Error | Available |
 | [PX1026](diagnostics/PX1026.md) | Underscores cannot be used in the names of DACs and DAC fields. | Error | Available |
-| [PX1027](diagnostics/PX1027.md) | The `CompanyMask`, `CompanyID`, and `DeletedDatabaseRecord` fields cannot be declared in DACs. The name of a DAC field also cannot begin with the `Company` prefix. | Error | Available |
+| [PX1027](diagnostics/PX1027.md) | The `CompanyMask`, `CompanyID`, `Notes`, `Files`, and `DeletedDatabaseRecord` fields cannot be declared in DACs. The name of a DAC field also cannot begin with the `Company` prefix. | Error | Available |
 | [PX1028](diagnostics/PX1028.md) | Constructors in DACs are prohibited. | Error | Available |
 | [PX1029](diagnostics/PX1029.md) | `PXGraph` instances cannot be used inside DAC properties. | Error | Unavailable |
 | [PX1030](diagnostics/PX1030.md) | The `PXDefault` attribute of the field is used incorrectly. | Warning (ISV Level 1: Significant) or Error | Available |

--- a/docs/diagnostics/PX1027.md
+++ b/docs/diagnostics/PX1027.md
@@ -3,12 +3,12 @@ This document describes the PX1027 diagnostic.
 
 ## Summary
 
-| Code   | Short Description                                                                                                                                                                     | Type  | Code Fix  | 
-| ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----- | --------- | 
-| PX1027 | The `CompanyMask`, `CompanyID`, `Notes`, `Files`, and `DeletedDatabaseRecord` fields cannot be declared in DACs. The name of a DAC field also cannot begin with the `Company` prefix. | Error | Available |
+| Code   | Short Description                                                                                                                                                                                             | Type  | Code Fix  | 
+| ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----- | --------- | 
+| PX1027 | The `CompanyMask`, `CompanyID`, `Notes`, `Files`, `DatabaseRecordStatus`, and `DeletedDatabaseRecord` fields cannot be declared in DACs. The name of a DAC field also cannot begin with the `Company` prefix. | Error | Available |
 
 ## Diagnostic Description
-The `CompanyMask`, `CompanyID`, `Notes`, `Files`, and `DeletedDatabaseRecord` table columns are handled automatically by the system and the corresponding fields cannot be declared in DACs. 
+The `CompanyMask`, `CompanyID`, `Notes`, `Files`, `DatabaseRecordStatus`, and `DeletedDatabaseRecord` table columns are handled automatically by the system and the corresponding fields cannot be declared in DACs. 
 A name of a DAC field also cannot begin with the `Company` prefix because such DAC fields are incorrectly handled by the system when the data in the database table is shared between multiple tenants via Acumatica Company Masks. 
 
 The code fix works only for DAC fields with incorrect names and removes the unnecessary field from the DAC. DAC fields which name starts with the `Company` prefix do not have a code fix.

--- a/docs/diagnostics/PX1027.md
+++ b/docs/diagnostics/PX1027.md
@@ -3,12 +3,12 @@ This document describes the PX1027 diagnostic.
 
 ## Summary
 
-| Code   | Short Description                                                                                                                                  | Type  | Code Fix  | 
-| ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----- | --------- | 
-| PX1027 | The `CompanyMask`, `CompanyID`, and `DeletedDatabaseRecord` fields cannot be declared in DACs. The name of a DAC field also cannot begin with the `Company` prefix. | Error | Available |
+| Code   | Short Description                                                                                                                                                                     | Type  | Code Fix  | 
+| ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----- | --------- | 
+| PX1027 | The `CompanyMask`, `CompanyID`, `Notes`, `Files`, and `DeletedDatabaseRecord` fields cannot be declared in DACs. The name of a DAC field also cannot begin with the `Company` prefix. | Error | Available |
 
 ## Diagnostic Description
-The `CompanyMask`, `CompanyID`, and `DeletedDatabaseRecord` table columns are handled automatically by the system and the corresponding fields cannot be declared in DACs. 
+The `CompanyMask`, `CompanyID`, `Notes`, `Files`, and `DeletedDatabaseRecord` table columns are handled automatically by the system and the corresponding fields cannot be declared in DACs. 
 A name of a DAC field also cannot begin with the `Company` prefix because such DAC fields are incorrectly handled by the system when the data in the database table is shared between multiple tenants via Acumatica Company Masks. 
 
 The code fix works only for DAC fields with incorrect names and removes the unnecessary field from the DAC. DAC fields which name starts with the `Company` prefix do not have a code fix.

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/ForbiddenFieldsInDac/DacForbiddenFieldsNonISVTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/ForbiddenFieldsInDac/DacForbiddenFieldsNonISVTests.cs
@@ -33,7 +33,11 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.ForbiddenFieldsInDac
 				Descriptors.PX1027_ForbiddenFieldsInDacDeclaration_NonISV.CreateFor(27, 25, "deletedDatabaseRecord"),
 				Descriptors.PX1027_ForbiddenFieldsInDacDeclaration_NonISV.CreateFor(30, 17, "DeletedDatabaseRecord"),
 				Descriptors.PX1027_ForbiddenFieldsInDacDeclaration.CreateFor(39, 25, "companyMask"),
-				Descriptors.PX1027_ForbiddenFieldsInDacDeclaration.CreateFor(42, 17, "CompanyMask"));
+				Descriptors.PX1027_ForbiddenFieldsInDacDeclaration.CreateFor(42, 17, "CompanyMask"),
+				Descriptors.PX1027_ForbiddenFieldsInDacDeclaration.CreateFor(45, 25, "notes"),
+				Descriptors.PX1027_ForbiddenFieldsInDacDeclaration.CreateFor(48, 17, "Notes"),
+				Descriptors.PX1027_ForbiddenFieldsInDacDeclaration.CreateFor(51, 25, "files"),
+				Descriptors.PX1027_ForbiddenFieldsInDacDeclaration.CreateFor(54, 17, "Files"));
 
 		[Theory]
 		[EmbeddedFileData("DacFieldsWithCompanyPrefix.cs")]

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/ForbiddenFieldsInDac/DacForbiddenFieldsNonISVTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/ForbiddenFieldsInDac/DacForbiddenFieldsNonISVTests.cs
@@ -37,7 +37,9 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.ForbiddenFieldsInDac
 				Descriptors.PX1027_ForbiddenFieldsInDacDeclaration.CreateFor(45, 25, "notes"),
 				Descriptors.PX1027_ForbiddenFieldsInDacDeclaration.CreateFor(48, 17, "Notes"),
 				Descriptors.PX1027_ForbiddenFieldsInDacDeclaration.CreateFor(51, 25, "files"),
-				Descriptors.PX1027_ForbiddenFieldsInDacDeclaration.CreateFor(54, 17, "Files"));
+				Descriptors.PX1027_ForbiddenFieldsInDacDeclaration.CreateFor(54, 17, "Files"),
+				Descriptors.PX1027_ForbiddenFieldsInDacDeclaration.CreateFor(57, 25, "databaseRecordStatus"),
+				Descriptors.PX1027_ForbiddenFieldsInDacDeclaration.CreateFor(60, 15, "DatabaseRecordStatus"));
 
 		[Theory]
 		[EmbeddedFileData("DacFieldsWithCompanyPrefix.cs")]

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/ForbiddenFieldsInDac/DacForbiddenFieldsTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/ForbiddenFieldsInDac/DacForbiddenFieldsTests.cs
@@ -30,7 +30,11 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.ForbiddenFieldsInDac
 				Descriptors.PX1027_ForbiddenFieldsInDacDeclaration.CreateFor(27, 25, "deletedDatabaseRecord"),
 				Descriptors.PX1027_ForbiddenFieldsInDacDeclaration.CreateFor(30, 17, "DeletedDatabaseRecord"),
 				Descriptors.PX1027_ForbiddenFieldsInDacDeclaration.CreateFor(39, 25, "companyMask"),
-				Descriptors.PX1027_ForbiddenFieldsInDacDeclaration.CreateFor(42, 17, "CompanyMask"));
+				Descriptors.PX1027_ForbiddenFieldsInDacDeclaration.CreateFor(42, 17, "CompanyMask"),
+				Descriptors.PX1027_ForbiddenFieldsInDacDeclaration.CreateFor(45, 25, "notes"),
+				Descriptors.PX1027_ForbiddenFieldsInDacDeclaration.CreateFor(48, 17, "Notes"),
+				Descriptors.PX1027_ForbiddenFieldsInDacDeclaration.CreateFor(51, 25, "files"),
+				Descriptors.PX1027_ForbiddenFieldsInDacDeclaration.CreateFor(54, 17, "Files"));
 
 		[Theory]
 		[EmbeddedFileData("DacFieldsWithCompanyPrefix.cs")]

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/ForbiddenFieldsInDac/DacForbiddenFieldsTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/ForbiddenFieldsInDac/DacForbiddenFieldsTests.cs
@@ -34,7 +34,9 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.ForbiddenFieldsInDac
 				Descriptors.PX1027_ForbiddenFieldsInDacDeclaration.CreateFor(45, 25, "notes"),
 				Descriptors.PX1027_ForbiddenFieldsInDacDeclaration.CreateFor(48, 17, "Notes"),
 				Descriptors.PX1027_ForbiddenFieldsInDacDeclaration.CreateFor(51, 25, "files"),
-				Descriptors.PX1027_ForbiddenFieldsInDacDeclaration.CreateFor(54, 17, "Files"));
+				Descriptors.PX1027_ForbiddenFieldsInDacDeclaration.CreateFor(54, 17, "Files"),
+				Descriptors.PX1027_ForbiddenFieldsInDacDeclaration.CreateFor(57, 25, "databaseRecordStatus"),
+				Descriptors.PX1027_ForbiddenFieldsInDacDeclaration.CreateFor(60, 15, "DatabaseRecordStatus"));
 
 		[Theory]
 		[EmbeddedFileData("DacFieldsWithCompanyPrefix.cs")]

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/ForbiddenFieldsInDac/Sources/DacForbiddenFields.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/ForbiddenFieldsInDac/Sources/DacForbiddenFields.cs
@@ -53,5 +53,11 @@ namespace PX.Objects.HackathonDemo
 		[PXUIField(DisplayName = "Files")]
 		public string Files { get; set; }
 		#endregion
+		#region DatabaseRecordStatus
+		public abstract class databaseRecordStatus : PX.Data.BQL.BqlInt.Field<databaseRecordStatus> { }
+		[PXDBString(2000, IsUnicode = true, InputMask = "")]
+		[PXUIField(DisplayName = "DatabaseRecordStatus")]
+		public int? DatabaseRecordStatus { get; set; }
+		#endregion
 	}
 }

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/ForbiddenFieldsInDac/Sources/DacForbiddenFields.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/ForbiddenFieldsInDac/Sources/DacForbiddenFields.cs
@@ -41,5 +41,17 @@ namespace PX.Objects.HackathonDemo
 		[PXUIField(DisplayName = "Company Mask")]
 		public string CompanyMask { get; set; }
 		#endregion
+		#region Notes
+		public abstract class notes : PX.Data.BQL.BqlString.Field<notes> { }
+		[PXDBString(2000, IsUnicode = true, InputMask = "")]
+		[PXUIField(DisplayName = "Notes")]
+		public string Notes { get; set; }
+		#endregion
+		#region Files
+		public abstract class files : PX.Data.BQL.BqlString.Field<files> { }
+		[PXDBString(2000, IsUnicode = true, InputMask = "")]
+		[PXUIField(DisplayName = "Files")]
+		public string Files { get; set; }
+		#endregion
 	}
 }

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/ForbiddenFieldsInDac/Sources/DacForbiddenFields_Expected.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/ForbiddenFieldsInDac/Sources/DacForbiddenFields_Expected.cs
@@ -28,5 +28,9 @@ namespace PX.Objects.HackathonDemo
 		#endregion
 
 
+
+
+
+
 	}
 }

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/ForbiddenFieldsInDac/Sources/DacForbiddenFields_Expected.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/ForbiddenFieldsInDac/Sources/DacForbiddenFields_Expected.cs
@@ -32,5 +32,7 @@ namespace PX.Objects.HackathonDemo
 
 
 
+
+
 	}
 }

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Constants/DacFieldNames.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Constants/DacFieldNames.cs
@@ -51,12 +51,16 @@ namespace Acuminator.Utilities.Roslyn.Constants
 			public const string DeletedDatabaseRecord = "DeletedDatabaseRecord";
 			public const string CompanyID 			  = "CompanyID";
 			public const string CompanyMask 		  = "CompanyMask";
+			public const string Notes 				  = "Notes";
+			public const string Files 				  = "Files";
 
 			public static ImmutableArray<string> All { get; } = new[]
 			{
 				DeletedDatabaseRecord,
 				CompanyID,
-				CompanyMask
+				CompanyMask,
+				Notes,
+				Files
 			}
 			.ToImmutableArray();
 		}

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Constants/DacFieldNames.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Constants/DacFieldNames.cs
@@ -49,6 +49,7 @@ namespace Acuminator.Utilities.Roslyn.Constants
 		public static class Restricted
 		{
 			public const string DeletedDatabaseRecord = "DeletedDatabaseRecord";
+			public const string DatabaseRecordStatus  = "DatabaseRecordStatus";
 			public const string CompanyID 			  = "CompanyID";
 			public const string CompanyMask 		  = "CompanyMask";
 			public const string Notes 				  = "Notes";
@@ -57,6 +58,7 @@ namespace Acuminator.Utilities.Roslyn.Constants
 			public static ImmutableArray<string> All { get; } = new[]
 			{
 				DeletedDatabaseRecord,
+				DatabaseRecordStatus,
 				CompanyID,
 				CompanyMask,
 				Notes,


### PR DESCRIPTION
**Merge after https://github.com/Acumatica/Acuminator/pull/526**

Forbid `DatabaseRecordStatus` DAC field.

Overview:
- Added new reserved `DatabaseRecordStatus` DAC field.
- Extended unit tests with new field
- Updated PX1027 documentation

