### PR TITLE
Bugfix/atr 806 dev integrate caller argument expression

### DIFF
--- a/src/Acuminator/Acuminator.Analyzers/ResourcesHelper.cs
+++ b/src/Acuminator/Acuminator.Analyzers/ResourcesHelper.cs
@@ -9,15 +9,10 @@ namespace Acuminator.Analyzers
 {
 	public static class ResourcesHelper
 	{
-		public static LocalizableString GetLocalized(this string resourceName)
-		{
-			return new LocalizableResourceString(resourceName, Resources.ResourceManager, typeof(Resources));
-		}
+		public static LocalizableString GetLocalized(this string resourceName) => 
+			new LocalizableResourceString(resourceName, Resources.ResourceManager, typeof(Resources));
 
-		public static LocalizableString GetLocalized<TResource>(this string resourceName, ResourceManager resourceManager)
-		{
-			resourceManager.ThrowOnNull(nameof(resourceManager));
-			return new LocalizableResourceString(resourceName, resourceManager, typeof(TResource));
-		}
+		public static LocalizableString GetLocalized<TResource>(this string resourceName, ResourceManager resourceManager) => 
+			new LocalizableResourceString(resourceName, resourceManager.CheckIfNull(), typeof(TResource));
 	}
 }

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/CallingBaseActionHandler/CallingBaseActionHandlerFromOverrideHandlerAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/CallingBaseActionHandler/CallingBaseActionHandlerFromOverrideHandlerAnalyzer.cs
@@ -71,8 +71,8 @@ namespace Acuminator.Analyzers.StaticAnalysis.CallingBaseActionHandler
 			public Walker(SymbolAnalysisContext context, PXContext pxContext, HashSet<ISymbol> baseActions, HashSet<IMethodSymbol> baseHandlers)
 				: base(pxContext, context.CancellationToken)
 			{
-				_baseActions = baseActions.CheckIfNull(nameof(baseActions));
-				_baseHandlers = baseHandlers.CheckIfNull(nameof(baseHandlers));
+				_baseActions = baseActions.CheckIfNull();
+				_baseHandlers = baseHandlers.CheckIfNull();
 				_context = context;
 			}
 

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/ChangesInPXCache/Walker.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/ChangesInPXCache/Walker.cs
@@ -18,10 +18,8 @@ namespace Acuminator.Analyzers.StaticAnalysis.ChangesInPXCache
 					  params object[] messageArgs)
 			: base(pxContext, context.CancellationToken)
 		{
-			diagnosticDescriptor.ThrowOnNull(nameof (diagnosticDescriptor));
-
 			_context = context;
-			_diagnosticDescriptor = diagnosticDescriptor;
+			_diagnosticDescriptor = diagnosticDescriptor.CheckIfNull();
 			_messageArgs = messageArgs;
 		}
 

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/DacExtensionDefaultAttribute/DacExtensionDefaultAttributeFix.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/DacExtensionDefaultAttribute/DacExtensionDefaultAttributeFix.cs
@@ -154,11 +154,10 @@ namespace Acuminator.Analyzers.StaticAnalysis.DacExtensionDefaultAttribute
 
 		public static bool IsBoundField(Diagnostic diagnostic)
 		{
-			diagnostic.ThrowOnNull(nameof(diagnostic));
+			diagnostic.ThrowOnNull();
 
-			return diagnostic.Properties.TryGetValue(DiagnosticProperty.IsBoundField, out string boundFlag)
-				? boundFlag == bool.TrueString
-				: false;
+			return diagnostic.Properties.TryGetValue(DiagnosticProperty.IsBoundField, out string boundFlag) && 
+				   boundFlag == bool.TrueString;
 		}
 	}
 

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/DatabaseQueries/DatabaseQueriesInRowSelectingAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/DatabaseQueries/DatabaseQueriesInRowSelectingAnalyzer.cs
@@ -44,8 +44,8 @@ namespace Acuminator.Analyzers.StaticAnalysis.DatabaseQueries
 
 				public PXConnectionScopeVisitor(DiagnosticWalker parent, PXContext pxContext)
 				{
-					_parent = parent.CheckIfNull(nameof(parent));
-					_pxContext = pxContext.CheckIfNull(nameof(pxContext));
+					_parent = parent.CheckIfNull();
+					_pxContext = pxContext.CheckIfNull();
 				}
 
 				public override bool VisitUsingStatement(UsingStatementSyntax node)

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/DatabaseQueries/Walker.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/DatabaseQueries/Walker.cs
@@ -25,7 +25,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.DatabaseQueries
 		public Walker(SymbolAnalysisContext context, PXContext pxContext, DiagnosticDescriptor diagnosticDescriptor)
 			: base(pxContext, context.CancellationToken)
 		{
-			diagnosticDescriptor.ThrowOnNull(nameof(diagnosticDescriptor));
+			diagnosticDescriptor.ThrowOnNull();
 
 			_context = context;
 			_diagnosticDescriptor = diagnosticDescriptor;

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/DiagnosticUtils.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/DiagnosticUtils.cs
@@ -13,7 +13,7 @@ namespace Acuminator.Analyzers.StaticAnalysis
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static bool IsRegisteredForCodeFix(this Diagnostic diagnostic, bool considerRegisteredByDefault = true)
 		{
-			diagnostic.ThrowOnNull(nameof(diagnostic));
+			diagnostic.ThrowOnNull();
 
 			return diagnostic.Properties.TryGetValue(DiagnosticProperty.RegisterCodeFix, out string registered) 
 				? registered == bool.TrueString
@@ -23,8 +23,8 @@ namespace Acuminator.Analyzers.StaticAnalysis
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static bool IsFlagSet(this Diagnostic diagnostic, string flagName, bool? defaultValueForMissingFlag = null)
 		{
-			diagnostic.ThrowOnNull(nameof(diagnostic));
-			flagName.ThrowOnNullOrWhiteSpace(nameof(flagName));
+			diagnostic.ThrowOnNull();
+			flagName.ThrowOnNullOrWhiteSpace();
 
 			bool defaultValue = defaultValueForMissingFlag ?? false;
 
@@ -36,8 +36,8 @@ namespace Acuminator.Analyzers.StaticAnalysis
 
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static bool TryGetPropertyValue(this Diagnostic diagnostic, string propertyName, out string? propertyValue) =>
-			TryGetPropertyValueInternal(diagnostic.CheckIfNull(nameof(diagnostic)), 
-										propertyName.CheckIfNullOrWhiteSpace(nameof(propertyName)), 
+			TryGetPropertyValueInternal(diagnostic.CheckIfNull(), 
+										propertyName.CheckIfNullOrWhiteSpace(), 
 										out propertyValue);
 		
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/Localization/LocalizationMessageValidator.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/Localization/LocalizationMessageValidator.cs
@@ -43,7 +43,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.Localization
 											ValidationContext validationContext)
 		{
 			_syntaxContext = syntaxContext;
-			_pxContext = pxContext.CheckIfNull(nameof(pxContext));
+			_pxContext = pxContext.CheckIfNull();
 			_validationContext = validationContext;	
 		}
 

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/LongOperationDelegateClosures/LongOperationDelegateClosuresAnalyzer.CapturedLocalInstancesInExpressionsChecker.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/LongOperationDelegateClosures/LongOperationDelegateClosuresAnalyzer.CapturedLocalInstancesInExpressionsChecker.cs
@@ -39,8 +39,8 @@ namespace Acuminator.Analyzers.StaticAnalysis.LongOperationDelegateClosures
 															  SemanticModel semanticModel, PXContext pxContext, CancellationToken cancellation)
 			{
 				_outerMethodParametersToNotBeCaptured = outerMethodParametersToNotBeCaptured;
-				_semanticModel = semanticModel.CheckIfNull(nameof(semanticModel));
-				_pxContext = pxContext.CheckIfNull(nameof(pxContext));
+				_semanticModel = semanticModel.CheckIfNull();
+				_pxContext = pxContext.CheckIfNull();
 				_cancellation = cancellation;
 			}
 

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/LongOperationDelegateClosures/NonCapturableData/NonCapturableElementsInfo.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/LongOperationDelegateClosures/NonCapturableData/NonCapturableElementsInfo.cs
@@ -51,7 +51,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.LongOperationDelegateClosures
 
 		public NonCapturableElementsInfo(IReadOnlyDictionary<string, PassedParameter> nonCapturableContainingMethodsParameters)
 		{
-			nonCapturableContainingMethodsParameters.ThrowOnNull(nameof(nonCapturableContainingMethodsParameters));
+			nonCapturableContainingMethodsParameters.ThrowOnNull();
 
 			if (nonCapturableContainingMethodsParameters is Dictionary<string, PassedParameter> dictionary)
 				_nonCapturableContainingMethodsParameters = dictionary;
@@ -67,7 +67,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.LongOperationDelegateClosures
 		[MemberNotNull(nameof(_arguments))]
 		public void AddCallArgument(NonCapturableArgument nonCapturableArgument)
 		{
-			nonCapturableArgument.ThrowOnNull(nameof(nonCapturableArgument));
+			nonCapturableArgument.ThrowOnNull();
 
 			_arguments ??= new List<NonCapturableArgument>(capacity: 1);
 			_arguments.Add(nonCapturableArgument);
@@ -102,7 +102,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.LongOperationDelegateClosures
 		{
 			_nonCapturableContainingMethodsParameters?.Remove(parameterName);
 
-			var affectedArguments = GetCallArgumentsUsingParameter(parameterName.CheckIfNull(nameof(parameterName)));
+			var affectedArguments = GetCallArgumentsUsingParameter(parameterName.CheckIfNull());
 
 			if (affectedArguments.IsNullOrEmpty())
 				return;

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/LongOperationDelegateClosures/NonCapturableData/PassedParameter.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/LongOperationDelegateClosures/NonCapturableData/PassedParameter.cs
@@ -44,7 +44,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.LongOperationDelegateClosures
 
 		public PassedParameter(string name, CapturedInstancesTypes capturedInstanceTypes)
 		{
-			Name = name.CheckIfNullOrWhiteSpace(nameof(name));
+			Name = name.CheckIfNullOrWhiteSpace();
 			CapturedTypes = capturedInstanceTypes;
 		}
 

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/LongOperationStart/StartLongOperationWalker.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/LongOperationStart/StartLongOperationWalker.cs
@@ -16,10 +16,8 @@ namespace Acuminator.Analyzers.StaticAnalysis.LongOperationStart
         public StartLongOperationWalker(SymbolAnalysisContext context, PXContext pxContext, DiagnosticDescriptor descriptor)
             : base(pxContext, context.CancellationToken)
         {
-            descriptor.ThrowOnNull(nameof(descriptor));
-
             _reportDiagnostic = context.ReportDiagnostic;
-            _descriptor = descriptor;
+            _descriptor = descriptor.CheckIfNull();
         }
 
         public override void VisitInvocationExpression(InvocationExpressionSyntax node)

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXActionExecution/Walker.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXActionExecution/Walker.cs
@@ -19,10 +19,8 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXActionExecution
 					  params object[] messageArgs)
 			: base(pxContext, context.CancellationToken)
 		{
-			diagnosticDescriptor.ThrowOnNull(nameof (diagnosticDescriptor));
-
 			_context = context;
-			_diagnosticDescriptor = diagnosticDescriptor;
+			_diagnosticDescriptor = diagnosticDescriptor.CheckIfNull();
 			_messageArgs = messageArgs;
 		}
 

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXActionOnNonPrimaryView/PXActionOnNonPrimaryViewAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXActionOnNonPrimaryView/PXActionOnNonPrimaryViewAnalyzer.cs
@@ -1,19 +1,20 @@
-﻿using Acuminator.Analyzers.StaticAnalysis.PXGraph;
+﻿#nullable enable
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+
+using Acuminator.Analyzers.StaticAnalysis.PXGraph;
 using Acuminator.Utilities.Common;
 using Acuminator.Utilities.DiagnosticSuppression;
 using Acuminator.Utilities.Roslyn.PrimaryDacFinder;
 using Acuminator.Utilities.Roslyn.Semantic;
 using Acuminator.Utilities.Roslyn.Semantic.PXGraph;
 using Acuminator.Utilities.Roslyn.Syntax;
+
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Linq;
-using System.Threading.Tasks;
-
-
 
 namespace Acuminator.Analyzers.StaticAnalysis.PXActionOnNonPrimaryView
 {
@@ -33,13 +34,13 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXActionOnNonPrimaryView
 			if (declaredActions.Count == 0 || symbolContext.CancellationToken.IsCancellationRequested)
 				return;
 
-			PrimaryDacFinder primaryDacFinder = PrimaryDacFinder.Create(pxContext, pxGraph, symbolContext.CancellationToken);
-			ITypeSymbol primaryDAC = primaryDacFinder?.FindPrimaryDAC();
+			PrimaryDacFinder? primaryDacFinder = PrimaryDacFinder.Create(pxContext, pxGraph, symbolContext.CancellationToken);
+			ITypeSymbol? primaryDAC = primaryDacFinder?.FindPrimaryDAC();
 
 			if (primaryDAC == null)
 				return;
 
-			ImmutableDictionary<string, string> diagnosticExtraData = null;
+			ImmutableDictionary<string, string>? diagnosticExtraData = null;
 
 			foreach (ActionInfo action in declaredActions)
 			{
@@ -75,26 +76,27 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXActionOnNonPrimaryView
 														ImmutableDictionary<string, string> diagnosticProperties,
 														SymbolAnalysisContext symbolContext, PXContext pxContext)
 		{
-			SyntaxNode symbolSyntax = actionSymbol.GetSyntax(symbolContext.CancellationToken);
-			Location location = GetLocation(symbolSyntax);
+			var symbolSyntax = actionSymbol.GetSyntax(symbolContext.CancellationToken);
+			var location = GetLocation(symbolSyntax);
 
 			if (location == null)
 				return;
 
 			symbolContext.ReportDiagnosticWithSuppressionCheck(
 				Diagnostic.Create(Descriptors.PX1012_PXActionOnNonPrimaryView, location, diagnosticProperties,
-								  actionSymbol.Name, primaryDacName), pxContext.CodeAnalysisSettings);
+								  actionSymbol.Name, primaryDacName), 
+				pxContext.CodeAnalysisSettings);
 		}
 
-		private static Location GetLocation(SyntaxNode symbolSyntax) =>
+		private static Location? GetLocation(SyntaxNode? symbolSyntax) =>
 			symbolSyntax switch
 			{
-				PropertyDeclarationSyntax propertyDeclaration => propertyDeclaration.Type.GetLocation(),
-				FieldDeclarationSyntax fieldDeclaration => fieldDeclaration.Declaration.Type.GetLocation(),
-				VariableDeclarationSyntax variableDeclaration => variableDeclaration.Type.GetLocation(),
+				PropertyDeclarationSyntax propertyDeclaration 										=> propertyDeclaration.Type.GetLocation(),
+				FieldDeclarationSyntax fieldDeclaration 											=> fieldDeclaration.Declaration.Type.GetLocation(),
+				VariableDeclarationSyntax variableDeclaration 										=> variableDeclaration.Type.GetLocation(),
 				VariableDeclaratorSyntax variableDeclarator
-					when variableDeclarator.Parent is VariableDeclarationSyntax variableDeclaration => variableDeclaration.Type.GetLocation(),
-				_ => symbolSyntax?.GetLocation(),
+				when variableDeclarator.Parent is VariableDeclarationSyntax variableDeclaration		=> variableDeclaration.Type.GetLocation(),
+				_ 																					=> symbolSyntax?.GetLocation(),
 			};
 	}
 }

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXGraphCreationForBqlQueries/Walker.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXGraphCreationForBqlQueries/Walker.cs
@@ -35,8 +35,8 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXGraphCreationForBqlQueries
 
 			public BqlGraphArgWalker(SemanticModel semanticModel, PXContext pxContext, CancellationToken cancellation)
 			{				
-				_semanticModel = semanticModel.CheckIfNull(nameof(semanticModel));
-				_pxContext = pxContext.CheckIfNull(nameof(pxContext));
+				_semanticModel = semanticModel.CheckIfNull();
+				_pxContext = pxContext.CheckIfNull();
 				_cancellation = cancellation;
 			}
 

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/RowChangesInEventHandlers/AccessWalkerBase.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/RowChangesInEventHandlers/AccessWalkerBase.cs
@@ -18,10 +18,8 @@ namespace Acuminator.Analyzers.StaticAnalysis.RowChangesInEventHandlers
 			public bool Success { get; private set; }
 
 			protected AccessWalkerBase(SemanticModel semanticModel)
-			{
-				semanticModel.ThrowOnNull(nameof (semanticModel));
-				
-				SemanticModel = semanticModel;
+			{				
+				SemanticModel = semanticModel.CheckIfNull();
 			}
 
 			public void Reset()

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/RowChangesInEventHandlers/DacInstanceAccessWalker.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/RowChangesInEventHandlers/DacInstanceAccessWalker.cs
@@ -12,13 +12,8 @@ namespace Acuminator.Analyzers.StaticAnalysis.RowChangesInEventHandlers
 		/// <summary>
 		/// Searches for a member access (conditional and unconditional) on a DAC instance
 		/// </summary>
-		private class DacInstanceAccessWalker : AccessWalkerBase
+		private class DacInstanceAccessWalker(SemanticModel semanticModel) : AccessWalkerBase(semanticModel)
 		{
-			public DacInstanceAccessWalker(SemanticModel semanticModel)
-				: base(semanticModel)
-			{
-			}
-
 			protected override bool Predicate(ExpressionSyntax node)
 			{
 				if (node != null)

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/RowChangesInEventHandlers/DiagnosticWalker.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/RowChangesInEventHandlers/DiagnosticWalker.cs
@@ -39,12 +39,9 @@ namespace Acuminator.Analyzers.StaticAnalysis.RowChangesInEventHandlers
 				RowChangesAnalysisMode analysisMode,
 				params object[] messageArgs)
 			{
-				pxContext.ThrowOnNull(nameof (pxContext));
-				semanticModel.ThrowOnNull(nameof (semanticModel));
-
 				_context = context;
-				_semanticModel = semanticModel;
-				_pxContext = pxContext;
+				_semanticModel = semanticModel.CheckIfNull();
+				_pxContext = pxContext.CheckIfNull();
 				_analysisMode = analysisMode;
 				_rowVariables = rowVariables.ToImmutableHashSet();
 				_messageArgs = messageArgs;

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/RowChangesInEventHandlers/EventArgsRowWalker.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/RowChangesInEventHandlers/EventArgsRowWalker.cs
@@ -23,11 +23,8 @@ namespace Acuminator.Analyzers.StaticAnalysis.RowChangesInEventHandlers
 
 			public EventArgsRowWalker(SemanticModel semanticModel, PXContext pxContext)
 			{
-				semanticModel.ThrowOnNull(nameof (semanticModel));
-				pxContext.ThrowOnNull(nameof (pxContext));
-
-				_semanticModel = semanticModel;
-				_pxContext = pxContext;
+				_semanticModel = semanticModel.CheckIfNull();
+				_pxContext = pxContext.CheckIfNull();
 			}
 
 			public void Reset()

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/RowChangesInEventHandlers/VariablesWalker.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/RowChangesInEventHandlers/VariablesWalker.cs
@@ -30,12 +30,10 @@ namespace Acuminator.Analyzers.StaticAnalysis.RowChangesInEventHandlers
 			public VariablesWalker(MethodDeclarationSyntax methodSyntax, SemanticModel semanticModel, PXContext pxContext,
 				CancellationToken cancellationToken)
 			{
-				methodSyntax.ThrowOnNull(nameof (methodSyntax));
-				semanticModel.ThrowOnNull(nameof (semanticModel));
-				pxContext.ThrowOnNull(nameof (pxContext));
+				methodSyntax.ThrowOnNull();
 
-				_semanticModel = semanticModel;
-				_pxContext = pxContext;
+				_semanticModel = semanticModel.CheckIfNull();
+				_pxContext = pxContext.CheckIfNull();
 				_cancellationToken = cancellationToken;
 
 				_eventArgsRowWalker = new EventArgsRowWalker(semanticModel, pxContext);

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/SavingChanges/SaveOperationHelper.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/SavingChanges/SaveOperationHelper.cs
@@ -72,15 +72,16 @@ namespace Acuminator.Analyzers.StaticAnalysis.SavingChanges
 			if (containingType != null && 
 			    containingType.InheritsFromOrEquals(pxContext.PXDatabase.Type))
 			{
-				if (string.Equals(symbol.Name, DelegateNames.Insert))
-					return PXDBOperationKind.Insert;
-				else if (string.Equals(symbol.Name, DelegateNames.Delete))
-					return PXDBOperationKind.Delete;
-				else if (string.Equals(symbol.Name, DelegateNames.Update))
-					return PXDBOperationKind.Update;
-				else if (string.Equals(symbol.Name, DelegateNames.Ensure))
-					return PXDBOperationKind.Ensure;
+				return symbol.Name switch
+				{
+					DelegateNames.Insert => PXDBOperationKind.Insert,
+					DelegateNames.Delete => PXDBOperationKind.Delete,
+					DelegateNames.Update => PXDBOperationKind.Update,
+					DelegateNames.Ensure => PXDBOperationKind.Ensure,
+					_					 => PXDBOperationKind.None
+				};
 			}
+
 			return PXDBOperationKind.None;
 		}
 

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/SavingChanges/SaveOperationHelper.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/SavingChanges/SaveOperationHelper.cs
@@ -26,10 +26,10 @@ namespace Acuminator.Analyzers.StaticAnalysis.SavingChanges
 		public static SaveOperationKind GetSaveOperationKind(IMethodSymbol symbol, InvocationExpressionSyntax syntaxNode, 
 			SemanticModel semanticModel, PXContext pxContext)
 		{
-			symbol.ThrowOnNull(nameof (symbol));
-			syntaxNode.ThrowOnNull(nameof (syntaxNode));
-			semanticModel.ThrowOnNull(nameof (semanticModel));
-			pxContext.ThrowOnNull(nameof (pxContext));
+			symbol.ThrowOnNull();
+			syntaxNode.ThrowOnNull();
+			semanticModel.ThrowOnNull();
+			pxContext.ThrowOnNull();
 
 			var containingType = symbol.ContainingType?.OriginalDefinition;
 
@@ -64,8 +64,8 @@ namespace Acuminator.Analyzers.StaticAnalysis.SavingChanges
 
 		public static PXDBOperationKind GetPXDatabaseSaveOperationKind(IMethodSymbol symbol, PXContext pxContext)
 		{
-			symbol.ThrowOnNull(nameof(symbol));
-			pxContext.ThrowOnNull(nameof(pxContext));
+			symbol.ThrowOnNull();
+			pxContext.ThrowOnNull();
 
 			var containingType = symbol.ContainingType?.OriginalDefinition;
 
@@ -92,11 +92,8 @@ namespace Acuminator.Analyzers.StaticAnalysis.SavingChanges
 
 			public SavePressWalker(SemanticModel semanticModel, PXContext pxContext)
 			{
-				semanticModel.ThrowOnNull(nameof (semanticModel));
-				pxContext.ThrowOnNull(nameof (pxContext));
-
-				_semanticModel = semanticModel;
-				_pxContext = pxContext;
+				_semanticModel = semanticModel.CheckIfNull();
+				_pxContext	   = pxContext.CheckIfNull();
 			}
 
 			public bool Found { get; private set; }

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/ThrowingExceptions/WalkerForGraphAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/ThrowingExceptions/WalkerForGraphAnalyzer.cs
@@ -6,11 +6,11 @@ using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Acuminator.Analyzers.StaticAnalysis.ThrowingExceptions
 {
-    internal class WalkerForGraphAnalyzer : WalkerBase
-    {
-        private readonly DiagnosticDescriptor _descriptor;
+	internal class WalkerForGraphAnalyzer : WalkerBase
+	{
+		private readonly DiagnosticDescriptor _descriptor;
 
-        public WalkerForGraphAnalyzer(SymbolAnalysisContext context, PXContext pxContext, DiagnosticDescriptor descriptor) : base(context, pxContext)
+		public WalkerForGraphAnalyzer(SymbolAnalysisContext context, PXContext pxContext, DiagnosticDescriptor descriptor) : base(context, pxContext)
         {
             descriptor.ThrowOnNull(nameof(descriptor));
 
@@ -32,17 +32,17 @@ namespace Acuminator.Analyzers.StaticAnalysis.ThrowingExceptions
 		}
 
 		public override void VisitThrowStatement(ThrowStatementSyntax throwStatement)
-        {
-            ThrowIfCancellationRequested();
+		{
+			ThrowIfCancellationRequested();
 
-            if (IsPXSetupNotEnteredException(throwStatement.Expression))
-            {
-                ReportDiagnostic(_context.ReportDiagnostic, _descriptor, throwStatement);
-            }
-            else
-            {
-                base.VisitThrowStatement(throwStatement);
-            }
-        } 
-    }
+			if (IsPXSetupNotEnteredException(throwStatement.Expression))
+			{
+				ReportDiagnostic(_context.ReportDiagnostic, _descriptor, throwStatement);
+			}
+			else
+			{
+				base.VisitThrowStatement(throwStatement);
+			}
+		}
+	}
 }

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/ThrowingExceptions/WalkerForGraphAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/ThrowingExceptions/WalkerForGraphAnalyzer.cs
@@ -11,11 +11,9 @@ namespace Acuminator.Analyzers.StaticAnalysis.ThrowingExceptions
 		private readonly DiagnosticDescriptor _descriptor;
 
 		public WalkerForGraphAnalyzer(SymbolAnalysisContext context, PXContext pxContext, DiagnosticDescriptor descriptor) : base(context, pxContext)
-        {
-            descriptor.ThrowOnNull(nameof(descriptor));
-
-            _descriptor = descriptor;
-        }
+		{
+			_descriptor = descriptor.CheckIfNull();
+		}
 
 		public override void VisitThrowExpression(ThrowExpressionSyntax throwExpression)
 		{

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/UiPresentationLogic/Walker.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/UiPresentationLogic/Walker.cs
@@ -17,10 +17,8 @@ namespace Acuminator.Analyzers.StaticAnalysis.UiPresentationLogic
 			params object[] messageArgs)
 			: base(pxContext, context.CancellationToken)
 		{
-			diagnosticDescriptor.ThrowOnNull(nameof (diagnosticDescriptor));
-
 			_context = context;
-			_diagnosticDescriptor = diagnosticDescriptor;
+			_diagnosticDescriptor = diagnosticDescriptor.CheckIfNull();
 			_messageArgs = messageArgs;
 		}
 

--- a/src/Acuminator/Acuminator.Tests/Tests/Utilities/AttributeInformation/AttributeSymbolHelpersTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/Utilities/AttributeInformation/AttributeSymbolHelpersTests.cs
@@ -49,8 +49,8 @@ namespace Acuminator.Tests.Tests.Utilities.AttributeSymbolHelpersTests
 		{
 			Document document = CreateDocument(source);
 			var (semanticModel, syntaxRoot) = await document.GetSemanticModelAndRootAsync().ConfigureAwait(false);
-			semanticModel.ThrowOnNull(nameof(semanticModel));
-			syntaxRoot.ThrowOnNull(nameof(syntaxRoot));
+			semanticModel.ThrowOnNull();
+			syntaxRoot.ThrowOnNull();
 
 			List<bool> actual = new List<bool>(capacity: expected.Count);
 			var pxContext = new PXContext(semanticModel.Compilation, CodeAnalysisSettings.Default);
@@ -102,8 +102,8 @@ namespace Acuminator.Tests.Tests.Utilities.AttributeSymbolHelpersTests
 		{
 			Document document = CreateDocument(source);
 			var (semanticModel, syntaxRoot) = await document.GetSemanticModelAndRootAsync().ConfigureAwait(false);
-			semanticModel.ThrowOnNull(nameof(semanticModel));
-			syntaxRoot.ThrowOnNull(nameof(syntaxRoot));
+			semanticModel.ThrowOnNull();
+			syntaxRoot.ThrowOnNull();
 
 			var actual = new List<DbBoundnessType>(capacity: expected.Count);
 			var pxContext = new PXContext(semanticModel.Compilation, CodeAnalysisSettings.Default);
@@ -112,7 +112,7 @@ namespace Acuminator.Tests.Tests.Utilities.AttributeSymbolHelpersTests
 
 			foreach (var type in types)
 			{
-				INamedTypeSymbol typeSymbol = semanticModel.GetDeclaredSymbol(type).CheckIfNull(nameof(typeSymbol));
+				INamedTypeSymbol typeSymbol = semanticModel.GetDeclaredSymbol(type).CheckIfNull();
 
 				if (!typeSymbol.IsDacOrExtension(pxContext))
 					continue;
@@ -163,8 +163,8 @@ namespace Acuminator.Tests.Tests.Utilities.AttributeSymbolHelpersTests
 		{
 			Document document = CreateDocument(source, externalCode: code);
 			var (semanticModel, syntaxRoot)  = await document.GetSemanticModelAndRootAsync().ConfigureAwait(false);
-			semanticModel.ThrowOnNull(nameof(semanticModel));
-			syntaxRoot.ThrowOnNull(nameof(syntaxRoot));
+			semanticModel.ThrowOnNull();
+			syntaxRoot.ThrowOnNull();
 
 			List<bool> actual = new List<bool>(capacity: expected.Capacity);
 			var pxContext = new PXContext(semanticModel.Compilation, CodeAnalysisSettings.Default);
@@ -349,8 +349,8 @@ namespace Acuminator.Tests.Tests.Utilities.AttributeSymbolHelpersTests
 		{
 			Document document = CreateDocument(source);
 			var (semanticModel, syntaxRoot) = await document.GetSemanticModelAndRootAsync().ConfigureAwait(false);
-			semanticModel.ThrowOnNull(nameof(semanticModel));
-			syntaxRoot.ThrowOnNull(nameof(syntaxRoot));
+			semanticModel.ThrowOnNull();
+			syntaxRoot.ThrowOnNull();
 
 			var expectedSymbols = ConvertSymbolNamesToTypeSymbols(expectedFlattenedSets, semanticModel);
 			var actualResult = new List<List<ITypeSymbol>>(expectedSymbols.Count);
@@ -360,7 +360,7 @@ namespace Acuminator.Tests.Tests.Utilities.AttributeSymbolHelpersTests
 
 			foreach (var type in types)
 			{
-				INamedTypeSymbol typeSymbol = semanticModel.GetDeclaredSymbol(type).CheckIfNull(nameof(typeSymbol));
+				INamedTypeSymbol typeSymbol = semanticModel.GetDeclaredSymbol(type).CheckIfNull();
 
 				if (!typeSymbol.IsDacOrExtension(pxContext))
 					continue;

--- a/src/Acuminator/Acuminator.Utilities/Common/DictionaryExtensions.cs
+++ b/src/Acuminator/Acuminator.Utilities/Common/DictionaryExtensions.cs
@@ -14,7 +14,7 @@ namespace Acuminator.Utilities.Common
 		/// </summary>
 		public static bool TryAdd<TKey, TValue>(this IDictionary<TKey, TValue> dict, TKey key, TValue value)
 		{
-			dict.ThrowOnNull(nameof (dict));
+			dict.ThrowOnNull();
 
 			if (key != null && !dict.ContainsKey(key))
 			{

--- a/src/Acuminator/Acuminator.Utilities/Common/EnumerableExtensions.cs
+++ b/src/Acuminator/Acuminator.Utilities/Common/EnumerableExtensions.cs
@@ -32,8 +32,8 @@ namespace Acuminator.Utilities.Common
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static void ForEach<T>(this IEnumerable<T> source, Action<T?> action)
 		{
-			source.ThrowOnNull(nameof(source));
-			action.ThrowOnNull(nameof(action));
+			source.ThrowOnNull();
+			action.ThrowOnNull();
 
 			// perf optimization. try to not use enumerator if possible
 			switch (source)
@@ -66,21 +66,19 @@ namespace Acuminator.Utilities.Common
 
 		[DebuggerStepThrough]
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static ReadOnlyCollection<T> ToReadOnlyCollection<T>(this IEnumerable<T> source) => source != null
-			? new ReadOnlyCollection<T>(source.ToList())
-			: throw new ArgumentNullException(nameof(source));
+		public static ReadOnlyCollection<T> ToReadOnlyCollection<T>(this IEnumerable<T> source) =>
+			new(source.CheckIfNull().ToList());
 
 		[DebuggerStepThrough]
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static ReadOnlyCollection<T> ToReadOnlyCollectionShallow<T>(this IList<T> list) => list != null
-			? new ReadOnlyCollection<T>(list)
-			: throw new ArgumentNullException(nameof(list));
+		public static ReadOnlyCollection<T> ToReadOnlyCollectionShallow<T>(this IList<T> list) =>
+			new(list.CheckIfNull());
 
 		[DebuggerStepThrough]
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static HashSet<T> ToHashSet<T>(this IEnumerable<T> source, IEqualityComparer<T>? comparer = null)
 		{
-			source.ThrowOnNull(nameof(source));
+			source.ThrowOnNull();
 			return comparer != null
 				? new HashSet<T>(source, comparer)
 				: new HashSet<T>(source);
@@ -88,10 +86,8 @@ namespace Acuminator.Utilities.Common
 
 		[DebuggerStepThrough]
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Stack<T> ToStack<T>(this IEnumerable<T> source) => source != null
-			? new Stack<T>(source)
-			: throw new ArgumentNullException(nameof(source));
-
+		public static Stack<T> ToStack<T>(this IEnumerable<T> source) =>
+			new(source.CheckIfNull());
 
 		/// <summary>
 		/// Concatenate structure list to this collection. This is an optimization method which allows to avoid boxing for collections implemented as structs.
@@ -152,7 +148,7 @@ namespace Acuminator.Utilities.Common
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static IEnumerable<SyntaxToken> Where(this SyntaxTokenList source, Func<SyntaxToken, bool> predicate)
 		{
-			predicate.ThrowOnNull(nameof(predicate));
+			predicate.ThrowOnNull();
 			return WhereForSyntaxTokenListImplementation();
 
 			IEnumerable<SyntaxToken> WhereForSyntaxTokenListImplementation()
@@ -179,7 +175,7 @@ namespace Acuminator.Utilities.Common
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static SyntaxToken FirstOrDefault(this SyntaxTokenList source, Func<SyntaxToken, bool> predicate)
 		{
-			predicate.ThrowOnNull(nameof(predicate));
+			predicate.ThrowOnNull();
 
 			for (int i = 0; i < source.Count; i++)
 			{
@@ -204,7 +200,7 @@ namespace Acuminator.Utilities.Common
 		public static IEnumerable<TNode> Where<TNode>(this SyntaxList<TNode> source, Func<TNode, bool> predicate)
 		where TNode : SyntaxNode
 		{
-			predicate.ThrowOnNull(nameof(predicate));
+			predicate.ThrowOnNull();
 			return WhereForStructListImplementation();
 
 			IEnumerable<TNode> WhereForStructListImplementation()
@@ -232,7 +228,7 @@ namespace Acuminator.Utilities.Common
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static IEnumerable<TResult> Select<TResult>(this SyntaxTriviaList triviaList, Func<SyntaxTrivia, TResult> selector)
 		{
-			selector.ThrowOnNull(nameof(selector));
+			selector.ThrowOnNull();
 			return SelectForStructListImplementation();
 
 			IEnumerable<TResult> SelectForStructListImplementation()
@@ -257,7 +253,7 @@ namespace Acuminator.Utilities.Common
 		public static IEnumerable<TCollectionItem> SelectMany<TCollectionHolder, TCollectionItem>(this ImmutableArray<TCollectionHolder> array, 
 																								  Func<TCollectionHolder, IEnumerable<TCollectionItem>> selector)
 		{
-			selector.ThrowOnNull(nameof(selector));
+			selector.ThrowOnNull();
 			return GeneratorMethod();
 
 
@@ -299,8 +295,8 @@ namespace Acuminator.Utilities.Common
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static void AddRange<T>(this HashSet<T> hashset, IEnumerable<T> items)
 		{
-			hashset.ThrowOnNull(nameof(hashset));
-			items.ThrowOnNull(nameof(items));
+			hashset.ThrowOnNull();
+			items.ThrowOnNull();
 
 			foreach (var item in items)
 				hashset.Add(item);
@@ -309,7 +305,7 @@ namespace Acuminator.Utilities.Common
 		[DebuggerStepThrough]
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static bool IsEmpty<T>(this IEnumerable<T> source) =>
-			source.CheckIfNull(nameof(source)) switch
+			source.CheckIfNull() switch
 			{
 				IReadOnlyCollection<T> readOnlyCollection => readOnlyCollection.Count == 0,
 				ICollection<T> genericCollection => genericCollection.Count == 0,
@@ -336,13 +332,8 @@ namespace Acuminator.Utilities.Common
 			? source.Count == 0
 			: throw new ArgumentNullException(nameof(source));
 
-		public static bool Contains<T>(this IEnumerable<T> sequence, Func<T?, bool> predicate)
-		{
-			sequence.ThrowOnNull(nameof(sequence));
-			predicate.ThrowOnNull(nameof(predicate));
-
-			return sequence.Any(predicate);
-		}
+		public static bool Contains<T>(this IEnumerable<T> sequence, Func<T?, bool> predicate) =>
+			sequence.CheckIfNull().Any(predicate.CheckIfNull());
 
 		[DebuggerStepThrough]
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -356,7 +347,7 @@ namespace Acuminator.Utilities.Common
 		[DebuggerStepThrough]
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static bool IsNullOrEmpty<T>([NotNullWhen(returnValue: false)] this T[]? array) => 
-			array == null || array.Length == 0;
+			array?.Length is null or 0;
 
 		[DebuggerStepThrough]
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -371,7 +362,7 @@ namespace Acuminator.Utilities.Common
 		[DebuggerStepThrough]
 		public static int FindIndex<T>(this ImmutableArray<T> source, int startInclusive, int endExclusive, Func<T, bool> condition)
 		{
-			condition.ThrowOnNull(nameof(condition));
+			condition.ThrowOnNull();
 
 			if (startInclusive < 0 || startInclusive >= source.Length)
 				throw new ArgumentOutOfRangeException(nameof(startInclusive));
@@ -398,7 +389,7 @@ namespace Acuminator.Utilities.Common
 		[DebuggerStepThrough]
 		public static ImmutableArray<T> ToImmutableArray<T>(this IReadOnlyCollection<T> source)
 		{
-			source.ThrowOnNull(nameof(source));
+			source.ThrowOnNull();
 
 			if (source.Count == 0)
 				return ImmutableArray<T>.Empty;
@@ -429,7 +420,7 @@ namespace Acuminator.Utilities.Common
 		public static int FindIndex<TNode>(this SeparatedSyntaxList<TNode> source, int startInclusive, int endExclusive, Func<TNode, bool> condition)
 		where TNode : SyntaxNode
 		{
-			condition.ThrowOnNull(nameof(condition));
+			condition.ThrowOnNull();
 
 			if (startInclusive < 0 || startInclusive >= source.Count)
 				throw new ArgumentOutOfRangeException(nameof(startInclusive));
@@ -449,7 +440,7 @@ namespace Acuminator.Utilities.Common
 		public static bool All<TNode>(this SeparatedSyntaxList<TNode> source, Func<TNode, bool> condition)
 		where TNode : SyntaxNode
 		{
-			condition.ThrowOnNull(nameof(condition));
+			condition.ThrowOnNull();
 
 			for (int i = 0; i < source.Count; i++)
 			{
@@ -464,7 +455,7 @@ namespace Acuminator.Utilities.Common
 		public static bool Any<TNode>(this SeparatedSyntaxList<TNode> source, Func<TNode, bool> condition)
 		where TNode : SyntaxNode
 		{
-			condition.ThrowOnNull(nameof(condition));
+			condition.ThrowOnNull();
 
 			for (int i = 0; i < source.Count; i++)
 			{

--- a/src/Acuminator/Acuminator.Utilities/Common/EnumerableExtensions.cs
+++ b/src/Acuminator/Acuminator.Utilities/Common/EnumerableExtensions.cs
@@ -16,11 +16,8 @@ namespace Acuminator.Utilities.Common
 	public static class EnumerableExtensions
 	{
 		[DebuggerStepThrough]
-		public static IEnumerable<T> ToEnumerable<T>(this T? item)
-		{
-			if (item != null)
-				yield return item;
-		}
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static IEnumerable<T> ToEnumerable<T>(this T? item) => item != null ? [item] : [];
 
 		/// <summary>
 		/// Perfrom an <paramref name="action"/> on all items of the <paramref name="source"/> collection.

--- a/src/Acuminator/Acuminator.Utilities/Common/EnumerableExtensions.cs
+++ b/src/Acuminator/Acuminator.Utilities/Common/EnumerableExtensions.cs
@@ -92,22 +92,6 @@ namespace Acuminator.Utilities.Common
 			? new Stack<T>(source)
 			: throw new ArgumentNullException(nameof(source));
 
-		private static IEnumerable<T> ConcatIterator<T>(T extraElement, IEnumerable<T> source, bool insertAtStart)
-		{
-			if (insertAtStart)
-				yield return extraElement;
-
-			if (source != null)
-			{
-				foreach (var e in source)
-				{
-					yield return e;
-				}
-			}
-
-			if (!insertAtStart)
-				yield return extraElement;
-		}
 
 		/// <summary>
 		/// Concatenate structure list to this collection. This is an optimization method which allows to avoid boxing for collections implemented as structs.

--- a/src/Acuminator/Acuminator.Utilities/Common/EnumerableExtraExtensions.cs
+++ b/src/Acuminator/Acuminator.Utilities/Common/EnumerableExtraExtensions.cs
@@ -127,7 +127,7 @@ namespace Acuminator.Utilities.Common
 
 		public static bool SequenceEqual<T>(this IEnumerable<T> first, IEnumerable<T> second, Func<T, T, bool> comparer)
 		{
-			comparer.ThrowOnNull(nameof(comparer));
+			comparer.ThrowOnNull();
 
 			if (first == second)
 			{

--- a/src/Acuminator/Acuminator.Utilities/Common/EnumerableExtraExtensions.cs
+++ b/src/Acuminator/Acuminator.Utilities/Common/EnumerableExtraExtensions.cs
@@ -13,45 +13,41 @@ namespace Acuminator.Utilities.Common
 		public static T? FirstOrNullable<T>(this IEnumerable<T> source)
 		where T : struct
 		{
-			source.ThrowOnNull(nameof(source));
-			return source.Cast<T?>().FirstOrDefault();
+			return source.CheckIfNull()
+						 .Cast<T?>()
+						 .FirstOrDefault();
 		}
 
 		public static T? LastOrNullable<T>(this IEnumerable<T> source)
 		where T : struct
 		{
-			source.ThrowOnNull(nameof(source));
-			return source.Cast<T?>().LastOrDefault();
+			return source.CheckIfNull()
+						 .Cast<T?>()
+						 .LastOrDefault();
 		}
 
 		public static bool SetEquals<T>(this IEnumerable<T> source1, IEnumerable<T> source2, IEqualityComparer<T> comparer)
 		{
-			source1.ThrowOnNull(nameof(source1));
-			source2.ThrowOnNull(nameof(source2));
+			source1.ThrowOnNull();
+			source2.ThrowOnNull();
 			return source1.ToSet(comparer).SetEquals(source2);
 		}
 
 		public static bool SetEquals<T>(this IEnumerable<T> source1, IEnumerable<T> source2)
 		{
-			source1.ThrowOnNull(nameof(source1));
-			source2.ThrowOnNull(nameof(source2));
+			source1.ThrowOnNull();
+			source2.ThrowOnNull();
 
 			return source1.ToSet().SetEquals(source2);
 		}
 
-		public static ISet<T> ToSet<T>(this IEnumerable<T> source, IEqualityComparer<T> comparer)
-		{
-			source.ThrowOnNull(nameof(source));
-			return new HashSet<T>(source, comparer);
-		}
+		public static ISet<T> ToSet<T>(this IEnumerable<T> source, IEqualityComparer<T> comparer) =>
+			 new HashSet<T>(source, comparer);
 
-		public static ISet<T> ToSet<T>(this IEnumerable<T> source)
-		{
-			source.ThrowOnNull(nameof(source));
-			return source as ISet<T> ?? new HashSet<T>(source);
-		}
+		public static ISet<T> ToSet<T>(this IEnumerable<T> source) =>
+			source as ISet<T> ?? new HashSet<T>(source);
 
-		public static bool IsSingle<T>(this IEnumerable<T> list)
+		public static bool IsSingle<T>(this IEnumerable<T>? list)
 		{
 			if (list == null)
 				return false;
@@ -62,7 +58,7 @@ namespace Acuminator.Utilities.Common
 
 		public static bool All(this IEnumerable<bool> source)
 		{
-			source.ThrowOnNull(nameof(source));
+			source.ThrowOnNull();
 
 			foreach (bool b in source)
 			{
@@ -76,46 +72,38 @@ namespace Acuminator.Utilities.Common
 		}
 
 		public static IOrderedEnumerable<T> OrderBy<T>(this IEnumerable<T> source, IComparer<T> comparer) =>
-			 source.CheckIfNull(nameof(source)).OrderBy(Functions<T>.Identity, comparer);
+			 source.CheckIfNull()
+				   .OrderBy(Functions<T>.Identity, comparer);
 
 		public static IOrderedEnumerable<T> OrderByDescending<T>(this IEnumerable<T> source, IComparer<T> comparer) =>
-			source.CheckIfNull(nameof(source)).OrderByDescending(Functions<T>.Identity, comparer);
+			source.CheckIfNull()
+				  .OrderByDescending(Functions<T>.Identity, comparer);
 
-		public static IOrderedEnumerable<T> OrderBy<T>(this IEnumerable<T> source, Comparison<T> compare)
-		{
-			source.ThrowOnNull(nameof(source));
-			return source.OrderBy(Comparer<T>.Create(compare));
-		}
+		public static IOrderedEnumerable<T> OrderBy<T>(this IEnumerable<T> source, Comparison<T> compare) =>
+			source.CheckIfNull()
+				  .OrderBy(Comparer<T>.Create(compare));
 
 		public static IOrderedEnumerable<T> Order<T>(this IEnumerable<T> source)
-		where T : IComparable<T>
-		{
-			source.ThrowOnNull(nameof(source));
-			return source.OrderBy(Comparisons<T>.Comparer);
-		}
+		where T : IComparable<T> =>
+			source.CheckIfNull()
+				  .OrderBy(Comparisons<T>.Comparer);
 
-		public static IOrderedEnumerable<T> ThenBy<T>(this IOrderedEnumerable<T> source, IComparer<T> comparer)
-		{
-			source.ThrowOnNull(nameof(source));
-			return source.ThenBy(Functions<T>.Identity, comparer);
-		}
+		public static IOrderedEnumerable<T> ThenBy<T>(this IOrderedEnumerable<T> source, IComparer<T> comparer) => 
+			source.CheckIfNull()
+				  .ThenBy(Functions<T>.Identity, comparer);
 
-		public static IOrderedEnumerable<T> ThenBy<T>(this IOrderedEnumerable<T> source, Comparison<T> compare)
-		{
-			source.ThrowOnNull(nameof(source));
-			return source.ThenBy(Comparer<T>.Create(compare));
-		}
+		public static IOrderedEnumerable<T> ThenBy<T>(this IOrderedEnumerable<T> source, Comparison<T> compare) =>
+			 source.CheckIfNull()
+				   .ThenBy(Comparer<T>.Create(compare));
 
 		public static IOrderedEnumerable<T> ThenBy<T>(this IOrderedEnumerable<T> source)
-		where T : IComparable<T>
-		{
-			source.ThrowOnNull(nameof(source));
-			return source.ThenBy(Comparisons<T>.Comparer);
-		}
+		where T : IComparable<T> => 
+			source.CheckIfNull()
+				  .ThenBy(Comparisons<T>.Comparer);
 
 		public static bool IsSorted<T>(this IEnumerable<T> enumerable, IComparer<T> comparer)
 		{
-			using var e = enumerable.GetEnumerator();
+			using var e = enumerable.CheckIfNull().GetEnumerator();
 
 			if (!e.MoveNext())
 			{
@@ -189,7 +177,7 @@ namespace Acuminator.Utilities.Common
 		/// <returns/>
 		[DebuggerStepThrough]
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static IEnumerable<TItem> PrependItem<TItem>(this IEnumerable<TItem> source, TItem itemToAdd) =>
+		public static IEnumerable<TItem> PrependItem<TItem>(this IEnumerable<TItem>? source, TItem itemToAdd) =>
 			source.PrependOrAppend(itemToAdd, isAppending: false);
 
 		/// <summary>
@@ -201,11 +189,11 @@ namespace Acuminator.Utilities.Common
 		/// <returns/>
 		[DebuggerStepThrough]
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static IEnumerable<TItem> AppendItem<TItem>(this IEnumerable<TItem> source, TItem itemToAdd) =>
+		public static IEnumerable<TItem> AppendItem<TItem>(this IEnumerable<TItem>? source, TItem itemToAdd) =>
 			source.PrependOrAppend(itemToAdd, isAppending: true);
 
 		[DebuggerStepThrough]
-		private static IEnumerable<TItem> PrependOrAppend<TItem>(this IEnumerable<TItem> source, TItem itemToAdd, bool isAppending)
+		private static IEnumerable<TItem> PrependOrAppend<TItem>(this IEnumerable<TItem>? source, TItem itemToAdd, bool isAppending)
 		{
 			if (!isAppending)
 				yield return itemToAdd;
@@ -226,10 +214,7 @@ namespace Acuminator.Utilities.Common
 
 		private static T[] ConcatArray<T>(T extraElement, T[]? source, bool insertAtStart)
 		{
-			if (source == null)
-			{
-				source = new T[0];
-			}
+			source ??= [];
 
 			T[] result = new T[source.Length + 1];
 			source.CopyTo(result, insertAtStart ? 1 : 0);
@@ -243,10 +228,7 @@ namespace Acuminator.Utilities.Common
 
 		private static T[] ConcatArrays<T>(T[] extraElements, T[]? source, bool insertAtStart)
 		{
-			if (source == null)
-			{
-				source = new T[0];
-			}
+			source ??= [];
 
 			T[] result = new T[source.Length + extraElements.Length];
 			source.CopyTo(result, insertAtStart ? extraElements.Length : 0);
@@ -257,11 +239,11 @@ namespace Acuminator.Utilities.Common
 
 		public static List<TItem> ItemsWithMaxValues<TItem>(this IEnumerable<TItem> source, Func<TItem, double> selector)
 		{
-			source.ThrowOnNull(nameof(source));
-			selector.ThrowOnNull(nameof(selector));
+			source.ThrowOnNull();
+			selector.ThrowOnNull();
 
 			double maxValue = double.MinValue;
-			List<TItem> result = new List<TItem>(capacity: 2);
+			var result = new List<TItem>(capacity: 2);
 
 			foreach (TItem item in source)
 			{

--- a/src/Acuminator/Acuminator.Utilities/Common/ExceptionExtensions.cs
+++ b/src/Acuminator/Acuminator.Utilities/Common/ExceptionExtensions.cs
@@ -24,7 +24,7 @@ namespace Acuminator.Utilities.Common
 		[DebuggerStepThrough]
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		[return: NotNullIfNotNull("obj")]
-		public static T CheckIfNull<T>([NotNull] this T? obj, string? paramName = null, string? message = null)
+		public static T CheckIfNull<T>([NotNull] this T? obj, [CallerArgumentExpression(nameof(obj))] string? paramName = null, string? message = null)
 		{
 			obj.ThrowOnNull(paramName, message);
 			return obj;
@@ -32,7 +32,7 @@ namespace Acuminator.Utilities.Common
 
 		[DebuggerStepThrough]
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void ThrowOnNull<T>([NotNull] this T? obj, string? parameter = null, string? message = null)
+		public static void ThrowOnNull<T>([NotNull] this T? obj, [CallerArgumentExpression(nameof(obj))] string? parameter = null, string? message = null)
 		{
 			if (obj != null)
 				return;
@@ -53,7 +53,8 @@ namespace Acuminator.Utilities.Common
 		[DebuggerStepThrough]
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		[return: NotNullIfNotNull("collection")]
-		public static IEnumerable<T> CheckIfNullOrEmpty<T>([NotNull] this IEnumerable<T>? collection, string? paramName = null, string? message = null)
+		public static IEnumerable<T> CheckIfNullOrEmpty<T>([NotNull] this IEnumerable<T>? collection, 
+														   [CallerArgumentExpression(nameof(collection))] string? paramName = null, string? message = null)
 		{
 			collection.ThrowOnNullOrEmpty(paramName, message);
 			return collection;
@@ -69,7 +70,8 @@ namespace Acuminator.Utilities.Common
 		/// <param name="message">(Optional) The error message.</param>
 		[DebuggerStepThrough]
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void ThrowOnNullOrEmpty<T>([NotNull] this IEnumerable<T>? collection, string? paramName = null, string? message = null)
+		public static void ThrowOnNullOrEmpty<T>([NotNull] this IEnumerable<T>? collection, [CallerArgumentExpression(nameof(collection))] string? paramName = null,
+												 string? message = null)
 		{
 			if (collection == null)
 			{
@@ -96,7 +98,8 @@ namespace Acuminator.Utilities.Common
 		[DebuggerStepThrough]
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		[return: NotNullIfNotNull("str")]
-		public static string CheckIfNullOrWhiteSpace([NotNull] this string? str, string? paramName = null, string? message = null)
+		public static string CheckIfNullOrWhiteSpace([NotNull] this string? str, [CallerArgumentExpression(nameof(str))] string? paramName = null, 
+													  string? message = null)
 		{
 			str.ThrowOnNullOrWhiteSpace(paramName, message);
 			return str;
@@ -104,7 +107,8 @@ namespace Acuminator.Utilities.Common
 
 		[DebuggerStepThrough]
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static void ThrowOnNullOrWhiteSpace([NotNull] this string? str, string? parameter = null, string? message = null)
+		public static void ThrowOnNullOrWhiteSpace([NotNull] this string? str, [CallerArgumentExpression(nameof(str))] string? parameter = null, 
+												   string? message = null)
 		{
 			#pragma warning disable CS8777 // Parameter must have a non-null value when exiting. 
 			// string.IsNullOrWhiteSpace is just not annotated so its safe to return here

--- a/src/Acuminator/Acuminator.Utilities/Common/ExceptionExtensions.cs
+++ b/src/Acuminator/Acuminator.Utilities/Common/ExceptionExtensions.cs
@@ -23,7 +23,7 @@ namespace Acuminator.Utilities.Common
 		/// <returns/>
 		[DebuggerStepThrough]
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		[return: NotNullIfNotNull("obj")]
+		[return: NotNullIfNotNull(nameof(obj))]
 		public static T CheckIfNull<T>([NotNull] this T? obj, [CallerArgumentExpression(nameof(obj))] string? paramName = null, string? message = null)
 		{
 			obj.ThrowOnNull(paramName, message);
@@ -52,7 +52,7 @@ namespace Acuminator.Utilities.Common
 		/// <returns/>
 		[DebuggerStepThrough]
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		[return: NotNullIfNotNull("collection")]
+		[return: NotNullIfNotNull(nameof(collection))]
 		public static IEnumerable<T> CheckIfNullOrEmpty<T>([NotNull] this IEnumerable<T>? collection, 
 														   [CallerArgumentExpression(nameof(collection))] string? paramName = null, string? message = null)
 		{
@@ -97,7 +97,7 @@ namespace Acuminator.Utilities.Common
 		/// <returns/>
 		[DebuggerStepThrough]
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		[return: NotNullIfNotNull("str")]
+		[return: NotNullIfNotNull(nameof(str))]
 		public static string CheckIfNullOrWhiteSpace([NotNull] this string? str, [CallerArgumentExpression(nameof(str))] string? paramName = null, 
 													  string? message = null)
 		{

--- a/src/Acuminator/Acuminator.Utilities/Common/StringExtensions.cs
+++ b/src/Acuminator/Acuminator.Utilities/Common/StringExtensions.cs
@@ -83,6 +83,21 @@ namespace Acuminator.Utilities.Common
 		public static string Join(this IEnumerable<string> strings, string separator) => string.Join(separator, strings);
 
 		/// <summary>
+		/// Checks if <paramref name="source"/> string contains the given <paramref name="stringToSearch"/>.
+		/// </summary>
+		/// <param name="source">The string to act on.</param>
+		/// <param name="stringToSearch">The string to search.</param>
+		/// <param name="stringComparison">The string comparison type.</param>
+		/// <returns>
+		/// True if <paramref name="source"/> string contains the given <paramref name="stringToSearch"/>, false if not.
+		/// </returns>
+		[DebuggerStepThrough]
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static bool Contains(this string source, string stringToSearch, StringComparison stringComparison) =>
+			source.CheckIfNull()
+				  .IndexOf(stringToSearch, stringComparison) >= 0;
+
+		/// <summary>
 		/// Compute the distance between two strings.
 		/// </summary>
 		public static int LevenshteinDistance(string s, string t)

--- a/src/Acuminator/Acuminator.Utilities/Common/StringExtensions.cs
+++ b/src/Acuminator/Acuminator.Utilities/Common/StringExtensions.cs
@@ -87,8 +87,8 @@ namespace Acuminator.Utilities.Common
 		/// </summary>
 		public static int LevenshteinDistance(string s, string t)
 		{
-			int n = s.CheckIfNull(nameof(s)).Length;
-			int m = t.CheckIfNull(nameof(t)).Length;
+			int n = s.CheckIfNull().Length;
+			int m = t.CheckIfNull().Length;
 			int[,] d = new int[n + 1, m + 1];
 
 			// Step 1

--- a/src/Acuminator/Acuminator.Utilities/Common/StringExtensions.cs
+++ b/src/Acuminator/Acuminator.Utilities/Common/StringExtensions.cs
@@ -32,12 +32,8 @@ namespace Acuminator.Utilities.Common
 
 		[DebuggerStepThrough]
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static bool IsEmpty(this string source)
-		{
-			source.ThrowOnNull(nameof(source));
-
-			return source.Length == 0;
-		}
+		public static bool IsEmpty(this string source) =>
+			source.CheckIfNull().Length == 0;
 
 		/// <summary>
 		/// A string extension method that converts the string to a pascal case (first letter to upper case).

--- a/src/Acuminator/Acuminator.Utilities/DiagnosticSuppression/CodeActions/Operations/Base/SuppressionOperationBase.cs
+++ b/src/Acuminator/Acuminator.Utilities/DiagnosticSuppression/CodeActions/Operations/Base/SuppressionOperationBase.cs
@@ -17,7 +17,7 @@ namespace Acuminator.Utilities.DiagnosticSuppression.CodeActions
 
 		protected SuppressionOperationBase(string assemblyName)
 		{
-			AssemblyName = assemblyName.CheckIfNullOrWhiteSpace(nameof(assemblyName));
+			AssemblyName = assemblyName.CheckIfNullOrWhiteSpace();
 		}
 
 		protected void ShowLocalizedError(string resourceName, params string[] formatArgs)

--- a/src/Acuminator/Acuminator.Utilities/DiagnosticSuppression/CodeActions/Operations/SuppressInSuppressionFileOperation.cs
+++ b/src/Acuminator/Acuminator.Utilities/DiagnosticSuppression/CodeActions/Operations/SuppressInSuppressionFileOperation.cs
@@ -20,8 +20,8 @@ namespace Acuminator.Utilities.DiagnosticSuppression.CodeActions
 		public SuppressInSuppressionFileOperation(Diagnostic diagnosticToSuppress, string assemblyName, SemanticModel semanticModel) :
 											 base(assemblyName)
 		{		
-			_diagnosticToSuppress = diagnosticToSuppress.CheckIfNull(nameof(diagnosticToSuppress));
-			_semanticModel = semanticModel.CheckIfNull(nameof(semanticModel));
+			_diagnosticToSuppress = diagnosticToSuppress.CheckIfNull();
+			_semanticModel = semanticModel.CheckIfNull();
 		}
 
 		public override void Apply(Workspace workspace, CancellationToken cancellationToken)

--- a/src/Acuminator/Acuminator.Utilities/DiagnosticSuppression/CodeActions/SuppressWithSuppressionFileCodeAction.cs
+++ b/src/Acuminator/Acuminator.Utilities/DiagnosticSuppression/CodeActions/SuppressWithSuppressionFileCodeAction.cs
@@ -26,7 +26,7 @@ namespace Acuminator.Utilities.DiagnosticSuppression.CodeActions
 												base(title, equivalenceKey, displayPreview: false)
 		{
 			Context = context;
-			Diagnostic = diagnostic.CheckIfNull(nameof(diagnostic));
+			Diagnostic = diagnostic.CheckIfNull();
 		}
 
 		protected override async Task<IEnumerable<CodeActionOperation>> ComputeOperationsAsync(CancellationToken cancellationToken)

--- a/src/Acuminator/Acuminator.Utilities/DiagnosticSuppression/IO/Base/SuppressionFileSystemServiceBase.cs
+++ b/src/Acuminator/Acuminator.Utilities/DiagnosticSuppression/IO/Base/SuppressionFileSystemServiceBase.cs
@@ -24,7 +24,7 @@ namespace Acuminator.Utilities.DiagnosticSuppression.IO
 
 		public virtual XDocument Load(string path)
 		{
-			path.ThrowOnNullOrWhiteSpace(nameof(path));
+			path.ThrowOnNullOrWhiteSpace();
 
 			try
 			{
@@ -50,8 +50,8 @@ namespace Acuminator.Utilities.DiagnosticSuppression.IO
 
 		public virtual bool Save(XDocument document, string path)
 		{
-			document.ThrowOnNull(nameof(document));
-			path.ThrowOnNullOrWhiteSpace(nameof(path));
+			document.ThrowOnNull();
+			path.ThrowOnNullOrWhiteSpace();
 			
 			try
 			{
@@ -71,14 +71,14 @@ namespace Acuminator.Utilities.DiagnosticSuppression.IO
 
 		public virtual string GetFileName(string path)
 		{
-			path.ThrowOnNullOrWhiteSpace(nameof(path));
+			path.ThrowOnNullOrWhiteSpace();
 
 			return Path.GetFileNameWithoutExtension(path);
 		}
 
 		public virtual string GetFileDirectory(string path)
 		{
-			path.ThrowOnNullOrWhiteSpace(nameof(path));
+			path.ThrowOnNullOrWhiteSpace();
 			return Path.GetDirectoryName(path);
 		}
 

--- a/src/Acuminator/Acuminator.Utilities/DiagnosticSuppression/IO/DefaultIOErrorProcessor.cs
+++ b/src/Acuminator/Acuminator.Utilities/DiagnosticSuppression/IO/DefaultIOErrorProcessor.cs
@@ -12,7 +12,7 @@ namespace Acuminator.Utilities.DiagnosticSuppression.IO
 	{
 		public void ProcessError(Exception exception, [CallerMemberName]string reportedFrom = null)
 		{
-			exception.ThrowOnNull(nameof(exception));
+			exception.ThrowOnNull();
 			string errorMsg = Resources.FailedToLoadTheSuppressionFile + Environment.NewLine + Environment.NewLine +
 							  string.Format(Resources.FailedToLoadTheSuppressionFileDetails, Environment.NewLine + exception.Message);
 

--- a/src/Acuminator/Acuminator.Utilities/DiagnosticSuppression/IO/SuppressionFileWatcherService.cs
+++ b/src/Acuminator/Acuminator.Utilities/DiagnosticSuppression/IO/SuppressionFileWatcherService.cs
@@ -27,7 +27,7 @@ namespace Acuminator.Utilities.DiagnosticSuppression.IO
 
 		public SuppressionFileWatcherService(FileSystemWatcher watcher)
 		{
-			_fileSystemWatcher = watcher.CheckIfNull(nameof(watcher));
+			_fileSystemWatcher = watcher.CheckIfNull();
 		}
 
 		public void Dispose()

--- a/src/Acuminator/Acuminator.Utilities/DiagnosticSuppression/IO/Validation/SuppressionFileValidation.cs
+++ b/src/Acuminator/Acuminator.Utilities/DiagnosticSuppression/IO/Validation/SuppressionFileValidation.cs
@@ -36,7 +36,7 @@ namespace Acuminator.Utilities.DiagnosticSuppression.IO
 
 		public virtual bool ValidateSuppressionFile(XDocument document)
 		{
-			document.ThrowOnNull(nameof(document));
+			document.ThrowOnNull();
 
 			ValidationLog validationLog = new ValidationLog();
 

--- a/src/Acuminator/Acuminator.Utilities/DiagnosticSuppression/IO/Validation/XmlSchema/SuppressionFileSchemaValidator.cs
+++ b/src/Acuminator/Acuminator.Utilities/DiagnosticSuppression/IO/Validation/XmlSchema/SuppressionFileSchemaValidator.cs
@@ -23,7 +23,7 @@ namespace Acuminator.Utilities.DiagnosticSuppression.IO
 
 		protected SuppressionFileSchemaValidator(XmlSchema schema)
 		{
-			Schema = schema.CheckIfNull(nameof(schema));
+			Schema = schema.CheckIfNull();
 			_xmlSchemaSet = new XmlSchemaSet();
 			_xmlSchemaSet.Add(Schema);
 		}

--- a/src/Acuminator/Acuminator.Utilities/DiagnosticSuppression/IO/Validation/XmlSchema/SuppressionFileSchemaValidator.cs
+++ b/src/Acuminator/Acuminator.Utilities/DiagnosticSuppression/IO/Validation/XmlSchema/SuppressionFileSchemaValidator.cs
@@ -62,8 +62,8 @@ namespace Acuminator.Utilities.DiagnosticSuppression.IO
 		/// <returns/>
 		public void ValidateSuppressionFile(XDocument document, ValidationLog validationLog)
 		{
-			document.ThrowOnNull(nameof(document));
-			validationLog.ThrowOnNull(nameof(validationLog));
+			document.ThrowOnNull();
+			validationLog.ThrowOnNull();
 
 			try
 			{

--- a/src/Acuminator/Acuminator.Utilities/DiagnosticSuppression/SuppressMessage.cs
+++ b/src/Acuminator/Acuminator.Utilities/DiagnosticSuppression/SuppressMessage.cs
@@ -20,7 +20,8 @@ namespace Acuminator.Utilities.DiagnosticSuppression
 		private const string TargetElement = "target";
 		private const string SyntaxNodeElement = "syntaxNode";
 
-		private static HashSet<SyntaxKind> _targetKinds = new HashSet<SyntaxKind>(new[] {
+		private static HashSet<SyntaxKind> _targetKinds = 
+		[
 			SyntaxKind.ClassDeclaration,
 			SyntaxKind.StructDeclaration,
 			SyntaxKind.EnumDeclaration,
@@ -30,7 +31,7 @@ namespace Acuminator.Utilities.DiagnosticSuppression
 			SyntaxKind.ConstructorDeclaration,
 			SyntaxKind.PropertyDeclaration,
 			SyntaxKind.FieldDeclaration
-		});
+		];
 
 		/// <summary>
 		/// Suppressed diagnostic Id
@@ -56,13 +57,9 @@ namespace Acuminator.Utilities.DiagnosticSuppression
 
 		public SuppressMessage(string id, string target, string syntaxNode)
 		{
-			id.ThrowOnNull(nameof(id));
-			target.ThrowOnNull(nameof(target));
-			syntaxNode.ThrowOnNull(nameof(syntaxNode));
-
-			Id = id;
-			Target = target;
-			SyntaxNode = syntaxNode;
+			Id = id.CheckIfNull();
+			Target = target.CheckIfNull();
+			SyntaxNode = syntaxNode.CheckIfNull();
 
 			var hash = 17;
 
@@ -162,7 +159,7 @@ namespace Acuminator.Utilities.DiagnosticSuppression
 		{
 			var targetNode = node?.AncestorsAndSelf().FirstOrDefault(a => _targetKinds.Contains(a.Kind()));
 
-			if (!(targetNode is FieldDeclarationSyntax fieldDeclaration))
+			if (targetNode is not FieldDeclarationSyntax fieldDeclaration)
 				return targetNode;
 			else if (fieldDeclaration.Declaration == null)
 				return null;

--- a/src/Acuminator/Acuminator.Utilities/DiagnosticSuppression/SuppressionDiffResult.cs
+++ b/src/Acuminator/Acuminator.Utilities/DiagnosticSuppression/SuppressionDiffResult.cs
@@ -18,14 +18,14 @@ namespace Acuminator.Utilities.DiagnosticSuppression
 
 		public SuppressionDiffResult(string path, string assembly, HashSet<SuppressMessage> addedMessages, HashSet<SuppressMessage> deletedMessages)
 		{
-			Path = path.CheckIfNull(nameof(path));
-			Assembly = assembly.CheckIfNull(nameof(assembly));
+			Path = path.CheckIfNull();
+			Assembly = assembly.CheckIfNull();
 
-			AddedMessages = addedMessages.CheckIfNull(nameof(addedMessages))
+			AddedMessages = addedMessages.CheckIfNull()
 										 .Where(m => m.IsValid)
 										 .ToImmutableArray();
 
-			DeletedMessages = deletedMessages.CheckIfNull(nameof(deletedMessages))
+			DeletedMessages = deletedMessages.CheckIfNull()
 											 .Where(m => m.IsValid)
 											 .ToImmutableArray();
 		}

--- a/src/Acuminator/Acuminator.Utilities/DiagnosticSuppression/SuppressionFile.cs
+++ b/src/Acuminator/Acuminator.Utilities/DiagnosticSuppression/SuppressionFile.cs
@@ -73,8 +73,8 @@ namespace Acuminator.Utilities.DiagnosticSuppression
 		internal static SuppressionFile Load(ISuppressionFileSystemService fileSystemService, string suppressionFilePath, 
 											 bool generateSuppressionBase)
 		{
-			fileSystemService.ThrowOnNull(nameof(fileSystemService));
-			suppressionFilePath.ThrowOnNullOrWhiteSpace(nameof(suppressionFilePath));
+			fileSystemService.ThrowOnNull();
+			suppressionFilePath.ThrowOnNullOrWhiteSpace();
 
 			string assemblyName = fileSystemService.GetFileName(suppressionFilePath);
 			if (string.IsNullOrEmpty(assemblyName))
@@ -115,7 +115,7 @@ namespace Acuminator.Utilities.DiagnosticSuppression
 
 		internal XDocument MessagesToDocument(ISuppressionFileSystemService fileSystemService)
 		{
-			fileSystemService.ThrowOnNull(nameof(fileSystemService));
+			fileSystemService.ThrowOnNull();
 			XDocument document;
 
 			lock (fileSystemService)

--- a/src/Acuminator/Acuminator.Utilities/DiagnosticSuppression/SuppressionManager.SuppressionFileCreator.cs
+++ b/src/Acuminator/Acuminator.Utilities/DiagnosticSuppression/SuppressionManager.SuppressionFileCreator.cs
@@ -9,18 +9,13 @@ namespace Acuminator.Utilities.DiagnosticSuppression
 {
 	public partial class SuppressionManager
 	{
-		private class SuppressionFileCreator
+		private class SuppressionFileCreator(SuppressionManager suppressionManager)
 		{
-			private readonly SuppressionManager _suppressionManager;
-
-			public SuppressionFileCreator(SuppressionManager suppressionManager)
-			{
-				_suppressionManager = suppressionManager.CheckIfNull(nameof(suppressionManager));
-			}
+			private readonly SuppressionManager _suppressionManager = suppressionManager.CheckIfNull();
 
 			public SuppressionFile CreateSuppressionFileForProjectFromCommand(Project project)
 			{
-				project.ThrowOnNull(nameof(project));
+				project.ThrowOnNull();
 
 				//First check if file already exists to dismiss threads withou acquiring the lock
 				var existingSuppressionFile =  _suppressionManager.GetSuppressionFile(project.AssemblyName);
@@ -48,7 +43,7 @@ namespace Acuminator.Utilities.DiagnosticSuppression
 
 			public TextDocument AddAdditionalSuppressionDocumentToProject(Project project)
 			{
-				project.ThrowOnNull(nameof(project));
+				project.ThrowOnNull();
 
 				string suppressionFileName = project.AssemblyName + SuppressionFile.SuppressionFileExtension;
 				string projectDir = Instance._fileSystemService.GetFileDirectory(project.FilePath);

--- a/src/Acuminator/Acuminator.Utilities/DiagnosticSuppression/SuppressionManager.cs
+++ b/src/Acuminator/Acuminator.Utilities/DiagnosticSuppression/SuppressionManager.cs
@@ -187,7 +187,7 @@ namespace Acuminator.Utilities.DiagnosticSuppression
 		}
 
 		public SuppressionFile? GetSuppressionFile(string assemblyName) =>
-			_fileByAssembly.TryGetValue(assemblyName.CheckIfNullOrWhiteSpace(nameof(assemblyName)), out var existingSuppressionFile)
+			_fileByAssembly.TryGetValue(assemblyName.CheckIfNullOrWhiteSpace(), out var existingSuppressionFile)
 				? existingSuppressionFile
 				: null;
 
@@ -288,7 +288,7 @@ namespace Acuminator.Utilities.DiagnosticSuppression
 																Diagnostic diagnostic, CodeAnalysisSettings settings, CancellationToken cancellation)
 		{
 			cancellation.ThrowIfCancellationRequested();
-			reportDiagnostic.ThrowOnNull(nameof(reportDiagnostic));
+			reportDiagnostic.ThrowOnNull();
 
 			if (!settings.SuppressionMechanismEnabled)
 			{

--- a/src/Acuminator/Acuminator.Utilities/DiagnosticSuppression/SuppressionManager.cs
+++ b/src/Acuminator/Acuminator.Utilities/DiagnosticSuppression/SuppressionManager.cs
@@ -42,7 +42,7 @@ namespace Acuminator.Utilities.DiagnosticSuppression
 
 		private SuppressionManager(ISuppressionFileSystemService fileSystemService, ICustomBuildActionSetter? buildActionSetter)
 		{
-			_fileSystemService = fileSystemService.CheckIfNull(nameof(fileSystemService));
+			_fileSystemService = fileSystemService.CheckIfNull();
 			_suppressionFileCreator = new SuppressionFileCreator(this);
 
 			BuildActionSetter = buildActionSetter;

--- a/src/Acuminator/Acuminator.Utilities/DiagnosticSuppression/SuppressionManagerInitInfo.cs
+++ b/src/Acuminator/Acuminator.Utilities/DiagnosticSuppression/SuppressionManagerInitInfo.cs
@@ -14,9 +14,7 @@ namespace Acuminator.Utilities.DiagnosticSuppression
 
 		public SuppressionManagerInitInfo(string path, bool generateSuppressionBase)
 		{
-			path.ThrowOnNullOrWhiteSpace(nameof(path));
-
-			Path = path;
+			Path = path.CheckIfNullOrWhiteSpace();
 			GenerateSuppressionBase = generateSuppressionBase;
 		}
 

--- a/src/Acuminator/Acuminator.Utilities/DiagnosticSuppression/Utils/SuppressionExtensions.cs
+++ b/src/Acuminator/Acuminator.Utilities/DiagnosticSuppression/Utils/SuppressionExtensions.cs
@@ -34,7 +34,7 @@ namespace Acuminator.Utilities.DiagnosticSuppression
 
 		public static string GetXDocumentStringWithDeclaration(this XDocument xDocument)
 		{
-			xDocument.ThrowOnNull(nameof(xDocument));
+			xDocument.ThrowOnNull();
 
 			var builder = new StringBuilder(capacity: 65);
 

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/BqlModifyingMethods.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/BqlModifyingMethods.cs
@@ -44,10 +44,9 @@ namespace Acuminator.Utilities.Roslyn
 			DelegateNames.NewJoin
 		);
 
-
 		public static bool IsBqlModifyingInstanceMethod(IMethodSymbol methodSymbol, PXContext context)
 		{
-			methodSymbol.ThrowOnNull(nameof(methodSymbol));
+			methodSymbol.ThrowOnNull();
 
 			if (methodSymbol.IsStatic)
 			{

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/CodeActions/CodeActionWithNestedActionsFabric.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/CodeActions/CodeActionWithNestedActionsFabric.cs
@@ -45,7 +45,7 @@ namespace Acuminator.Utilities.Roslyn.CodeActions
 		public static CodeAction? CreateCodeActionWithNestedActions(string groupActionTitle, ImmutableArray<CodeAction> nestedCodeActions,
 																    bool isInlinable = false)
 		{
-			groupActionTitle.ThrowOnNullOrWhiteSpace(nameof(groupActionTitle));
+			groupActionTitle.ThrowOnNullOrWhiteSpace();
 
 			if (nestedCodeActions.IsDefaultOrEmpty)
 				return null;

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/CodeActions/DocumentChangeActionWithOptionalPreview.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/CodeActions/DocumentChangeActionWithOptionalPreview.cs
@@ -18,12 +18,10 @@ namespace Acuminator.Utilities.Roslyn.CodeActions
 													   string equivalenceKey = null) :
 												  base(title, equivalenceKey, displayPreview)
 		{
-			_createChangedDocument = createChangedDocument.CheckIfNull(nameof(createChangedDocument));
+			_createChangedDocument = createChangedDocument.CheckIfNull();
 		}
 
-		protected override Task<Document> GetChangedDocumentAsync(CancellationToken cancellationToken)
-		{
-			return _createChangedDocument(cancellationToken);
-		}
+		protected override Task<Document> GetChangedDocumentAsync(CancellationToken cancellationToken) =>
+			_createChangedDocument(cancellationToken);
 	}
 }

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/CodeActions/SolutionChangeActionWithOptionalPreview.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/CodeActions/SolutionChangeActionWithOptionalPreview.cs
@@ -24,12 +24,10 @@ namespace Acuminator.Utilities.Roslyn.CodeActions
 													   string equivalenceKey = null) :
 												  base(title, equivalenceKey, displayPreview)
 		{
-			_createChangedSolution = createChangedSolution.CheckIfNull(nameof(createChangedSolution));
+			_createChangedSolution = createChangedSolution.CheckIfNull();
 		}
 
-		protected override Task<Solution> GetChangedSolutionAsync(CancellationToken cancellationToken)
-		{
-			return _createChangedSolution(cancellationToken);
-		}
+		protected override Task<Solution> GetChangedSolutionAsync(CancellationToken cancellationToken) => 
+			_createChangedSolution(cancellationToken);
 	}
 }

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/CodeGeneration/CodeGeneration.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/CodeGeneration/CodeGeneration.cs
@@ -29,8 +29,8 @@ namespace Acuminator.Utilities.Roslyn.CodeGeneration
 		/// </returns>
 		public static CompilationUnitSyntax AddMissingUsingDirectiveForNamespace(this CompilationUnitSyntax root, string namespaceName)
 		{
-			root.ThrowOnNull(nameof(root));
-			namespaceName.ThrowOnNullOrWhiteSpace(nameof(namespaceName));
+			root.ThrowOnNull();
+			namespaceName.ThrowOnNullOrWhiteSpace();
 
 			bool alreadyHasUsing = root.Usings.Any(usingDirective => namespaceName == usingDirective.Name?.ToString());
 

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/DiagnosticUtils.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/DiagnosticUtils.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#nullable enable
+
+using System;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Acuminator.Utilities.Common;
@@ -11,10 +13,7 @@ namespace Acuminator.Utilities.Roslyn
 	/// </summary>
 	public static class DiagnosticUtils
 	{
-		public static bool IsAcuminatorDiagnostic(this Diagnostic diagnostic)
-		{
-			diagnostic.ThrowOnNull(nameof(diagnostic));
-			return diagnostic.Id.StartsWith(SharedConstants.AcuminatorDiagnosticPrefix);
-		}
+		public static bool IsAcuminatorDiagnostic(this Diagnostic diagnostic) =>
+			diagnostic.CheckIfNull().Id.StartsWith(SharedConstants.AcuminatorDiagnosticPrefix);
 	}
 }

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/NestedInvocationWalker.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/NestedInvocationWalker.cs
@@ -81,9 +81,7 @@ namespace Acuminator.Utilities.Roslyn
 		/// <param name="bypassMethod">(Optional) An optional delegate to control if it is needed to bypass analysis of an invocation of a method and do not step into it. </param>
 		protected NestedInvocationWalker(PXContext pxContext, CancellationToken cancellationToken, Func<IMethodSymbol, bool>? extraBypassCheck = null)
 		{
-			pxContext.ThrowOnNull(nameof (pxContext));
-
-			PxContext = pxContext;
+			PxContext = pxContext.CheckIfNull();
             CancellationToken = cancellationToken;
 			_extraBypassCheck = extraBypassCheck;
 
@@ -92,17 +90,16 @@ namespace Acuminator.Utilities.Roslyn
 		}
 
 		/// <summary>
-		/// Gets types to bypass. The alker won't go into their type members.
+		/// Gets types to bypass. The walker won't go into their type members.
 		/// </summary>
 		/// <returns>
 		/// The types to bypass.
 		/// </returns>
 		/// <remarks>
-		/// some core types from PX.Data namespace
+		/// Some core types from PX.Data namespace
 		/// </remarks>
 		protected virtual HashSet<INamedTypeSymbol> GetTypesToBypass() =>
-			new HashSet<INamedTypeSymbol>()
-			{
+			[
 				PxContext.PXGraph.Type!,
 				PxContext.PXView.Type!,
 				PxContext.PXCache.Type!,
@@ -111,7 +108,7 @@ namespace Acuminator.Utilities.Roslyn
 				PxContext.PXSelectBaseGeneric.Type!,
 				PxContext.PXAdapterType,
 				PxContext.PXDatabase.Type!
-			};
+			];
 
 		protected void ThrowIfCancellationRequested() => CancellationToken.ThrowIfCancellationRequested();
 

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/PXFieldAttributes/AcumaticaAttributesRelationsInfoProvider.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/PXFieldAttributes/AcumaticaAttributesRelationsInfoProvider.cs
@@ -32,7 +32,7 @@ namespace Acuminator.Utilities.Roslyn.PXFieldAttributes
 		/// True if is an Acumatica attribute, false if not.
 		/// </returns>
 		public static bool IsAcumaticaAttribute(this ITypeSymbol attributeType, PXContext pxContext) =>
-			pxContext.CheckIfNull(nameof(pxContext)).AttributeTypes.PXEventSubscriberAttribute.Equals(attributeType) ||
+			pxContext.CheckIfNull().AttributeTypes.PXEventSubscriberAttribute.Equals(attributeType) ||
 			attributeType.IsDerivedFromPXEventSubscriberAttribute(pxContext);
 
 		/// <summary>
@@ -44,7 +44,7 @@ namespace Acuminator.Utilities.Roslyn.PXFieldAttributes
 		/// True if derived from PXEventSubscriberAttribute, false if not.
 		/// </returns>
 		public static bool IsDerivedFromPXEventSubscriberAttribute(this ITypeSymbol attributeType, PXContext pxContext) =>
-			attributeType.InheritsFrom(pxContext.CheckIfNull(nameof(pxContext)).AttributeTypes.PXEventSubscriberAttribute);
+			attributeType.InheritsFrom(pxContext.CheckIfNull().AttributeTypes.PXEventSubscriberAttribute);
 
 		/// <summary>
 		/// Check if <paramref name="attributeType"/> is an Acumatica aggregator attribute.
@@ -55,7 +55,7 @@ namespace Acuminator.Utilities.Roslyn.PXFieldAttributes
 		/// True if is an Acumatica aggregator attribute, false if not.
 		/// </returns>
 		public static bool IsAggregatorAttribute(this ITypeSymbol attributeType, PXContext pxContext) =>
-			attributeType.InheritsFromOrEquals(pxContext.CheckIfNull(nameof(pxContext)).AttributeTypes.PXAggregateAttribute);
+			attributeType.InheritsFromOrEquals(pxContext.CheckIfNull().AttributeTypes.PXAggregateAttribute);
 
 		/// <summary>
 		/// Check if Acumatica attribute is derived from the specified Acumatica attribute type or aggregates it.<br/>
@@ -101,7 +101,7 @@ namespace Acuminator.Utilities.Roslyn.PXFieldAttributes
 		/// </returns>
 		internal static bool IsDerivedFromOrAggregatesAttributeUnsafe(this ITypeSymbol attributeType, ITypeSymbol baseAttributeTypeToCheck, 
 																	  PXContext pxContext) =>
-			 IsDerivedFromAttribute(attributeType, baseAttributeTypeToCheck, pxContext.CheckIfNull(nameof(pxContext)), recursionDepth: 0);
+			 IsDerivedFromAttribute(attributeType, baseAttributeTypeToCheck, pxContext.CheckIfNull(), recursionDepth: 0);
 
 		private static bool IsDerivedFromAttribute(ITypeSymbol attributeType, ITypeSymbol baseAttributeTypeToCheck, PXContext pxContext, int recursionDepth)
 		{
@@ -141,7 +141,7 @@ namespace Acuminator.Utilities.Roslyn.PXFieldAttributes
 		/// <returns/>
 		public static ImmutableHashSet<ITypeSymbol> GetThisAndAllAggregatedAttributes(this ITypeSymbol? attributeType, PXContext pxContext, bool includeBaseTypes)
 		{
-			var eventSubscriberAttribute = pxContext.CheckIfNull(nameof(pxContext)).AttributeTypes.PXEventSubscriberAttribute;
+			var eventSubscriberAttribute = pxContext.CheckIfNull().AttributeTypes.PXEventSubscriberAttribute;
 
 			if (attributeType == null || attributeType.Equals(eventSubscriberAttribute))
 				return ImmutableHashSet<ITypeSymbol>.Empty;
@@ -224,7 +224,7 @@ namespace Acuminator.Utilities.Roslyn.PXFieldAttributes
 		public static ImmutableHashSet<AttributeWithApplication> GetThisAndAllAggregatedAttributesWithApplications(this AttributeData? attributeApplication,
 																												   PXContext pxContext, bool includeBaseTypes)
 		{
-			var eventSubscriberAttribute = pxContext.CheckIfNull(nameof(pxContext)).AttributeTypes.PXEventSubscriberAttribute;
+			var eventSubscriberAttribute = pxContext.CheckIfNull().AttributeTypes.PXEventSubscriberAttribute;
 
 			if (attributeApplication?.AttributeClass == null || attributeApplication.AttributeClass.Equals(eventSubscriberAttribute))
 				return ImmutableHashSet<AttributeWithApplication>.Empty;
@@ -313,9 +313,9 @@ namespace Acuminator.Utilities.Roslyn.PXFieldAttributes
 		/// True if equals or directly aggregates attribute, false if not.
 		/// </returns>
 		internal static bool EqualsOrAggregatesAttributeDirectly(this ITypeSymbol attribute, ITypeSymbol attributeToCheck, PXContext pxContext) =>
-			EqualsOrAggregatesAttributeDirectly(attribute.CheckIfNull(nameof(attribute)), 
-												attributeToCheck.CheckIfNull(nameof(attributeToCheck)), 
-												pxContext.CheckIfNull(nameof(pxContext)), recursionDepth: 0);
+			EqualsOrAggregatesAttributeDirectly(attribute.CheckIfNull(), 
+												attributeToCheck.CheckIfNull(), 
+												pxContext.CheckIfNull(), recursionDepth: 0);
 
 		private static bool EqualsOrAggregatesAttributeDirectly(ITypeSymbol attribute, ITypeSymbol attributeToCheck, PXContext pxContext, int recursionDepth)
 		{

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/PXFieldAttributes/DBBoundnessCalculator.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/PXFieldAttributes/DBBoundnessCalculator.cs
@@ -31,7 +31,7 @@ namespace Acuminator.Utilities.Roslyn.PXFieldAttributes
 
 		public DbBoundnessCalculator(PXContext pxContext)
 		{
-			Context = pxContext.CheckIfNull(nameof(pxContext));
+			Context = pxContext.CheckIfNull();
 			AttributesMetadataProvider = new FieldTypeAttributesMetadataProvider(pxContext);
 		}
 

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/PXFieldAttributes/DBBoundnessCalculator.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/PXFieldAttributes/DBBoundnessCalculator.cs
@@ -68,7 +68,7 @@ namespace Acuminator.Utilities.Roslyn.PXFieldAttributes
 																		ImmutableHashSet<ITypeSymbol>? preparedFlattenedAttributesSet,
 																		IReadOnlyCollection<DataTypeAttributeInfo>? preparedAttributesMetadata)
 		{
-			attributeApplication.ThrowOnNull(nameof(attributeApplication));
+			attributeApplication.ThrowOnNull();
 
 			if (!attributeApplication.AttributeClass.IsAcumaticaAttribute(Context))
 				return DbBoundnessType.NotDefined;

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/PXFieldAttributes/Enum/DbBoundnessType.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/PXFieldAttributes/Enum/DbBoundnessType.cs
@@ -75,7 +75,7 @@ namespace Acuminator.Utilities.Roslyn.PXFieldAttributes
 		/// </returns>
 		public static DbBoundnessType Combine(this IEnumerable<DbBoundnessType> dbBoundnesses)
 		{
-			var sortedDbBoundness = dbBoundnesses.CheckIfNull(nameof(dbBoundnesses)).OrderBy(b => b);
+			var sortedDbBoundness = dbBoundnesses.CheckIfNull().OrderBy(b => b);
 			DbBoundnessType aggregatedBoundness = DbBoundnessType.NotDefined;
 
 			foreach (var dbBoundness in sortedDbBoundness)

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/PXFieldAttributes/FieldTypeAttributesMetadataProvider.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/PXFieldAttributes/FieldTypeAttributesMetadataProvider.cs
@@ -38,7 +38,7 @@ namespace Acuminator.Utilities.Roslyn.PXFieldAttributes
 
 		public FieldTypeAttributesMetadataProvider(PXContext pxContext)
 		{
-			_pxContext = pxContext.CheckIfNull(nameof(pxContext));
+			_pxContext = pxContext.CheckIfNull();
 			_pxDBScalarAttribute = _pxContext.FieldAttributes.PXDBScalarAttribute;
 			_pxDBCalcedAttribute = _pxContext.FieldAttributes.PXDBCalcedAttribute;
 			_pxDBFieldAttribute = _pxContext.FieldAttributes.PXDBFieldAttribute;
@@ -84,7 +84,7 @@ namespace Acuminator.Utilities.Roslyn.PXFieldAttributes
 																										ImmutableHashSet<ITypeSymbol> flattenedAttributes)
 		{
 			if (flattenedAttributes.Count == 0)
-				return Array.Empty<DataTypeAttributeInfo>();
+				return [];
 
 			var mixedDbBoundnessAttributeInfos = GetMixedDbBoundnessAttributeInfosInFlattenedSet(originalAttribute, flattenedAttributes);
 			bool hasMixedBoundnessAttributes = mixedDbBoundnessAttributeInfos?.Count > 0;

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/PXFieldAttributes/Infos/AttributeWithApplication.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/PXFieldAttributes/Infos/AttributeWithApplication.cs
@@ -24,8 +24,8 @@ namespace Acuminator.Utilities.Roslyn.PXFieldAttributes
 
 		public AttributeWithApplication(AttributeData attributeApplication, ITypeSymbol attributeType)
 		{
-			Application = attributeApplication.CheckIfNull(nameof(attributeApplication));
-			Type = attributeType.CheckIfNull(nameof(attributeType));		
+			Application = attributeApplication.CheckIfNull();
+			Type = attributeType.CheckIfNull();
 		}
 
 		public override bool Equals(object obj) => obj is AttributeWithApplication other && Equals(other);

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/PXSystemActions/PXSystemActionsRegister.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/PXSystemActions/PXSystemActionsRegister.cs
@@ -1,8 +1,12 @@
-﻿using System.Collections.Generic;
+﻿#nullable enable
+
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+
 using Acuminator.Utilities.Common;
 using Acuminator.Utilities.Roslyn.Semantic;
+
 using Microsoft.CodeAnalysis;
 
 namespace Acuminator.Utilities.Roslyn.PXSystemActions
@@ -18,9 +22,7 @@ namespace Acuminator.Utilities.Roslyn.PXSystemActions
 		
 		public PXSystemActionsRegister(PXContext pxContext)
 		{
-			pxContext.ThrowOnNull(nameof(pxContext));
-
-			_context = pxContext;
+			_context	  = pxContext.CheckIfNull();
 			SystemActions = GetSystemActions(_context).ToImmutableHashSet();
 		}
 
@@ -30,17 +32,13 @@ namespace Acuminator.Utilities.Roslyn.PXSystemActions
 		/// </summary>
 		/// <param name="pxAction">The action to check.</param>
 		/// <returns/>
-		public bool IsSystemAction(ITypeSymbol pxAction)
-		{
-			pxAction.ThrowOnNull(nameof(pxAction));
-
-			return pxAction.GetBaseTypesAndThis()
-						   .Any(action => SystemActions.Contains(action) || SystemActions.Contains(action.OriginalDefinition));
-		}
+		public bool IsSystemAction(ITypeSymbol pxAction) =>
+			pxAction.CheckIfNull()
+					.GetBaseTypesAndThis()
+					.Any(action => SystemActions.Contains(action) || SystemActions.Contains(action.OriginalDefinition));
 
 		private static HashSet<ITypeSymbol> GetSystemActions(PXContext pxContext) =>
-			new HashSet<ITypeSymbol>
-			{
+			[
 				pxContext.PXSystemActions.PXSave,
 				pxContext.PXSystemActions.PXCancel,
 				pxContext.PXSystemActions.PXInsert,
@@ -51,6 +49,6 @@ namespace Acuminator.Utilities.Roslyn.PXSystemActions
 				pxContext.PXSystemActions.PXNext,
 				pxContext.PXSystemActions.PXLast,
 				pxContext.PXSystemActions.PXChangeID
-			};	
+			];
 	}
 }

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/PrimaryDacFinder/PrimaryDacFinder.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/PrimaryDacFinder/PrimaryDacFinder.cs
@@ -1,13 +1,17 @@
-﻿using System.Collections.Generic;
+﻿#nullable enable
+
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
+
 using Acuminator.Utilities.Common;
 using Acuminator.Utilities.Roslyn.PrimaryDacFinder.PrimaryDacRules.Base;
 using Acuminator.Utilities.Roslyn.PrimaryDacFinder.PrimaryDacRules.RulesProvider;
 using Acuminator.Utilities.Roslyn.Semantic;
-using Acuminator.Utilities.Roslyn.Semantic.PXGraph;
 using Acuminator.Utilities.Roslyn.Semantic.Dac;
+using Acuminator.Utilities.Roslyn.Semantic.PXGraph;
+
 using Microsoft.CodeAnalysis;
 
 namespace Acuminator.Utilities.Roslyn.PrimaryDacFinder
@@ -27,8 +31,8 @@ namespace Acuminator.Utilities.Roslyn.PrimaryDacFinder
 
 		public ImmutableArray<DataViewInfo> GraphViews { get; }
 
-		private readonly Dictionary<ISymbol, (ITypeSymbol DAC, Score Score)> _viewsWithDacAndScores;
-		private readonly ILookup<ITypeSymbol, ISymbol> _dacWithViewsLookup;
+		private readonly Dictionary<ISymbol, (DataViewInfo View, Score Score)> _viewsWithScores;
+		private readonly ILookup<ITypeSymbol, DataViewInfo> _dacWithViewsLookup;
 
 		private readonly List<PrimaryDacRuleBase> _absoluteRules;
 		private readonly List<PrimaryDacRuleBase> _heuristicRules;
@@ -36,58 +40,56 @@ namespace Acuminator.Utilities.Roslyn.PrimaryDacFinder
 		private PrimaryDacFinder(PXContext pxContext, PXGraphSemanticModel graphSemanticModel, ImmutableArray<PrimaryDacRuleBase> rules,
 								 CancellationToken cancellationToken, IEnumerable<DataViewInfo> graphViewInfos, IEnumerable<ActionInfo> actionInfos)
 		{
-			PxContext = pxContext;
+			PxContext 		   = pxContext;
 			GraphSemanticModel = graphSemanticModel;
-			CancellationToken = cancellationToken;
-			GraphActions = actionInfos.ToImmutableArray();
-			GraphViews = graphViewInfos.ToImmutableArray();
-			_viewsWithDacAndScores = new Dictionary<ISymbol, (ITypeSymbol DAC, Score Score)>(GraphViews.Length);
+			CancellationToken  = cancellationToken;
+			GraphActions 	   = actionInfos.ToImmutableArray();
+			GraphViews 		   = graphViewInfos.ToImmutableArray();
 
-			foreach (DataViewInfo viewInfo in GraphViews)
-			{
-				var dac = viewInfo.Type.GetDacFromView(PxContext);
+			_viewsWithScores = GraphViews.Where(viewInfo => viewInfo.DAC != null)
+										 .ToDictionary(keySelector: viewInfo => viewInfo.Symbol, 
+													   elementSelector: viewInfo => (viewInfo, new Score(0.0)));
 
-				if (dac == null)
-					continue;
+			_dacWithViewsLookup = _viewsWithScores.Values.ToLookup(viewAndScore => viewAndScore.View.DAC!,
+																   viewAndScore => viewAndScore.View);
 
-				_viewsWithDacAndScores.Add(viewInfo.Symbol, (dac, new Score(0.0)));
-			}
-
-			_dacWithViewsLookup = _viewsWithDacAndScores.ToLookup(viewAndDac => viewAndDac.Value.DAC,
-																  viewAndDac => viewAndDac.Key);
-			_absoluteRules = rules.Where(rule => rule.IsAbsolute).ToList();
-			_heuristicRules = rules.Where(rule => !rule.IsAbsolute).ToList();
+			_absoluteRules  = rules.Where(rule => rule.IsAbsolute).ToList(capacity: 4);
+			_heuristicRules = rules.Where(rule => !rule.IsAbsolute).ToList(capacity: 16);
 		}
 
-		public static PrimaryDacFinder Create(PXContext pxContext, INamedTypeSymbol graphOrGraphExtension, CancellationToken cancellationToken,
-											  IRulesProvider rulesProvider = null)
+		public static PrimaryDacFinder? Create(PXContext pxContext, INamedTypeSymbol graphOrGraphExtension, CancellationToken cancellationToken,
+											   IRulesProvider? customRulesProvider = null)
 		{
-			if (pxContext == null || graphOrGraphExtension == null || cancellationToken.IsCancellationRequested)
+			cancellationToken.ThrowIfCancellationRequested();
+
+			if (!graphOrGraphExtension.IsPXGraphOrExtension(pxContext))
 				return null;
 
-			bool isGraph = graphOrGraphExtension.InheritsFrom(pxContext.PXGraph.Type);
-
-			if (!isGraph && !graphOrGraphExtension.InheritsFrom(pxContext.PXGraphExtension.Type))
-				return null;
-
-			PXGraphSemanticModel graphSemanticModel = PXGraphSemanticModel.InferModels(pxContext, graphOrGraphExtension, 
+			PXGraphSemanticModel? graphSemanticModel = PXGraphSemanticModel.InferModels(pxContext, graphOrGraphExtension, 
 																					   GraphSemanticModelCreationOptions.CollectGeneralGraphInfo, 
 																					   cancellationToken)
-																		 ?.FirstOrDefault();
-			return Create(pxContext, graphSemanticModel, cancellationToken, rulesProvider);
+																		  ?.FirstOrDefault();
+			return graphSemanticModel != null 
+				? Create(pxContext, graphSemanticModel, cancellationToken, customRulesProvider)
+				: null;
 		}
 
-		public static PrimaryDacFinder Create(PXContext pxContext, PXGraphSemanticModel graphSemanticModel, CancellationToken cancellationToken,
-											  IRulesProvider rulesProvider = null)
+		public static PrimaryDacFinder? Create(PXContext pxContext, PXGraphSemanticModel graphSemanticModel, CancellationToken cancellationToken,
+											   IRulesProvider? customRulesProvider = null)
 		{
-			if (pxContext == null || graphSemanticModel?.GraphSymbol == null || cancellationToken.IsCancellationRequested)
+			cancellationToken.ThrowIfCancellationRequested();
+			pxContext.ThrowOnNull();
+
+			if (graphSemanticModel.CheckIfNull().GraphSymbol == null)
 				return null;
 
-			rulesProvider = rulesProvider ?? new DefaultRulesProvider(pxContext);
-			var rules = rulesProvider.GetRules();
+			IRulesProvider rulesProvider = customRulesProvider ?? new DefaultRulesProvider(pxContext);
+			ImmutableArray<PrimaryDacRuleBase> rules = rulesProvider.GetRules();
 
-			if (rules.Length == 0 || cancellationToken.IsCancellationRequested)
+			if (rules.Length == 0)
 				return null;
+
+			cancellationToken.ThrowIfCancellationRequested();
 
 			var allGraphActionInfos = graphSemanticModel.Actions
 														.Where(action => action.Symbol.ContainingType.IsPXGraph(pxContext))
@@ -96,78 +98,51 @@ namespace Acuminator.Utilities.Roslyn.PrimaryDacFinder
 												 .Where(view => view.Symbol.ContainingType.IsPXGraph(pxContext))
 												 .OrderBy(view => view.DeclarationOrder);
 
-			return cancellationToken.IsCancellationRequested
-				? null
-				: new PrimaryDacFinder(pxContext, graphSemanticModel, rules, cancellationToken, allViewInfos, allGraphActionInfos);
+			cancellationToken.ThrowIfCancellationRequested();
+
+			return new PrimaryDacFinder(pxContext, graphSemanticModel, rules, cancellationToken, allViewInfos, allGraphActionInfos);
 		}
 
-		public ITypeSymbol FindPrimaryDAC()
+		public ITypeSymbol? FindPrimaryDAC()
 		{
-			if (_dacWithViewsLookup.Count == 0)
+			if (_viewsWithScores.Count == 0)
 				return null;
 
 			foreach (PrimaryDacRuleBase rule in _absoluteRules)
 			{
-				ITypeSymbol primaryDAC = ApplyRule(rule);
+				CancellationToken.ThrowIfCancellationRequested();
 
-				if (CancellationToken.IsCancellationRequested)
-					return null;
-				else if (primaryDAC != null)
+				ITypeSymbol? primaryDAC = ApplyRule(rule);
+
+				if (primaryDAC != null)
 					return primaryDAC;
 			}
 
-			if (CancellationToken.IsCancellationRequested)
-				return null;
+			CancellationToken.ThrowIfCancellationRequested();
 
 			foreach (PrimaryDacRuleBase rule in _heuristicRules)
 			{
+				CancellationToken.ThrowIfCancellationRequested();
 				ApplyRule(rule);
-
-				if (CancellationToken.IsCancellationRequested)
-					return null;
 			}
 
-			if (CancellationToken.IsCancellationRequested)
-				return null;
-
-			var maxScoredViews = _viewsWithDacAndScores.ItemsWithMaxValues(viewWithDacAndScore => viewWithDacAndScore.Value.Score.Value);
-			var maxScoredDACs = maxScoredViews.Select(viewWithDacAndScore => viewWithDacAndScore.Value.DAC)
+			var maxScoredViews = _viewsWithScores.ItemsWithMaxValues(viewWithDacAndScore => viewWithDacAndScore.Value.Score.Value);
+			var maxScoredDACs = maxScoredViews.Select(viewWithDacAndScore => viewWithDacAndScore.Value.View.DAC!)
 											  .ToHashSet();
 			return maxScoredDACs.Count == 1
 				? maxScoredDACs.FirstOrDefault()
 				: null;
 		}
 
-		private ITypeSymbol ApplyRule(PrimaryDacRuleBase rule)
+		private ITypeSymbol? ApplyRule(PrimaryDacRuleBase rule)
 		{
-			IEnumerable<ITypeSymbol> dacCandidates = null;
-			IEnumerable<ISymbol> viewCandidates = null;
-
-			switch (rule.RuleKind)
-			{
-				case PrimaryDacRuleKind.Graph:
-					dacCandidates = (rule as GraphRuleBase)?.GetCandidatesFromGraphRule(this);
-					break;
-				case PrimaryDacRuleKind.View:
-					var viewWithTypeCandidates = GetViewCandidatesFromViewRule(rule as ViewRuleBase);
-					viewCandidates = viewWithTypeCandidates?.Select(view => view.Symbol);
-					dacCandidates = viewWithTypeCandidates?.Select(view => view.Type.GetDacFromView(PxContext));
-					break;
-				case PrimaryDacRuleKind.Dac:
-					var dacWithViewCandidates = GetCandidatesFromDacRule(rule as DacRuleBase);
-					dacCandidates = dacWithViewCandidates?.Select(group => group.Key);
-					viewCandidates = dacWithViewCandidates?.SelectMany(group => group);
-					break;
-				case PrimaryDacRuleKind.Action:
-					dacCandidates = GetCandidatesFromActionRule(rule as ActionRuleBase);
-					break;
-			}
+			var (dacCandidates, viewCandidates) = GetDacAndViewCandidates(rule);
 
 			if (dacCandidates.IsNullOrEmpty())
 				return null;
 
-			var dacCandidatesList = dacCandidates.Where(dac => dac != null).Distinct().ToList();
-			ITypeSymbol primaryDac = null;
+			List<ITypeSymbol> dacCandidatesList = dacCandidates.Where(dac => dac != null).Distinct().ToList()!;
+			ITypeSymbol? primaryDac = null;
 
 			if (rule.IsAbsolute && dacCandidatesList.Count == 1)
 				primaryDac = dacCandidatesList[0];
@@ -177,52 +152,67 @@ namespace Acuminator.Utilities.Roslyn.PrimaryDacFinder
 			return primaryDac;
 		}
 
-		private List<DataViewInfo> GetViewCandidatesFromViewRule(ViewRuleBase viewRule)
+		private (IEnumerable<ITypeSymbol?> DacCandidates, IEnumerable<DataViewInfo> ViewCandidates) GetDacAndViewCandidates(PrimaryDacRuleBase rule)
 		{
-			if (viewRule == null || GraphViews.Length == 0 || CancellationToken.IsCancellationRequested)
-				return null;
+			switch (rule)
+			{
+				case GraphRuleBase graphRule:
+					return (DacCandidates: graphRule.GetCandidatesFromGraphRule(this), ViewCandidates: []);
 
-			return GraphViews.Where(view => viewRule.SatisfyRule(this, view.Symbol, view.Type)).ToList();
+				case ViewRuleBase viewRule:
+				{
+					var viewCandidates = GetViewCandidatesFromViewRule(viewRule);
+					var dacCandidates = viewCandidates.Select(view => view.DAC);
+
+					return (dacCandidates, viewCandidates);
+				}
+				case DacRuleBase dacRule:
+				{
+					var dacWithViewCandidates = GetDacCandidatesWithViewsFromDacRule(dacRule);
+					var dacCandidates = dacWithViewCandidates.Select(dacWithViews => dacWithViews.Key);
+					var viewCandidates = dacWithViewCandidates.SelectMany(dacWithViews => dacWithViews);
+
+					return (dacCandidates, viewCandidates);
+				}
+				case ActionRuleBase actionRule:
+					return (DacCandidates: GetCandidatesFromActionRule(actionRule), ViewCandidates: []);
+
+				default:
+					return (DacCandidates: [], ViewCandidates: []);
+			}
 		}
 
-		private List<IGrouping<ITypeSymbol, ISymbol>> GetCandidatesFromDacRule(DacRuleBase dacRule)
-		{
-			if (dacRule == null || CancellationToken.IsCancellationRequested)
-				return null;
+		private List<DataViewInfo> GetViewCandidatesFromViewRule(ViewRuleBase viewRule) =>
+			GraphViews.Length > 0
+				? GraphViews.Where(view => viewRule.SatisfyRule(this, view)).ToList()
+				: [];
 
-			var candidates = _dacWithViewsLookup.TakeWhile(dacWithViews => !CancellationToken.IsCancellationRequested)
-												  .Where(dacWithViews => dacRule.SatisfyRule(this, dacWithViews.Key));
-
-			return !CancellationToken.IsCancellationRequested
-				? candidates.ToList()
-				: null;
-		}
+		private List<IGrouping<ITypeSymbol, DataViewInfo>> GetDacCandidatesWithViewsFromDacRule(DacRuleBase dacRule) =>
+			_dacWithViewsLookup.Where(dacWithViews => dacRule.SatisfyRule(this, dacWithViews.Key))
+							   .ToList();
 
 		private IEnumerable<ITypeSymbol> GetCandidatesFromActionRule(ActionRuleBase actionRule)
 		{
-			if (actionRule == null || GraphActions.Length == 0 || CancellationToken.IsCancellationRequested)
-				return null;
+			if (GraphActions.Length == 0)
+				return [];
 
 			var dacCandidates = from action in GraphActions
 								where actionRule.SatisfyRule(this, action.Symbol, action.Type)
 								select action.Type.GetDacFromAction();
-
-			return !CancellationToken.IsCancellationRequested
-				? dacCandidates
-				: null;
+			return dacCandidates;
 		}
 
-		private void ScoreRuleForViewCandidates(IEnumerable<ISymbol> viewCandidates, PrimaryDacRuleBase rule)
+		private void ScoreRuleForViewCandidates(IEnumerable<DataViewInfo> viewCandidates, PrimaryDacRuleBase rule)
 		{
 			if (rule.Weight == 0)
 				return;
 
-			foreach (ISymbol candidate in viewCandidates)
+			foreach (var viewInfo in viewCandidates)
 			{
-				if (!_viewsWithDacAndScores.TryGetValue(candidate, out var dacWithScore))
+				if (!_viewsWithScores.TryGetValue(viewInfo.Symbol, out var viewWithScore))
 					continue;
 
-				Score score = dacWithScore.Score;
+				Score score = viewWithScore.Score;
 
 				if (rule.Weight > 0)
 				{

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/PrimaryDacFinder/PrimaryDacRules/ActionRules/ScoreSimpleActionRule.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/PrimaryDacFinder/PrimaryDacRules/ActionRules/ScoreSimpleActionRule.cs
@@ -1,4 +1,6 @@
-﻿using Acuminator.Utilities.Roslyn.PrimaryDacFinder.PrimaryDacRules.Base;
+﻿#nullable enable
+using Acuminator.Utilities.Roslyn.PrimaryDacFinder.PrimaryDacRules.Base;
+
 using Microsoft.CodeAnalysis;
 
 namespace Acuminator.Utilities.Roslyn.PrimaryDacFinder.PrimaryDacRules.ActionRules
@@ -6,19 +8,13 @@ namespace Acuminator.Utilities.Roslyn.PrimaryDacFinder.PrimaryDacRules.ActionRul
 	/// <summary>
 	/// A rule to  add score to DACs which has action declared for it.
 	/// </summary>
-	public class ScoreSimpleActionRule : ActionRuleBase
+	public class ScoreSimpleActionRule(double? weight = null) : ActionRuleBase(weight)
 	{
-		public sealed override bool IsAbsolute => false;
-
-		public ScoreSimpleActionRule(double? weight = null) : base(weight)
-		{
-		}
+		public override sealed bool IsAbsolute => false;
 
 		public override bool SatisfyRule(PrimaryDacFinder dacFinder, ISymbol action, INamedTypeSymbol actionType)
 		{
-			if (dacFinder == null || dacFinder.CancellationToken.IsCancellationRequested || actionType == null)
-				return false;
-
+			dacFinder.CancellationToken.ThrowIfCancellationRequested();
 			return true;
 		}
 	}

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/PrimaryDacFinder/PrimaryDacRules/ActionRules/ScoreSystemActionRule.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/PrimaryDacFinder/PrimaryDacRules/ActionRules/ScoreSystemActionRule.cs
@@ -1,5 +1,8 @@
-﻿using Acuminator.Utilities.Roslyn.PXSystemActions;
+﻿#nullable enable
+
+using Acuminator.Utilities.Roslyn.PXSystemActions;
 using Acuminator.Utilities.Roslyn.Semantic;
+
 using Microsoft.CodeAnalysis;
 
 namespace Acuminator.Utilities.Roslyn.PrimaryDacFinder.PrimaryDacRules.ActionRules
@@ -7,21 +10,12 @@ namespace Acuminator.Utilities.Roslyn.PrimaryDacFinder.PrimaryDacRules.ActionRul
 	/// <summary>
 	/// A rule to  add score to DACs which has system action declared for it.
 	/// </summary>
-	public class ScoreSystemActionRule : ScoreSimpleActionRule
+	public class ScoreSystemActionRule(PXContext context, double? weight = null) : ScoreSimpleActionRule(weight)
 	{
-		private readonly PXSystemActionsRegister _systemActionsRegister;
+		private readonly PXSystemActionsRegister _systemActionsRegister = new(context);
 
-		public ScoreSystemActionRule(PXContext context, double? weight = null) : base(weight)
-		{
-			_systemActionsRegister = new PXSystemActionsRegister(context);
-		}
-
-		public override bool SatisfyRule(PrimaryDacFinder dacFinder, ISymbol action, INamedTypeSymbol actionType)
-		{
-			if (!base.SatisfyRule(dacFinder, action, actionType))
-				return false;
-
-			return _systemActionsRegister.IsSystemAction(actionType);
-		}
+		public override bool SatisfyRule(PrimaryDacFinder dacFinder, ISymbol action, INamedTypeSymbol actionType) =>
+			base.SatisfyRule(dacFinder, action, actionType) && 
+			_systemActionsRegister.IsSystemAction(actionType);
 	}
 }

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/PrimaryDacFinder/PrimaryDacRules/Base/ActionRuleBase.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/PrimaryDacFinder/PrimaryDacRules/Base/ActionRuleBase.cs
@@ -1,20 +1,18 @@
-﻿using Microsoft.CodeAnalysis;
+﻿#nullable enable
+
+using Microsoft.CodeAnalysis;
 
 namespace Acuminator.Utilities.Roslyn.PrimaryDacFinder.PrimaryDacRules.Base
 {
 	/// <summary>
 	/// A rule to filter DAC based on a graph's action.
 	/// </summary>
-	public abstract class ActionRuleBase : PrimaryDacRuleBase
+	public abstract class ActionRuleBase(double? customWeight) : PrimaryDacRuleBase(customWeight)
 	{
 		/// <summary>
 		/// The rule kind.
 		/// </summary>
-		public sealed override PrimaryDacRuleKind RuleKind => PrimaryDacRuleKind.Action;
-
-		protected ActionRuleBase(double? customWeight) : base(customWeight)
-		{
-		}
+		public override sealed PrimaryDacRuleKind RuleKind => PrimaryDacRuleKind.Action;
 
 		/// <summary>
 		/// Query if action satisfies this rule's conditions.

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/PrimaryDacFinder/PrimaryDacRules/Base/DacRuleBase.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/PrimaryDacFinder/PrimaryDacRules/Base/DacRuleBase.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.CodeAnalysis;
+﻿#nullable enable
+
+using Microsoft.CodeAnalysis;
 
 namespace Acuminator.Utilities.Roslyn.PrimaryDacFinder.PrimaryDacRules.Base
 {
@@ -10,7 +12,7 @@ namespace Acuminator.Utilities.Roslyn.PrimaryDacFinder.PrimaryDacRules.Base
 		/// <summary>
 		/// The rule kind.
 		/// </summary>
-		public sealed override PrimaryDacRuleKind RuleKind => PrimaryDacRuleKind.Dac;
+		public override sealed PrimaryDacRuleKind RuleKind => PrimaryDacRuleKind.Dac;
 
 		protected DacRuleBase(double? customWeight) : base(customWeight)
 		{

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/PrimaryDacFinder/PrimaryDacRules/Base/GraphRuleBase.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/PrimaryDacFinder/PrimaryDacRules/Base/GraphRuleBase.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿#nullable enable
+
+using System.Collections.Generic;
+
 using Microsoft.CodeAnalysis;
 
 namespace Acuminator.Utilities.Roslyn.PrimaryDacFinder.PrimaryDacRules.Base
@@ -22,6 +25,6 @@ namespace Acuminator.Utilities.Roslyn.PrimaryDacFinder.PrimaryDacRules.Base
 		/// </summary>
 		/// <param name="dacFinder">The DAC finder.</param>
 		/// <returns/>
-		public abstract IEnumerable<ITypeSymbol> GetCandidatesFromGraphRule(PrimaryDacFinder dacFinder);
+		public abstract IEnumerable<ITypeSymbol?> GetCandidatesFromGraphRule(PrimaryDacFinder dacFinder);
 	}
 }

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/PrimaryDacFinder/PrimaryDacRules/Base/PrimaryDacRuleBase.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/PrimaryDacFinder/PrimaryDacRules/Base/PrimaryDacRuleBase.cs
@@ -1,4 +1,6 @@
-﻿using Acuminator.Utilities.Roslyn.PrimaryDacFinder.PrimaryDacRules.RulesProvider;
+﻿#nullable enable
+
+using Acuminator.Utilities.Roslyn.PrimaryDacFinder.PrimaryDacRules.RulesProvider;
 
 namespace Acuminator.Utilities.Roslyn.PrimaryDacFinder.PrimaryDacRules.Base
 {

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/PrimaryDacFinder/PrimaryDacRules/Base/PrimaryDacRuleKind.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/PrimaryDacFinder/PrimaryDacRules/Base/PrimaryDacRuleKind.cs
@@ -1,4 +1,6 @@
-﻿namespace Acuminator.Utilities.Roslyn.PrimaryDacFinder.PrimaryDacRules.Base
+﻿#nullable enable
+
+namespace Acuminator.Utilities.Roslyn.PrimaryDacFinder.PrimaryDacRules.Base
 {
 	/// <summary>
 	/// Values that represent kinds of rule of the graph's primary DAC.

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/PrimaryDacFinder/PrimaryDacRules/Base/ViewRuleBase.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/PrimaryDacFinder/PrimaryDacRules/Base/ViewRuleBase.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.CodeAnalysis;
+﻿#nullable enable
+
+using Acuminator.Utilities.Roslyn.Semantic.PXGraph;
 
 namespace Acuminator.Utilities.Roslyn.PrimaryDacFinder.PrimaryDacRules.Base
 {
@@ -10,7 +12,7 @@ namespace Acuminator.Utilities.Roslyn.PrimaryDacFinder.PrimaryDacRules.Base
 		/// <summary>
 		/// The rule kind.
 		/// </summary>
-		public sealed override PrimaryDacRuleKind RuleKind => PrimaryDacRuleKind.View;
+		public override sealed PrimaryDacRuleKind RuleKind => PrimaryDacRuleKind.View;
 
 		protected ViewRuleBase(double? customWeight) : base(customWeight)
 		{
@@ -20,9 +22,8 @@ namespace Acuminator.Utilities.Roslyn.PrimaryDacFinder.PrimaryDacRules.Base
 		/// Query if view satisfies this rule's conditions.
 		/// </summary>
 		/// <param name="dacFinder">The DAC finder.</param>
-		/// <param name="view">The view.</param>
-		/// <param name="viewType">Type of the view.</param>
+		/// <param name="viewInfo">The view info.</param>
 		/// <returns/>
-		public abstract bool SatisfyRule(PrimaryDacFinder dacFinder, ISymbol view, INamedTypeSymbol viewType);
+		public abstract bool SatisfyRule(PrimaryDacFinder dacFinder, DataViewInfo viewInfo);
 	}
 }

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/PrimaryDacFinder/PrimaryDacRules/DacRules/SameOrDescendingNamespaceDacRule.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/PrimaryDacFinder/PrimaryDacRules/DacRules/SameOrDescendingNamespaceDacRule.cs
@@ -1,32 +1,30 @@
-﻿using System.Linq;
+﻿#nullable enable
+
+using System.Linq;
+
 using Acuminator.Utilities.Roslyn.PrimaryDacFinder.PrimaryDacRules.Base;
 using Acuminator.Utilities.Roslyn.Semantic;
+
 using Microsoft.CodeAnalysis;
 
 namespace Acuminator.Utilities.Roslyn.PrimaryDacFinder.PrimaryDacRules.DacRules
 {
 	/// <summary>
-	/// A rule to  add score to DACs which has action declared for it.
+	/// A rule to add score to DACs which are declared in the same namespace as the graph for which the primary DAC is calculated.
 	/// </summary>
-	public class SameOrDescendingNamespaceDacRule : DacRuleBase
+	public class SameOrDescendingNamespaceDacRule(double? weight = null) : DacRuleBase(weight)
 	{
 		public sealed override bool IsAbsolute => false;
 
-		public SameOrDescendingNamespaceDacRule(double? weight = null) : base(weight)
-		{
-		}
-
 		public override bool SatisfyRule(PrimaryDacFinder dacFinder, ITypeSymbol dac)
 		{
-			if (dacFinder?.GraphSemanticModel?.GraphSymbol?.ContainingNamespace == null || 
-				dacFinder.CancellationToken.IsCancellationRequested ||
-				dac?.ContainingNamespace == null)
-			{
-				return false;
-			}
+			dacFinder.CancellationToken.ThrowIfCancellationRequested();
 
-			var graphNameSpace = dacFinder.GraphSemanticModel.GraphSymbol.ContainingNamespace;
-			return dac.GetContainingNamespaces().Contains(graphNameSpace);
+			if (dacFinder.GraphSemanticModel.GraphSymbol?.ContainingNamespace == null)
+				return false;
+
+			var graphNamespace = dacFinder.GraphSemanticModel.GraphSymbol.ContainingNamespace;
+			return dac.GetContainingNamespaces().Contains(graphNamespace);
 		}
 	}
 }

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/PrimaryDacFinder/PrimaryDacRules/GraphRules/FirstViewsInGraphRule.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/PrimaryDacFinder/PrimaryDacRules/GraphRules/FirstViewsInGraphRule.cs
@@ -1,9 +1,12 @@
-﻿using System;
+﻿#nullable enable
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
+
 using Acuminator.Utilities.Roslyn.PrimaryDacFinder.PrimaryDacRules.Base;
 using Acuminator.Utilities.Roslyn.PrimaryDacFinder.PrimaryDacRules.RulesProvider;
-using Acuminator.Utilities.Roslyn.Semantic.Dac;
+
 using Microsoft.CodeAnalysis;
 
 namespace Acuminator.Utilities.Roslyn.PrimaryDacFinder.PrimaryDacRules.GraphRules
@@ -13,7 +16,7 @@ namespace Acuminator.Utilities.Roslyn.PrimaryDacFinder.PrimaryDacRules.GraphRule
 	/// </summary>
 	public class FirstViewsInGraphRule : GraphRuleBase
 	{
-		public sealed override bool IsAbsolute => false;
+		public override sealed bool IsAbsolute => false;
 
 		/// <summary>
 		/// The number of first views to select from graph.
@@ -37,16 +40,13 @@ namespace Acuminator.Utilities.Roslyn.PrimaryDacFinder.PrimaryDacRules.GraphRule
 			}
 		}
 
-		public override IEnumerable<ITypeSymbol> GetCandidatesFromGraphRule(PrimaryDacFinder dacFinder)
+		public override IEnumerable<ITypeSymbol?> GetCandidatesFromGraphRule(PrimaryDacFinder dacFinder)
 		{
-			if (dacFinder == null || dacFinder.GraphViews.Length == 0 || dacFinder.CancellationToken.IsCancellationRequested)
-			{
-				return Enumerable.Empty<ITypeSymbol>();
-			}
+			if (dacFinder.GraphViews.Length == 0)
+				return [];
 
 			return dacFinder.GraphViews.Take(NumberOfViews)
-									   .Select(view => view.Type.GetDacFromView(dacFinder.PxContext))
-									   .Where(dac => dac != null);
+									   .Select(viewInfo => viewInfo.DAC);
 		}
 	}
 }

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/PrimaryDacFinder/PrimaryDacRules/GraphRules/PairOfViewsWithSpecialNamesGraphRule.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/PrimaryDacFinder/PrimaryDacRules/GraphRules/PairOfViewsWithSpecialNamesGraphRule.cs
@@ -1,9 +1,14 @@
-﻿using System;
+﻿#nullable enable
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
+
 using Acuminator.Utilities.Common;
 using Acuminator.Utilities.Roslyn.PrimaryDacFinder.PrimaryDacRules.Base;
 using Acuminator.Utilities.Roslyn.Semantic.Dac;
+using Acuminator.Utilities.Roslyn.Semantic.PXGraph;
+
 using Microsoft.CodeAnalysis;
 
 namespace Acuminator.Utilities.Roslyn.PrimaryDacFinder.PrimaryDacRules.GraphRules
@@ -11,47 +16,34 @@ namespace Acuminator.Utilities.Roslyn.PrimaryDacFinder.PrimaryDacRules.GraphRule
 	/// <summary>
 	/// A rule to add scores to the pair of views with special names in graph.
 	/// </summary>
-	public class PairOfViewsWithSpecialNamesGraphRule : GraphRuleBase
+	public class PairOfViewsWithSpecialNamesGraphRule(string firstName, string secondName, double? customWeight = null) : GraphRuleBase(customWeight)
 	{
-		public sealed override bool IsAbsolute => false;
+		private readonly string _firstName  = firstName.CheckIfNullOrWhiteSpace();
+		private readonly string _secondName = secondName.CheckIfNullOrWhiteSpace();
 
-		private readonly string _firstName, _secondName;
+		public override sealed bool IsAbsolute => false;
 
-		public PairOfViewsWithSpecialNamesGraphRule(string firstName, string secondName, double? customWeight = null) : base(customWeight)
+		public override IEnumerable<ITypeSymbol?> GetCandidatesFromGraphRule(PrimaryDacFinder dacFinder)
 		{
-			if (firstName.IsNullOrWhiteSpace())
-				throw new ArgumentNullException(nameof(firstName));
-			else if (secondName.IsNullOrWhiteSpace())
-				throw new ArgumentNullException(nameof(secondName));
+			if (dacFinder.GraphSemanticModel.GraphSymbol == null || dacFinder.GraphViews.Length == 0)
+				return [];
 
-			_firstName = firstName;
-			_secondName = secondName;
-		}
-
-		public override IEnumerable<ITypeSymbol> GetCandidatesFromGraphRule(PrimaryDacFinder dacFinder)
-		{
-			if (dacFinder?.GraphSemanticModel?.GraphSymbol == null || dacFinder.CancellationToken.IsCancellationRequested ||
-				dacFinder.GraphViews.Length == 0)
-			{
-				return Enumerable.Empty<ITypeSymbol>();
-			}
-
-			bool firstNameFound = dacFinder.GraphSemanticModel.ViewsByNames.TryGetValue(_firstName, out var firstView);
-			bool secondNameFound = dacFinder.GraphSemanticModel.ViewsByNames.TryGetValue(_secondName, out var secondView);
+			bool firstNameFound = dacFinder.GraphSemanticModel.ViewsByNames.TryGetValue(_firstName, out DataViewInfo firstView);
+			bool secondNameFound = dacFinder.GraphSemanticModel.ViewsByNames.TryGetValue(_secondName, out DataViewInfo secondView);
 
 			if (!firstNameFound || !secondNameFound)
 			{
-				return Enumerable.Empty<ITypeSymbol>();
+				return [];
 			}
 
-			ITypeSymbol firstDacCandidate = firstView.Type.GetDacFromView(dacFinder.PxContext);
-			ITypeSymbol secondDacCandidate = secondView.Type.GetDacFromView(dacFinder.PxContext);
+			ITypeSymbol? firstDacCandidate = firstView.Type.GetDacFromView(dacFinder.PxContext);
+			ITypeSymbol? secondDacCandidate = secondView.Type.GetDacFromView(dacFinder.PxContext);
 
 			var dacCandidate = ChooseDacCandidate(firstDacCandidate, secondDacCandidate);
-			return dacCandidate?.ToEnumerable() ?? Enumerable.Empty<ITypeSymbol>();
+			return dacCandidate != null ? [dacCandidate] : [];
 		}
 
-		private static ITypeSymbol ChooseDacCandidate(ITypeSymbol firstDacCandidate, ITypeSymbol secondDacCandidate)
+		private static ITypeSymbol? ChooseDacCandidate(ITypeSymbol? firstDacCandidate, ITypeSymbol? secondDacCandidate)
 		{
 			if (firstDacCandidate == null && secondDacCandidate == null)
 				return null;

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/PrimaryDacFinder/PrimaryDacRules/GraphRules/PrimaryDacSpecifiedGraphRule.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/PrimaryDacFinder/PrimaryDacRules/GraphRules/PrimaryDacSpecifiedGraphRule.cs
@@ -1,8 +1,11 @@
-﻿using System.Collections.Generic;
-using System.Linq;
+﻿#nullable enable
+
+using System.Collections.Generic;
+
 using Acuminator.Utilities.Common;
 using Acuminator.Utilities.Roslyn.PrimaryDacFinder.PrimaryDacRules.Base;
 using Acuminator.Utilities.Roslyn.Semantic.PXGraph;
+
 using Microsoft.CodeAnalysis;
 
 namespace Acuminator.Utilities.Roslyn.PrimaryDacFinder.PrimaryDacRules.GraphRules
@@ -10,22 +13,18 @@ namespace Acuminator.Utilities.Roslyn.PrimaryDacFinder.PrimaryDacRules.GraphRule
 	/// <summary>
 	/// A rule to select primary DAC when graph has primary DAC specified.
 	/// </summary>
-	public class PrimaryDacSpecifiedGraphRule : GraphRuleBase
+	public class PrimaryDacSpecifiedGraphRule() : GraphRuleBase(customWeight: null)
 	{
 		public override bool IsAbsolute => true;
 
-		public PrimaryDacSpecifiedGraphRule() : base(null)
+		public override IEnumerable<ITypeSymbol?> GetCandidatesFromGraphRule(PrimaryDacFinder dacFinder)
 		{
-		}
+			if (dacFinder.GraphSemanticModel.GraphSymbol == null)
+				return [];
 
-		public override IEnumerable<ITypeSymbol> GetCandidatesFromGraphRule(PrimaryDacFinder dacFinder)
-		{
-			if (dacFinder?.GraphSemanticModel?.GraphSymbol == null)
-				return Enumerable.Empty<ITypeSymbol>();
-
-			ITypeSymbol primaryDac = dacFinder.GraphSemanticModel.GraphSymbol
-																 .GetDeclaredPrimaryDacFromGraphOrGraphExtension(dacFinder.PxContext);
-			return primaryDac?.ToEnumerable() ?? Enumerable.Empty<ITypeSymbol>();
+			ITypeSymbol? primaryDac = dacFinder.GraphSemanticModel.GraphSymbol
+																  .GetDeclaredPrimaryDacFromGraphOrGraphExtension(dacFinder.PxContext);
+			return primaryDac != null ? [primaryDac] : [];
 		}
 	}
 }

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/PrimaryDacFinder/PrimaryDacRules/RulesProvider/DefaultRulesProvider.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/PrimaryDacFinder/PrimaryDacRules/RulesProvider/DefaultRulesProvider.cs
@@ -1,5 +1,8 @@
-﻿using System.Collections.Generic;
+﻿#nullable enable
+
+using System.Collections.Generic;
 using System.Collections.Immutable;
+
 using Acuminator.Utilities.Common;
 using Acuminator.Utilities.Roslyn.PrimaryDacFinder.PrimaryDacRules.ActionRules;
 using Acuminator.Utilities.Roslyn.PrimaryDacFinder.PrimaryDacRules.Base;
@@ -19,10 +22,13 @@ namespace Acuminator.Utilities.Roslyn.PrimaryDacFinder.PrimaryDacRules.RulesProv
 
 		public DefaultRulesProvider(PXContext context)
 		{
-			context.ThrowOnNull(nameof(context));
+			_rules = GetPrimaryDacCalculationRules(context.CheckIfNull()).ToImmutableArray();
+		}
 
-			_rules = new List<PrimaryDacRuleBase>
-			{
+		public ImmutableArray<PrimaryDacRuleBase> GetRules() => _rules;
+
+		private static PrimaryDacRuleBase[] GetPrimaryDacCalculationRules(PXContext context) =>
+			[
 				//AbsoluteRules
 				new PrimaryDacSpecifiedGraphRule(),
 				new PXImportAttributeGraphRule(),
@@ -44,7 +50,7 @@ namespace Acuminator.Utilities.Roslyn.PrimaryDacFinder.PrimaryDacRules.RulesProv
 				// View rules
 				new ForbiddenWordsInNameViewRule(useCaseSensitiveComparison: false),
 				new HiddenAttributesViewRule(),
-				new NoPXSetupViewRule(context),
+				new NoPXSetupViewRule(),
 				new PXViewNameAttributeViewRule(context),			
 
 				// Action rules
@@ -53,10 +59,6 @@ namespace Acuminator.Utilities.Roslyn.PrimaryDacFinder.PrimaryDacRules.RulesProv
 
 				// DAC rules
 				new SameOrDescendingNamespaceDacRule()
-			}
-			.ToImmutableArray();
-		}
-
-		public ImmutableArray<PrimaryDacRuleBase> GetRules() => _rules;
+			];
 	}
 }

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/PrimaryDacFinder/PrimaryDacRules/RulesProvider/IRulesProvider.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/PrimaryDacFinder/PrimaryDacRules/RulesProvider/IRulesProvider.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Immutable;
+﻿#nullable enable
+
+using System.Collections.Immutable;
+
 using Acuminator.Utilities.Roslyn.PrimaryDacFinder.PrimaryDacRules.Base;
 
 namespace Acuminator.Utilities.Roslyn.PrimaryDacFinder.PrimaryDacRules.RulesProvider

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/PrimaryDacFinder/PrimaryDacRules/RulesProvider/WeightsTable.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/PrimaryDacFinder/PrimaryDacRules/RulesProvider/WeightsTable.cs
@@ -1,5 +1,8 @@
-﻿using System.Collections.Generic;
+﻿#nullable enable
+
+using System.Collections.Generic;
 using System.Collections.Immutable;
+
 using Acuminator.Utilities.Common;
 using Acuminator.Utilities.Roslyn.PrimaryDacFinder.PrimaryDacRules.ActionRules;
 using Acuminator.Utilities.Roslyn.PrimaryDacFinder.PrimaryDacRules.DacRules;
@@ -13,32 +16,32 @@ namespace Acuminator.Utilities.Roslyn.PrimaryDacFinder.PrimaryDacRules.RulesProv
 	/// </summary>
 	internal class WeightsTable
 	{
-		public static readonly WeightsTable Default = new WeightsTable();
+		public static readonly WeightsTable Default = new();
 
 		private static readonly IImmutableDictionary<string, double> _weights = new Dictionary<string, double>
 		{
-			[nameof(PrimaryDacSpecifiedGraphRule)]             = double.MaxValue,
-			[nameof(PXImportAttributeGraphRule)]               = 1000.0,
-			[nameof(PXFilteredProcessingGraphRule)]			   = 1000.0,
+			[nameof(PrimaryDacSpecifiedGraphRule)] 			   = double.MaxValue,
+			[nameof(PXImportAttributeGraphRule)] 			   = 1000.0,
+			[nameof(PXFilteredProcessingGraphRule)] 		   = 1000.0,
 
-			[$"{nameof(FirstViewsInGraphRule)}-1"]             = 1.0,
-			[$"{nameof(FirstViewsInGraphRule)}-3"]             = 5.0,
-			[$"{nameof(FirstViewsInGraphRule)}-5"]             = 5.0,
-			[$"{nameof(FirstViewsInGraphRule)}-10"]            = 10.0,
+			[$"{nameof(FirstViewsInGraphRule)}-1"] 			   = 1.0,
+			[$"{nameof(FirstViewsInGraphRule)}-3"] 			   = 5.0,
+			[$"{nameof(FirstViewsInGraphRule)}-5"] 			   = 5.0,
+			[$"{nameof(FirstViewsInGraphRule)}-10"] 		   = 10.0,
 
-			[nameof(NoReadOnlyViewGraphRule)]                  = -20.0,
+			[nameof(NoReadOnlyViewGraphRule)] 				   = -20.0,
 			[nameof(ViewsWithoutPXViewNameAttributeGraphRule)] = -3.0,
-			[nameof(PairOfViewsWithSpecialNamesGraphRule)]	   = 10,
+			[nameof(PairOfViewsWithSpecialNamesGraphRule)] 	   = 10,
 
-			[nameof(ForbiddenWordsInNameViewRule)]             = -15.0,
-			[nameof(HiddenAttributesViewRule)]                 = -50.0,
-			[nameof(NoPXSetupViewRule)]                        = -40.0,		
-			[nameof(PXViewNameAttributeViewRule)]	           = 3.0,
+			[nameof(ForbiddenWordsInNameViewRule)] 			   = -15.0,
+			[nameof(HiddenAttributesViewRule)] 				   = -50.0,
+			[nameof(NoPXSetupViewRule)] 					   = -40.0,
+			[nameof(PXViewNameAttributeViewRule)] 			   = 3.0,
 
-			[nameof(ScoreSimpleActionRule)]                    = 1.0,
-			[nameof(ScoreSystemActionRule)]                    = 8.0,
+			[nameof(ScoreSimpleActionRule)] 				   = 1.0,
+			[nameof(ScoreSystemActionRule)] 				   = 8.0,
 
-			[nameof(SameOrDescendingNamespaceDacRule)]         = 2.0,
+			[nameof(SameOrDescendingNamespaceDacRule)] 		   = 2.0,
 		}
 		.ToImmutableDictionary();
 

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/PrimaryDacFinder/PrimaryDacRules/ViewRules/ForbiddenWordsInNameViewRule.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/PrimaryDacFinder/PrimaryDacRules/ViewRules/ForbiddenWordsInNameViewRule.cs
@@ -7,6 +7,7 @@ using System.Linq;
 
 using Acuminator.Utilities.Common;
 using Acuminator.Utilities.Roslyn.PrimaryDacFinder.PrimaryDacRules.Base;
+using Acuminator.Utilities.Roslyn.Semantic.PXGraph;
 
 using Microsoft.CodeAnalysis;
 
@@ -50,12 +51,8 @@ namespace Acuminator.Utilities.Roslyn.PrimaryDacFinder.PrimaryDacRules.ViewRules
 		/// <param name="view">The view.</param>
 		/// <param name="viewType">Type of the view.</param>
 		/// <returns/>
-		public override sealed bool SatisfyRule(PrimaryDacFinder dacFinder, ISymbol view, INamedTypeSymbol viewType)
-		{
-			dacFinder.CancellationToken.ThrowIfCancellationRequested();
-
-			return _forbiddenWords.Any(word => view.Name.Contains(word, _stringComparisonKind));
-		}
+		public override sealed bool SatisfyRule(PrimaryDacFinder dacFinder, DataViewInfo viewInfo) =>
+			_forbiddenWords.Any(word => viewInfo.Name.Contains(word, _stringComparisonKind));
 
 		private List<string> GetDefaultForbiddenWords() => ["dummy"];
 	}

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/PrimaryDacFinder/PrimaryDacRules/ViewRules/ForbiddenWordsInNameViewRule.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/PrimaryDacFinder/PrimaryDacRules/ViewRules/ForbiddenWordsInNameViewRule.cs
@@ -1,9 +1,13 @@
-﻿using System;
+﻿#nullable enable
+
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+
 using Acuminator.Utilities.Common;
 using Acuminator.Utilities.Roslyn.PrimaryDacFinder.PrimaryDacRules.Base;
+
 using Microsoft.CodeAnalysis;
 
 namespace Acuminator.Utilities.Roslyn.PrimaryDacFinder.PrimaryDacRules.ViewRules
@@ -13,15 +17,17 @@ namespace Acuminator.Utilities.Roslyn.PrimaryDacFinder.PrimaryDacRules.ViewRules
 	/// </summary>
 	public class ForbiddenWordsInNameViewRule : ViewRuleBase
 	{
-		private readonly bool _useCaseSensitiveComparison;
-		private readonly ImmutableArray<string> _forbiddenWords;
+		private readonly StringComparison _stringComparisonKind;
+		private readonly List<string> _forbiddenWords;
 
-		public sealed override bool IsAbsolute => false;
+		public override sealed bool IsAbsolute => false;
 
-		public ForbiddenWordsInNameViewRule(bool useCaseSensitiveComparison, IEnumerable<string> wordsToForbid = null, double? weight = null) :
+		public ForbiddenWordsInNameViewRule(bool useCaseSensitiveComparison, IEnumerable<string>? wordsToForbid = null, double? weight = null) :
 									   base(weight)
 		{
-			_useCaseSensitiveComparison = useCaseSensitiveComparison;
+			_stringComparisonKind = useCaseSensitiveComparison
+				? StringComparison.Ordinal
+				: StringComparison.OrdinalIgnoreCase;
 
 			if (wordsToForbid.IsNullOrEmpty())
 			{
@@ -29,12 +35,11 @@ namespace Acuminator.Utilities.Roslyn.PrimaryDacFinder.PrimaryDacRules.ViewRules
 			}
 			else
 			{
-				if (_useCaseSensitiveComparison)
-				{
-					wordsToForbid = wordsToForbid.Select(w => w.ToUpper());
-				}
+				var stringComparer = useCaseSensitiveComparison 
+					? StringComparer.Ordinal 
+					: StringComparer.OrdinalIgnoreCase;
 
-				_forbiddenWords = wordsToForbid.Distinct().ToImmutableArray();
+				_forbiddenWords = wordsToForbid.Distinct(stringComparer).ToList();
 			}
 		}
 
@@ -45,19 +50,13 @@ namespace Acuminator.Utilities.Roslyn.PrimaryDacFinder.PrimaryDacRules.ViewRules
 		/// <param name="view">The view.</param>
 		/// <param name="viewType">Type of the view.</param>
 		/// <returns/>
-		public sealed override bool SatisfyRule(PrimaryDacFinder dacFinder, ISymbol view, INamedTypeSymbol viewType)
+		public override sealed bool SatisfyRule(PrimaryDacFinder dacFinder, ISymbol view, INamedTypeSymbol viewType)
 		{
-			if (view == null)
-				return false;
+			dacFinder.CancellationToken.ThrowIfCancellationRequested();
 
-			string viewName = _useCaseSensitiveComparison
-				? view.Name
-				: view.Name.ToUpper();
-
-			return _forbiddenWords.Any(word => viewName.Contains(word));
+			return _forbiddenWords.Any(word => view.Name.Contains(word, _stringComparisonKind));
 		}
 
-		private ImmutableArray<string> GetDefaultForbiddenWords() =>
-			ImmutableArray.Create("dummy");
+		private List<string> GetDefaultForbiddenWords() => ["dummy"];
 	}
 }

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/PrimaryDacFinder/PrimaryDacRules/ViewRules/NoPXSetupViewRule.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/PrimaryDacFinder/PrimaryDacRules/ViewRules/NoPXSetupViewRule.cs
@@ -1,42 +1,25 @@
-﻿using System.Collections.Immutable;
-using System.Linq;
-using Acuminator.Utilities.Common;
+﻿#nullable enable
+
 using Acuminator.Utilities.Roslyn.PrimaryDacFinder.PrimaryDacRules.Base;
-using Acuminator.Utilities.Roslyn.Semantic;
-using Microsoft.CodeAnalysis;
+using Acuminator.Utilities.Roslyn.Semantic.PXGraph;
 
 namespace Acuminator.Utilities.Roslyn.PrimaryDacFinder.PrimaryDacRules.ViewRules
 {
 	/// <summary>
-	/// A rule to filter out views which are PXSetup.
+	/// A rule to filter out views which are PXSetup views.
 	/// </summary>
-	public class NoPXSetupViewRule : ViewRuleBase
+	public class NoPXSetupViewRule(double? weight = null) : ViewRuleBase(weight)
 	{
-		public sealed override bool IsAbsolute => false;
+		public override sealed bool IsAbsolute => false;
 
-		private readonly ImmutableArray<INamedTypeSymbol> _setupTypes;
-
-		public NoPXSetupViewRule(PXContext context, double? weight = null) : base(weight)
-		{
-			context.ThrowOnNull(nameof(context));
-
-			_setupTypes = context.BQL.PXSetupTypes;
-		}
-		
 		/// <summary>
-		/// Query if view type is PXSetup-like. 
+		/// Query if view type is PXSetup view. 
 		/// </summary>
 		/// <param name="dacFinder">The DAC finder.</param>
 		/// <param name="view">The view.</param>
 		/// <param name="viewType">Type of the view.</param>
 		/// <returns/>
-		public sealed override bool SatisfyRule(PrimaryDacFinder dacFinder, ISymbol view, INamedTypeSymbol viewType)
-		{
-			if (dacFinder == null || viewType == null || dacFinder.CancellationToken.IsCancellationRequested)
-				return false;
-
-			return viewType.GetBaseTypesAndThis()
-						   .Any(type => _setupTypes.Contains(type));
-		}
+		public override sealed bool SatisfyRule(PrimaryDacFinder dacFinder, DataViewInfo viewInfo) =>
+			viewInfo.IsSetup;
 	}
 }

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/PrimaryDacFinder/Score.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/PrimaryDacFinder/Score.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#nullable enable
+
+using System;
 
 namespace Acuminator.Utilities.Roslyn.PrimaryDacFinder
 {
@@ -15,32 +17,17 @@ namespace Acuminator.Utilities.Roslyn.PrimaryDacFinder
 			Value = value;
 		}
 
-		public int CompareTo(Score other)
-		{
-			if (other == null)
-				return 1;
-			else if (Value == other.Value)
-				return 0;
-			else if (Value > other.Value)
-				return 1;
-			else
-				return -1;
-		}
-
-		public bool Equals(Score other)
-		{
-			if (other == null)
-				return false;
-			else if (ReferenceEquals(this, other))
-				return true;
-			else
-				return Value == other.Value;
-		}
+		public int CompareTo(Score? other) =>
+			other != null
+				? Value.CompareTo(other.Value)
+				: 1;
 
 		public override bool Equals(object obj) => Equals(obj as Score);
-		
+
+		public bool Equals(Score? other) => ReferenceEquals(this, other) || Value == other?.Value;
+
 		public override int GetHashCode() => Value.GetHashCode();
 
-		public override string ToString() => Value.ToString();	
+		public override string ToString() => Value.ToString();
 	}
 }

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/ProjectSystem/WorkspaceUtils.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/ProjectSystem/WorkspaceUtils.cs
@@ -30,11 +30,11 @@ namespace Acuminator.Utilities.Roslyn.ProjectSystem
 
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static IEnumerable<TextDocument> GetAllAdditionalDocuments(this Solution solution) =>
-			solution.CheckIfNull(nameof(solution)).Projects.SelectMany(p => p.AdditionalDocuments);
+			solution.CheckIfNull().Projects.SelectMany(p => p.AdditionalDocuments);
 
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static IEnumerable<TextDocument> GetSuppressionFiles(this Project project) =>
-			project.CheckIfNull(nameof(project)).AdditionalDocuments
+			project.CheckIfNull().AdditionalDocuments
 												.Where(additionalDoc => SuppressionFile.IsSuppressionFile(additionalDoc.FilePath));
 
 		/// <summary>
@@ -45,12 +45,12 @@ namespace Acuminator.Utilities.Roslyn.ProjectSystem
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static int GetWorkspaceIndentationSize(this Workspace workspace)
 		{
-			workspace.ThrowOnNull(nameof(workspace));
+			workspace.ThrowOnNull();
 			return workspace.Options.GetOption(FormattingOptions.IndentationSize, LanguageNames.CSharp);
 		}		
 
 		public static bool IsActiveDocumentCleared(this WorkspaceChangeEventArgs changeEventArgs, Document? oldDocument) =>
-			changeEventArgs.CheckIfNull(nameof(changeEventArgs)).Kind switch
+			changeEventArgs.CheckIfNull().Kind switch
 			{
 				var kind when kind == WorkspaceChangeKind.SolutionRemoved ||
 							  kind == WorkspaceChangeKind.SolutionCleared ||
@@ -66,7 +66,7 @@ namespace Acuminator.Utilities.Roslyn.ProjectSystem
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static bool IsActiveDocumentChanged(this WorkspaceChangeEventArgs changeEventArgs, Document? oldDocument)
 		{
-			changeEventArgs.ThrowOnNull(nameof(changeEventArgs));
+			changeEventArgs.ThrowOnNull();
 
 			if (changeEventArgs.Kind != WorkspaceChangeKind.DocumentChanged)
 				return false;
@@ -77,7 +77,7 @@ namespace Acuminator.Utilities.Roslyn.ProjectSystem
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static bool IsDocumentTextChanged(this WorkspaceChangeEventArgs changeEventArgs, Document? oldDocument)
 		{
-			changeEventArgs.ThrowOnNull(nameof(changeEventArgs));
+			changeEventArgs.ThrowOnNull();
 
 			if (changeEventArgs.Kind != WorkspaceChangeKind.DocumentChanged &&
 				changeEventArgs.Kind != WorkspaceChangeKind.DocumentReloaded)
@@ -92,11 +92,11 @@ namespace Acuminator.Utilities.Roslyn.ProjectSystem
 			oldDocument?.Id != changeEventArgs.DocumentId || oldDocument?.Project.Id != changeEventArgs.ProjectId;
 
 		public static bool IsFullyLoadedProject(this Project project) =>
-			project.CheckIfNull(nameof(project)).FilePath.NullIfWhiteSpace() != null;
+			project.CheckIfNull().FilePath.NullIfWhiteSpace() != null;
 
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static bool IsProjectStatusInSolutionChanged(this WorkspaceChangeEventArgs changeEventArgs) =>
-			changeEventArgs.CheckIfNull(nameof(changeEventArgs)).Kind switch
+			changeEventArgs.CheckIfNull().Kind switch
 			{
 				WorkspaceChangeKind.ProjectAdded => true,
 				WorkspaceChangeKind.ProjectRemoved => true,
@@ -106,7 +106,7 @@ namespace Acuminator.Utilities.Roslyn.ProjectSystem
 
 		public static bool IsProjectMetadataChanged(this WorkspaceChangeEventArgs changeEventArgs)
 		{
-			changeEventArgs.ThrowOnNull(nameof(changeEventArgs));
+			changeEventArgs.ThrowOnNull();
 
 			if ((changeEventArgs.Kind != WorkspaceChangeKind.ProjectChanged && 
 				changeEventArgs.Kind != WorkspaceChangeKind.ProjectReloaded) || 

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/ArgumentsToParametersMapping/ArgumentsToParametersMapper.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/ArgumentsToParametersMapping/ArgumentsToParametersMapper.cs
@@ -27,8 +27,8 @@ namespace Acuminator.Utilities.Roslyn.Semantic.ArgumentsToParametersMapping
 		/// </returns>
 		public static ArgumentsToParametersMapping? MapArgumentsToParameters(this IMethodSymbol method, BaseArgumentListSyntax argumentsList)
 		{
-			method.ThrowOnNull(nameof(method));
-			argumentsList.ThrowOnNull(nameof(argumentsList));
+			method.ThrowOnNull();
+			argumentsList.ThrowOnNull();
 			
 			// Need to also filter out unsafe methods here but there is no flag on IMethodSymbol to do this
 			// And obtaining syntax node and checking modifiers will be expensive considering that unsafe code is not used in Acumatica

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/ArgumentsToParametersMapping/ArgumentsToParametersMapping.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/ArgumentsToParametersMapping/ArgumentsToParametersMapping.cs
@@ -53,13 +53,13 @@ namespace Acuminator.Utilities.Roslyn.Semantic.ArgumentsToParametersMapping
 
 		public ArgumentsToParametersMapping(int[] parametersMapping)
 		{
-			_parametersMapping = parametersMapping.CheckIfNull(nameof(parametersMapping));
+			_parametersMapping = parametersMapping.CheckIfNull();
 			_length = parametersMapping.Length;
 		}
 
 		public IParameterSymbol GetMappedParameter(IMethodSymbol methodSymbol, int argIndex)
 		{
-			methodSymbol.ThrowOnNull(nameof(methodSymbol));
+			methodSymbol.ThrowOnNull();
 			int parameterIndex = GetMappedParameterPosition(argIndex);
 			return methodSymbol.Parameters[parameterIndex];
 		}

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/CodeResolvingUtils.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/CodeResolvingUtils.cs
@@ -23,15 +23,15 @@ namespace Acuminator.Utilities.Roslyn.Semantic
 		/// </returns>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static bool IsAccessibleOutsideOfAssembly(this ISymbol symbol) =>
-			symbol.CheckIfNull(nameof(symbol)).DeclaredAccessibility switch
+			symbol.CheckIfNull().DeclaredAccessibility switch
 			{
-				Accessibility.Private => false,
-				Accessibility.Internal => false,
+				Accessibility.Private 			   => false,
+				Accessibility.Internal 			   => false,
 				Accessibility.ProtectedAndInternal => false,
-				Accessibility.Protected => true,
-				Accessibility.ProtectedOrInternal => true,
-				Accessibility.Public => true,
-				_ => true,
+				Accessibility.Protected 		   => true,
+				Accessibility.ProtectedOrInternal  => true,
+				Accessibility.Public 			   => true,
+				_ 								   => true,
 			};
 
 		/// <summary>
@@ -275,8 +275,8 @@ namespace Acuminator.Utilities.Roslyn.Semantic
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool IsPXGraph(this ITypeSymbol typeSymbol, PXContext pxContext)
         {
-            typeSymbol.ThrowOnNull(nameof(typeSymbol));
-            pxContext.ThrowOnNull(nameof(pxContext));
+            typeSymbol.ThrowOnNull();
+            pxContext.ThrowOnNull();
 
 			if (typeSymbol is ITypeParameterSymbol typeParameterSymbol)
 			{
@@ -292,8 +292,8 @@ namespace Acuminator.Utilities.Roslyn.Semantic
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static bool IsPXGraphExtension(this ITypeSymbol typeSymbol, PXContext pxContext)
         {
-            typeSymbol.ThrowOnNull(nameof(typeSymbol));
-            pxContext.ThrowOnNull(nameof(pxContext));
+            typeSymbol.ThrowOnNull();
+            pxContext.ThrowOnNull();
 
             return typeSymbol.InheritsFromOrEquals(pxContext.PXGraphExtension.Type);
         }
@@ -317,8 +317,8 @@ namespace Acuminator.Utilities.Roslyn.Semantic
 
 		public static bool IsCustomBqlCommand(this ITypeSymbol bqlTypeSymbol, PXContext context)
 		{
-			bqlTypeSymbol.ThrowOnNull(nameof(bqlTypeSymbol));
-			context.ThrowOnNull(nameof(context));
+			bqlTypeSymbol.ThrowOnNull();
+			context.ThrowOnNull();
 
 			int pxSelectBaseStandartDepth = context.IsAcumatica2018R2_OrGreater ? 3 : 2;
 			int? pxSelectBaseDepth = bqlTypeSymbol.GetInheritanceDepth(context.PXSelectBase.Type);
@@ -333,7 +333,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic
 
 		public static bool IsPXSelectReadOnlyCommand(this ITypeSymbol bqlTypeSymbol)
 		{
-			bqlTypeSymbol.ThrowOnNull(nameof(bqlTypeSymbol));
+			bqlTypeSymbol.ThrowOnNull();
 
 			if (!bqlTypeSymbol.IsBqlCommand())
 				return false;
@@ -354,8 +354,8 @@ namespace Acuminator.Utilities.Roslyn.Semantic
 
 		public static bool IsPXNonUpdateableBqlCommand(this ITypeSymbol bqlTypeSymbol, PXContext context)
 		{
-			bqlTypeSymbol.ThrowOnNull(nameof(bqlTypeSymbol));
-			context.ThrowOnNull(nameof(context));
+			bqlTypeSymbol.ThrowOnNull();
+			context.ThrowOnNull();
 
 			if (!bqlTypeSymbol.IsBqlCommand(context))
 				return false;
@@ -365,8 +365,8 @@ namespace Acuminator.Utilities.Roslyn.Semantic
 
 		public static bool IsPXSetupBqlCommand(this ITypeSymbol bqlTypeSymbol, PXContext context)
 		{
-			bqlTypeSymbol.ThrowOnNull(nameof(bqlTypeSymbol));
-			context.ThrowOnNull(nameof(context));
+			bqlTypeSymbol.ThrowOnNull();
+			context.ThrowOnNull();
 
 			ImmutableArray<INamedTypeSymbol> setupTypes = context.BQL.PXSetupTypes;
 			return bqlTypeSymbol.GetBaseTypesAndThis()

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/IMethodSymbolExtensions.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/IMethodSymbolExtensions.cs
@@ -19,7 +19,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic
 	{
 		public static bool IsInstanceConstructor(this IMethodSymbol methodSymbol)
 		{
-			methodSymbol.ThrowOnNull(nameof (methodSymbol));
+			methodSymbol.ThrowOnNull();
 
 			return !methodSymbol.IsStatic && methodSymbol.MethodKind == MethodKind.Constructor;
 		}
@@ -48,7 +48,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic
 		private static IMethodSymbol? GetStaticOrNonLocalContainingMethod(IMethodSymbol localFunction, bool stopOnStaticMethod,
 																		  CancellationToken cancellation)
 		{
-			localFunction.ThrowOnNull(nameof(localFunction));
+			localFunction.ThrowOnNull();
 
 			if (localFunction.MethodKind != MethodKind.LocalFunction)
 				return localFunction;
@@ -62,12 +62,12 @@ namespace Acuminator.Utilities.Roslyn.Semantic
 		}
 
 		public static IEnumerable<IMethodSymbol> GetContainingMethodsAndThis(this IMethodSymbol localFunction) =>
-			localFunction.CheckIfNull(nameof(localFunction)).MethodKind == MethodKind.LocalFunction
+			localFunction.CheckIfNull().MethodKind == MethodKind.LocalFunction
 				? localFunction.GetContainingMethods(includeThis: true)
 				: new[] { localFunction };
 
 		public static IEnumerable<IMethodSymbol> GetContainingMethods(this IMethodSymbol localFunction) =>
-			localFunction.CheckIfNull(nameof(localFunction)).MethodKind == MethodKind.LocalFunction
+			localFunction.CheckIfNull().MethodKind == MethodKind.LocalFunction
 				? localFunction.GetContainingMethods(includeThis: false)
 				: Enumerable.Empty<IMethodSymbol>();
 
@@ -95,7 +95,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic
 		public static ImmutableArray<IParameterSymbol> GetAllParametersAvailableForLocalFunction(this IMethodSymbol localFunction, bool includeOwnParameters,
 																								 CancellationToken cancellation)
 		{
-			if (localFunction.CheckIfNull(nameof(localFunction)).MethodKind != MethodKind.LocalFunction)
+			if (localFunction.CheckIfNull().MethodKind != MethodKind.LocalFunction)
 				return localFunction.Parameters;
 
 			ImmutableArray<IParameterSymbol>.Builder parametersBuilder;
@@ -149,7 +149,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic
 		/// </returns>
 		public static bool IsNonLocalMethodParameterRedefined(this IMethodSymbol localMethod, string parameterName, CancellationToken cancellation)
 		{
-			localMethod.ThrowOnNull(nameof(localMethod));
+			localMethod.ThrowOnNull();
 
 			if (parameterName.IsNullOrWhiteSpace() || localMethod.MethodKind != MethodKind.LocalFunction)
 				return false;
@@ -206,8 +206,8 @@ namespace Acuminator.Utilities.Roslyn.Semantic
 		/// </returns>
 		public static bool IsDefinitelyStatic(this IMethodSymbol method, SyntaxNode methodDeclaration)
 		{
-			method.ThrowOnNull(nameof(method));
-			methodDeclaration.ThrowOnNull(nameof(methodDeclaration));
+			method.ThrowOnNull();
+			methodDeclaration.ThrowOnNull();
 
 			if (method.MethodKind != MethodKind.LocalFunction)
 				return method.IsStatic;
@@ -222,7 +222,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic
 		/// <returns>True if <paramref name="method"/> </returns>
 		public static bool CanBeOverriden(this IMethodSymbol method)
 		{
-			method.ThrowOnNull(nameof(method));
+			method.ThrowOnNull();
 
 			return method.IsVirtual || method.IsOverride || method.IsAbstract;
 		}

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/ISymbolGenericUtils.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/ISymbolGenericUtils.cs
@@ -19,17 +19,17 @@ namespace Acuminator.Utilities.Roslyn.Semantic
 	public static class ISymbolGenericUtils
 	{
 		public static bool IsReadOnly(this ISymbol symbol) =>
-			symbol.CheckIfNull(nameof(symbol)) switch
+			symbol.CheckIfNull() switch
 			{
-				IFieldSymbol field       => field.IsReadOnly,
-				IPropertySymbol property => property.IsReadOnly, 
-				ITypeSymbol type         => type.IsReadOnly(),
-				_                        => false
+				IFieldSymbol field 		 => field.IsReadOnly,
+				IPropertySymbol property => property.IsReadOnly,
+				ITypeSymbol type 		 => type.IsReadOnly(),
+				_ 						 => false
 			};
 
 		public static bool IsReadOnly(this ITypeSymbol typeSymbol)
 		{
-			typeSymbol.ThrowOnNull(nameof(typeSymbol));
+			typeSymbol.ThrowOnNull();
 
 			var readonlyProperty = typeSymbol.GetType().GetProperty("IsReadOnly");
 
@@ -57,11 +57,11 @@ namespace Acuminator.Utilities.Roslyn.Semantic
 		/// </returns>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static bool IsExplicitlyDeclared(this ISymbol symbol) =>
-			!symbol.CheckIfNull(nameof(symbol)).IsImplicitlyDeclared && symbol.CanBeReferencedByName;
+			!symbol.CheckIfNull().IsImplicitlyDeclared && symbol.CanBeReferencedByName;
 
 		public static bool IsDeclaredInType(this ISymbol symbol, ITypeSymbol? type)
 		{
-			symbol.ThrowOnNull(nameof(symbol));
+			symbol.ThrowOnNull();
 		
 			if (type == null || symbol.ContainingType == null)
 				return false;
@@ -83,8 +83,8 @@ namespace Acuminator.Utilities.Roslyn.Semantic
 												 bool checkForDerivedAttributes = true)
 		where TSymbol : class, ISymbol
 		{
-			symbol.ThrowOnNull(nameof(symbol));
-			attributeType.ThrowOnNull(nameof(attributeType));
+			symbol.ThrowOnNull();
+			attributeType.ThrowOnNull();
 
 			Func<TSymbol, bool> attributeCheck = checkForDerivedAttributes
 				? HasDerivedAttribute
@@ -129,10 +129,10 @@ namespace Acuminator.Utilities.Roslyn.Semantic
 		public static IEnumerable<TSymbol> GetOverriddenAndThis<TSymbol>(this TSymbol symbol)
 		where TSymbol : class, ISymbol
 		{
-			if (symbol.CheckIfNull(nameof(symbol)).IsOverride)
+			if (symbol.CheckIfNull().IsOverride)
 				return GetOverriddenImpl(symbol, includeThis: true);
 			else
-				return new[] { symbol };
+				return [symbol];
 		}
 
 		/// <summary>
@@ -145,10 +145,10 @@ namespace Acuminator.Utilities.Roslyn.Semantic
 		public static IEnumerable<TSymbol> GetOverridden<TSymbol>(this TSymbol symbol)
 		where TSymbol : class, ISymbol
 		{
-			if (symbol.CheckIfNull(nameof(symbol)).IsOverride)
+			if (symbol.CheckIfNull().IsOverride)
 				return GetOverriddenImpl(symbol, includeThis: false);
 			else
-				return Enumerable.Empty<TSymbol>();
+				return [];
 		}
 
 		private static IEnumerable<TSymbol> GetOverriddenImpl<TSymbol>(TSymbol symbol, bool includeThis)

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/ITypeSymbolExtensions.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/ITypeSymbolExtensions.cs
@@ -42,7 +42,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic
 
 		private static IEnumerable<ITypeSymbol> GetBaseTypesImplementation(this ITypeSymbol type, bool includeThis)
 		{
-			type.ThrowOnNull(nameof(type));
+			type.ThrowOnNull();
 
 			if (type is ITypeParameterSymbol typeParameter)
 			{
@@ -71,7 +71,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic
 
 		public static IEnumerable<INamedTypeSymbol> GetFlattenedNestedTypes(this ITypeSymbol type, CancellationToken cancellationToken)
 		{
-			type.ThrowOnNull(nameof(type));
+			type.ThrowOnNull();
 			cancellationToken.ThrowIfCancellationRequested();
 			return type.GetFlattenedNestedTypesImplementation(shouldWalkThroughNestedTypesPredicate: null, cancellationToken);			
 		}
@@ -79,9 +79,9 @@ namespace Acuminator.Utilities.Roslyn.Semantic
 		public static IEnumerable<INamedTypeSymbol> GetFlattenedNestedTypes(this ITypeSymbol type, Func<ITypeSymbol, bool>? shouldWalkThroughNestedTypesPredicate, 
 																			CancellationToken cancellationToken)
 		{
-			type.ThrowOnNull(nameof(type));
+			type.ThrowOnNull();
 			cancellationToken.ThrowIfCancellationRequested();
-			shouldWalkThroughNestedTypesPredicate.ThrowOnNull(nameof(shouldWalkThroughNestedTypesPredicate));
+			shouldWalkThroughNestedTypesPredicate.ThrowOnNull();
 
 			return type.GetFlattenedNestedTypesImplementation(shouldWalkThroughNestedTypesPredicate, cancellationToken);
 		}
@@ -144,7 +144,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic
 
 		public static INamedTypeSymbol? TopMostContainingType(this ITypeSymbol type)
 		{
-			INamedTypeSymbol current = type.CheckIfNull(nameof(type)).ContainingType;
+			INamedTypeSymbol current = type.CheckIfNull().ContainingType;
 
 			while (current != null)
 			{
@@ -187,8 +187,8 @@ namespace Acuminator.Utilities.Roslyn.Semantic
 		/// <returns/>
 		public static bool InheritsFromOrEquals(this ITypeSymbol type, ITypeSymbol baseType, bool includeInterfaces)
 		{
-			type.ThrowOnNull(nameof(type));
-			baseType.ThrowOnNull(nameof(baseType));
+			type.ThrowOnNull();
+			baseType.ThrowOnNull();
 
 			var typeList = type.GetBaseTypesAndThis();
 
@@ -206,8 +206,8 @@ namespace Acuminator.Utilities.Roslyn.Semantic
 
 		public static bool InheritsFromOrEqualsGeneric(this ITypeSymbol type, ITypeSymbol baseType, bool includeInterfaces)
 		{
-			type.ThrowOnNull(nameof(type));
-			baseType.ThrowOnNull(nameof(baseType));
+			type.ThrowOnNull();
+			baseType.ThrowOnNull();
 
 			var typeList = type.GetBaseTypesAndThis();
 
@@ -220,8 +220,8 @@ namespace Acuminator.Utilities.Roslyn.Semantic
 
 		public static bool InheritsFrom(this ITypeSymbol type, ITypeSymbol baseType, bool includeInterfaces = false)
 		{
-			type.ThrowOnNull(nameof(type));
-			baseType.ThrowOnNull(nameof(baseType));
+			type.ThrowOnNull();
+			baseType.ThrowOnNull();
 
 			IEnumerable<ITypeSymbol> baseTypes = type.GetBaseTypes();
 
@@ -236,8 +236,8 @@ namespace Acuminator.Utilities.Roslyn.Semantic
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static bool ImplementsInterface(this ITypeSymbol type, ITypeSymbol interfaceType)
 		{
-			type.ThrowOnNull(nameof(type));
-			interfaceType.ThrowOnNull(nameof(interfaceType));
+			type.ThrowOnNull();
+			interfaceType.ThrowOnNull();
 
 			if (interfaceType.TypeKind != TypeKind.Interface)
 			{
@@ -256,8 +256,8 @@ namespace Acuminator.Utilities.Roslyn.Semantic
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static bool InheritsFrom(this ITypeSymbol symbol, string baseType)
 		{
-			symbol.ThrowOnNull(nameof(symbol));
-			baseType.ThrowOnNullOrWhiteSpace(nameof(baseType));
+			symbol.ThrowOnNull();
+			baseType.ThrowOnNullOrWhiteSpace();
 
 			return symbol.GetBaseTypesAndThis()
 						 .Any(t => t.Name == baseType);
@@ -320,7 +320,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic
 		/// <returns/>
 		public static IEnumerable<ITypeSymbol> GetAllConstraintTypes(this ITypeParameterSymbol typeParameterSymbol, bool includeInterfaces = true)
 		{
-			typeParameterSymbol.ThrowOnNull(nameof(typeParameterSymbol));
+			typeParameterSymbol.ThrowOnNull();
 			
 			var constraintTypes = includeInterfaces
 				? GetAllConstraintTypesImplementation(typeParameterSymbol)
@@ -367,8 +367,8 @@ namespace Acuminator.Utilities.Roslyn.Semantic
 		/// </returns>
 		public static int? GetInheritanceDepth(this ITypeSymbol type, ITypeSymbol baseType)
 		{
-			type.ThrowOnNull(nameof(type));
-			baseType.ThrowOnNull(nameof(type));
+			type.ThrowOnNull();
+			baseType.ThrowOnNull();
 
 			ITypeSymbol current = type;
 			int depth = 0;
@@ -390,7 +390,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static IEnumerable<AttributeData> GetAllAttributesApplicationsDefinedOnThisAndBaseTypes(this ITypeSymbol typeSymbol)
 		{
-			typeSymbol.ThrowOnNull(nameof(typeSymbol));
+			typeSymbol.ThrowOnNull();
 			return typeSymbol.GetBaseTypesAndThis()
 							 .SelectMany(t => t.GetAttributes());
 		}
@@ -410,7 +410,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static bool IsNullable(this ITypeSymbol? typeSymbol, PXContext pxContext)
 		{
-			pxContext.ThrowOnNull(nameof(pxContext));
+			pxContext.ThrowOnNull();
 			return typeSymbol?.OriginalDefinition?.Equals(pxContext.SystemTypes.Nullable) ?? false;
 		}
 
@@ -469,7 +469,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic
 		internal static IEnumerable<(ConstructorDeclarationSyntax Node, IMethodSymbol Symbol)> GetDeclaredInstanceConstructors(
 			this INamedTypeSymbol typeSymbol, CancellationToken cancellation = default)
 		{
-			typeSymbol.ThrowOnNull(nameof(typeSymbol));
+			typeSymbol.ThrowOnNull();
 
 			List<(ConstructorDeclarationSyntax, IMethodSymbol)> initializers = new List<(ConstructorDeclarationSyntax, IMethodSymbol)>();
 
@@ -496,7 +496,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic
 		public static ImmutableArray<StaticConstructorInfo> GetStaticConstructors(this INamedTypeSymbol typeSymbol,
 																				  CancellationToken cancellation = default)
 		{
-			typeSymbol.ThrowOnNull(nameof(typeSymbol));
+			typeSymbol.ThrowOnNull();
 
 			int order = 0;
 			List<StaticConstructorInfo> staticCtrs = new List<StaticConstructorInfo>();
@@ -573,7 +573,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static bool IsInAcumaticaRootNamespace(this ITypeSymbol type)
 		{
-			type.ThrowOnNull(nameof(type));
+			type.ThrowOnNull();
 
 			var typeRootNamespace = type
 				.GetContainingNamespaces()
@@ -591,7 +591,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic
 		/// <returns/>
 		public static string GetSimplifiedName(this ITypeSymbol type)
 		{
-			type.ThrowOnNull(nameof(type));
+			type.ThrowOnNull();
 
 			switch (type.SpecialType)
 			{

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/PXContext.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/PXContext.cs
@@ -131,7 +131,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic
 
 		public PXContext(Compilation compilation, CodeAnalysisSettings? codeAnalysisSettings)
 		{
-			compilation.ThrowOnNull(nameof(compilation));
+			compilation.ThrowOnNull();
 
 			CodeAnalysisSettings = codeAnalysisSettings ?? CodeAnalysisSettings.Default;
 			Compilation = compilation;

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/Attribute/AttributeInfo.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/Attribute/AttributeInfo.cs
@@ -62,7 +62,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic.Attribute
 		protected AttributeInfo(AttributeData attributeData, IEnumerable<AttributeWithApplication> flattenedAttributeApplications, IEnumerable<DataTypeAttributeInfo> attributeInfos,
 								DbBoundnessType dbBoundness, int declarationOrder, bool isKey, bool isIdentity, bool isDefaultAttribute, bool isAutoNumberAttribute)
 		{
-			AttributeData                = attributeData.CheckIfNull(nameof(attributeData));
+			AttributeData                = attributeData.CheckIfNull();
 			FlattenedAcumaticaAttributes = (flattenedAttributeApplications as ImmutableHashSet<AttributeWithApplication>) ?? flattenedAttributeApplications.ToImmutableHashSet();
 			AggregatedAttributeMetadata  = attributeInfos.ToImmutableArray();
 			DbBoundness                  = dbBoundness;
@@ -75,8 +75,8 @@ namespace Acuminator.Utilities.Roslyn.Semantic.Attribute
 
 		public static AttributeInfo Create(AttributeData attribute, DbBoundnessCalculator dbBoundnessCalculator, int declarationOrder)
 		{
-			attribute.ThrowOnNull(nameof(attribute));
-			dbBoundnessCalculator.ThrowOnNull(nameof(dbBoundnessCalculator));
+			attribute.ThrowOnNull();
+			dbBoundnessCalculator.ThrowOnNull();
 
 			var flattenedAttributeApplications = attribute.GetThisAndAllAggregatedAttributesWithApplications(dbBoundnessCalculator.Context, includeBaseTypes: true);
 			var flattenedAttributeTypes = flattenedAttributeApplications.Select(attributeWithApplication => attributeWithApplication.Type).ToImmutableHashSet();

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/Base/NodeSymbolItem.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/Base/NodeSymbolItem.cs
@@ -22,7 +22,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic
 		public NodeSymbolItem(N node, S symbol, int declarationOrder)
 			: base(symbol, declarationOrder)
 		{
-			Node = node.CheckIfNull(nameof(node));
+			Node = node.CheckIfNull();
 		}
 	}
 }

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/Base/OverridableItemUtils.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/Base/OverridableItemUtils.cs
@@ -12,14 +12,14 @@ namespace Acuminator.Utilities.Roslyn.Semantic
 		public static IEnumerable<TInfo> ThisAndOverridenItems<TInfo>(this TInfo info)
 		where TInfo : IOverridableItem<TInfo>
 		{
-			info.ThrowOnNull(nameof(info));
+			info.ThrowOnNull();
 			return GetOverridenItems(info, includeOriginalItem: true);
 		}
 
 		public static IEnumerable<TInfo> JustOverridenItems<TInfo>(this TInfo info)
 		where TInfo : IOverridableItem<TInfo>
 		{
-			info.ThrowOnNull(nameof(info));
+			info.ThrowOnNull();
 			return GetOverridenItems(info, includeOriginalItem: false);
 		}
 

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/Base/OverridableItemsCollection.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/Base/OverridableItemsCollection.cs
@@ -30,7 +30,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic
 																					Func<TRawData, int, TWriteableInfo> infoConstructor)
 		where TWriteableInfo : TInfo, IWriteableBaseItem<TInfo>
 		{
-			itemsToAdd.ThrowOnNull(nameof(itemsToAdd));
+			itemsToAdd.ThrowOnNull();
 
 			int order = startingOrder;
 
@@ -46,7 +46,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic
 		internal virtual void Add<TRawData, TWriteableInfo>(TRawData rawData, int declarationOrder, Func<TRawData, int, TWriteableInfo> infoConstructor)
 		where TWriteableInfo : TInfo, IWriteableBaseItem<TInfo>
 		{
-			infoConstructor.ThrowOnNull(nameof(infoConstructor));
+			infoConstructor.ThrowOnNull();
 			TWriteableInfo info = infoConstructor(rawData, declarationOrder);
 			Add(info);
 		}

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/Base/SymbolItem.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/Base/SymbolItem.cs
@@ -26,8 +26,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic
 
 		public SymbolItem(ISymbol symbol, int declarationOrder)
 		{
-			symbol.ThrowOnNull(nameof(symbol));
-			SymbolBase = symbol;
+			SymbolBase = symbol.CheckIfNull();
 			DeclarationOrder = declarationOrder;
 		}
 

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/Dac/DacSemanticModel.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/Dac/DacSemanticModel.cs
@@ -85,8 +85,8 @@ namespace Acuminator.Utilities.Roslyn.Semantic.Dac
 		/// <returns/>
 		public static DacSemanticModel InferModel(PXContext pxContext, INamedTypeSymbol typeSymbol, CancellationToken cancellation = default)
 		{		
-			pxContext.ThrowOnNull(nameof(pxContext));
-			typeSymbol.ThrowOnNull(nameof(typeSymbol));
+			pxContext.ThrowOnNull();
+			typeSymbol.ThrowOnNull();
 			cancellation.ThrowIfCancellationRequested();
 
 			DacType? dacType = typeSymbol.IsDAC(pxContext)

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/Dac/Infos/DacFieldInfo.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/Dac/Infos/DacFieldInfo.cs
@@ -1,7 +1,9 @@
-﻿using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Acuminator.Utilities.Common;
+﻿#nullable enable
 
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+using Acuminator.Utilities.Common;
 
 namespace Acuminator.Utilities.Roslyn.Semantic.Dac
 {
@@ -10,13 +12,13 @@ namespace Acuminator.Utilities.Roslyn.Semantic.Dac
 		/// <summary>
 		/// The overriden dac field if any
 		/// </summary>
-		public DacFieldInfo Base
+		public DacFieldInfo? Base
 		{
 			get;
 			internal set;
 		}
 	
-		DacFieldInfo IWriteableBaseItem<DacFieldInfo>.Base
+		DacFieldInfo? IWriteableBaseItem<DacFieldInfo>.Base
 		{
 			get => Base;
 			set => Base = value;
@@ -30,7 +32,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic.Dac
 		public DacFieldInfo(ClassDeclarationSyntax node, INamedTypeSymbol symbol, int declarationOrder, DacFieldInfo baseInfo) :
 					   this(node, symbol, declarationOrder)
 		{
-			baseInfo.ThrowOnNull(nameof(baseInfo));
+			baseInfo.ThrowOnNull();
 			Base = baseInfo;
 		}
 	}

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/Dac/Infos/DacPropertyInfo.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/Dac/Infos/DacPropertyInfo.cs
@@ -82,7 +82,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic.Dac
 								  int declarationOrder, bool isDacProperty, IEnumerable<AttributeInfo> attributeInfos, DacPropertyInfo baseInfo) :
 							 this(node, symbol, effectivePropertyType, declarationOrder, isDacProperty, attributeInfos)
 		{
-			Base = baseInfo.CheckIfNull(nameof(baseInfo));
+			Base = baseInfo.CheckIfNull();
 
 			// TODO - need to add support for PXMergeAttributesAttribute in the future
 			EffectiveDbBoundness = DeclaredDbBoundness.Combine(baseInfo.EffectiveDbBoundness);
@@ -119,10 +119,10 @@ namespace Acuminator.Utilities.Roslyn.Semantic.Dac
 											 DbBoundnessCalculator dbBoundnessCalculator, IDictionary<string, DacFieldInfo> dacFields,
 											 DacPropertyInfo? baseInfo = null)
 		{
-			context.ThrowOnNull(nameof(context));
-			property.ThrowOnNull(nameof(property));
-			dbBoundnessCalculator.ThrowOnNull(nameof(dbBoundnessCalculator));
-			dacFields.ThrowOnNull(nameof(dacFields));
+			context.ThrowOnNull();
+			property.ThrowOnNull();
+			dbBoundnessCalculator.ThrowOnNull();
+			dacFields.ThrowOnNull();
 
 			bool isDacProperty = dacFields.ContainsKey(property.Name);
 			var attributeInfos = GetAttributeInfos(property, dbBoundnessCalculator);

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/Dac/Utils/DacFieldSymbolUtils.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/Dac/Utils/DacFieldSymbolUtils.cs
@@ -26,8 +26,8 @@ namespace Acuminator.Utilities.Roslyn.Semantic.Dac
 		/// </returns>
 		public static INamedTypeSymbol? GetCorrespondingBqlField(this IPropertySymbol property, PXContext pxContext, bool checkContainingTypeIsDac)
 		{
-			property.ThrowOnNull(nameof(property));
-			pxContext.ThrowOnNull(nameof(pxContext));
+			property.ThrowOnNull();
+			pxContext.ThrowOnNull();
 
 			var containingDacOrDacExt = property.ContainingType;
 
@@ -82,8 +82,8 @@ namespace Acuminator.Utilities.Roslyn.Semantic.Dac
 																				   bool includeFromInheritanceChain = true,
 																				   CancellationToken cancellation = default)
 		{
-			dac.ThrowOnNull(nameof(dac));
-			pxContext.ThrowOnNull(nameof(pxContext));
+			dac.ThrowOnNull();
+			pxContext.ThrowOnNull();
 
 			if (!dac.IsDAC(pxContext))
 				return new OverridableItemsCollection<DacFieldInfo>();
@@ -109,8 +109,8 @@ namespace Acuminator.Utilities.Roslyn.Semantic.Dac
 		public static OverridableItemsCollection<DacFieldInfo> GetDacFieldsFromDacExtensionAndBaseDac(this ITypeSymbol dacExtension, PXContext pxContext,
 																									  CancellationToken cancellation = default)
 		{
-			dacExtension.ThrowOnNull(nameof(dacExtension));
-			pxContext.ThrowOnNull(nameof(pxContext));
+			dacExtension.ThrowOnNull();
+			pxContext.ThrowOnNull();
 
 			return GetPropertiesOrFieldsInfoFromDacExtension<DacFieldInfo>(dacExtension, pxContext, AddFieldsFromDac, AddFieldsFromDacExtension);
 

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/Dac/Utils/DacPropertySymbolUtils.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/Dac/Utils/DacPropertySymbolUtils.cs
@@ -46,8 +46,8 @@ namespace Acuminator.Utilities.Roslyn.Semantic.Dac
 																						  bool includeFromInheritanceChain = true,																					  
 																						  CancellationToken cancellation = default)
 		{
-			pxContext.ThrowOnNull(nameof(pxContext));
-			dacFields.ThrowOnNull(nameof(dacFields));
+			pxContext.ThrowOnNull();
+			dacFields.ThrowOnNull();
 
 			if (!dac.IsDAC(pxContext))
 				return new OverridableItemsCollection<DacPropertyInfo>();
@@ -77,7 +77,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic.Dac
 																											   IDictionary<string, DacFieldInfo> dacFields,
 																											   CancellationToken cancellation = default)
 		{
-			pxContext.ThrowOnNull(nameof(pxContext));
+			pxContext.ThrowOnNull();
 
 			bool isDac = dacOrExtension.IsDAC(pxContext);
 
@@ -103,8 +103,8 @@ namespace Acuminator.Utilities.Roslyn.Semantic.Dac
 																										  IDictionary<string, DacFieldInfo> dacFields,
 																										  CancellationToken cancellation = default)
 		{
-			dacExtension.ThrowOnNull(nameof(dacExtension));
-			pxContext.ThrowOnNull(nameof(pxContext));
+			dacExtension.ThrowOnNull();
+			pxContext.ThrowOnNull();
 
 			var dbBoundnessCalculator = new DbBoundnessCalculator(pxContext);
 			return GetPropertiesOrFieldsInfoFromDacExtension<DacPropertyInfo>(dacExtension, pxContext, AddPropertiesFromDac, AddPropertiesFromDacExtension);

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/Dac/Utils/DacSymbolsHierarchyUtils.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/Dac/Utils/DacSymbolsHierarchyUtils.cs
@@ -15,12 +15,12 @@ namespace Acuminator.Utilities.Roslyn.Semantic.Dac
 	{
         public static IEnumerable<ITypeSymbol> GetDacExtensionsWithDac(this ITypeSymbol dacExtension, PXContext pxContext)
         {
-            dacExtension.ThrowOnNull(nameof(dacExtension));
-            pxContext.ThrowOnNull(nameof(pxContext));
+            dacExtension.ThrowOnNull();
+            pxContext.ThrowOnNull();
 
             if (!dacExtension.IsDacExtension(pxContext))
             {
-                return Enumerable.Empty<ITypeSymbol>();
+                return [];
             }
 
             var extensionBaseType = dacExtension.BaseType;
@@ -29,7 +29,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic.Dac
 
             if (dacType == null || !dacType.IsDAC(pxContext))
             {
-                return Enumerable.Empty<ITypeSymbol>();
+                return [];
             }
 
             var types = new List<ITypeSymbol>(typeArguments.Length + 1) { dacExtension };
@@ -39,7 +39,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic.Dac
             {
                 if (!ta.IsDacExtension(pxContext))
                 {
-                    return Enumerable.Empty<ITypeSymbol>();
+                    return [];
                 }
 
                 types.Add(ta);
@@ -82,8 +82,8 @@ namespace Acuminator.Utilities.Roslyn.Semantic.Dac
 
 		private static IEnumerable<ITypeSymbol> GetDacBaseTypes(ITypeSymbol dacType, PXContext pxContext, bool includeDacType)
 		{
-			dacType.ThrowOnNull(nameof(dacType));
-			var pxBqlTable = pxContext.CheckIfNull(nameof(pxContext)).PXBqlTable;
+			dacType.ThrowOnNull();
+			var pxBqlTable = pxContext.CheckIfNull().PXBqlTable;
 
 			if (dacType.BaseType == null || dacType.BaseType.SpecialType == SpecialType.System_Object ||
 				(pxBqlTable != null && dacType.BaseType.Equals(pxBqlTable)))
@@ -135,8 +135,8 @@ namespace Acuminator.Utilities.Roslyn.Semantic.Dac
 
 		private static IEnumerable<ITypeSymbol> GetDacBaseTypesThatMayStoreDacProperties(ITypeSymbol dacType, PXContext pxContext, bool includeDacType)
 		{
-			dacType.ThrowOnNull(nameof(dacType));
-			var pxBqlTable = pxContext.CheckIfNull(nameof(pxContext)).PXBqlTable;
+			dacType.ThrowOnNull();
+			var pxBqlTable = pxContext.CheckIfNull().PXBqlTable;
 
 			// Optimization for hot path - most DACs have trivial type hierarchy
 			if (dacType.BaseType == null || dacType.BaseType.SpecialType == SpecialType.System_Object ||
@@ -167,7 +167,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic.Dac
 		/// <param name="extensionType">The DAC extension type to act on.</param>
 		/// <returns/>
 		public static IEnumerable<ITypeSymbol> GetDacExtensionWithBaseTypes(this ITypeSymbol extensionType) =>
-			extensionType.CheckIfNull(nameof(extensionType))
+			extensionType.CheckIfNull()
 						 .GetBaseTypesAndThis()
 						 .TakeWhile(type => !type.IsDacExtensionBaseType());
 
@@ -190,17 +190,17 @@ namespace Acuminator.Utilities.Roslyn.Semantic.Dac
 			pxContext.ThrowOnNull(nameof(pxContext));
 
 			if (dacExtension == null || !dacExtension.IsDacExtension(pxContext))
-				return Enumerable.Empty<ITypeSymbol>();
+				return [];
 
 			var extensionBaseType = dacExtension.GetBaseTypesAndThis()
 												.FirstOrDefault(type => type.IsDacExtensionBaseType()) as INamedTypeSymbol;
 			if (extensionBaseType == null)
-				return Enumerable.Empty<ITypeSymbol>();
+				return [];
 
 			var dacType = extensionBaseType.TypeArguments.LastOrDefault();
 
 			if (dacType == null || !dacType.IsDAC(pxContext))
-				return Enumerable.Empty<ITypeSymbol>();
+				return [];
 
 			return sortDirection == SortDirection.Ascending
 				? GetExtensionInAscendingOrder(dacType, dacExtension, extensionBaseType, pxContext, includeDac)
@@ -223,7 +223,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic.Dac
 				var baseExtension = extensionBaseType.TypeArguments[i];
 
 				if (!baseExtension.IsDacExtension(pxContext))
-					return Enumerable.Empty<ITypeSymbol>();
+					return [];
 
 				extensions.Add(baseExtension);      //According to Platform team we shouldn't consider case when the extensions chaining mixes with .Net inheritance
 			}
@@ -244,7 +244,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic.Dac
 				var baseExtension = extensionBaseType.TypeArguments[i];
 
 				if (!baseExtension.IsDacExtension(pxContext))
-					return Enumerable.Empty<ITypeSymbol>();
+					return [];
 
 				extensions.Add(baseExtension);      //According to Platform team we shouldn't consider case when the extensions chaining mixes with .Net inheritance
 			}

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/Dac/Utils/DacSymbolsHierarchyUtils.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/Dac/Utils/DacSymbolsHierarchyUtils.cs
@@ -187,7 +187,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic.Dac
 		public static IEnumerable<ITypeSymbol> GetDacExtensionWithBaseExtensions(this ITypeSymbol dacExtension, PXContext pxContext,
 																				 SortDirection sortDirection, bool includeDac)
 		{
-			pxContext.ThrowOnNull(nameof(pxContext));
+			pxContext.ThrowOnNull();
 
 			if (dacExtension == null || !dacExtension.IsDacExtension(pxContext))
 				return [];

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/Dac/Utils/DacSymbolsUtils.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/Dac/Utils/DacSymbolsUtils.cs
@@ -26,7 +26,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic.Dac
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static DacType? GetDacType(this ITypeSymbol type, PXContext pxContext)
 		{
-			return type.CheckIfNull(nameof(type)).IsDAC(pxContext)
+			return type.CheckIfNull().IsDAC(pxContext)
 				? DacType.Dac
 				: type.IsDacExtension(pxContext)
 					? DacType.DacExtension
@@ -53,7 +53,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic.Dac
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static bool IsDAC(this ITypeSymbol typeSymbol, PXContext pxContext)
 		{
-			typeSymbol.ThrowOnNull(nameof(typeSymbol));
+			typeSymbol.ThrowOnNull();
 
 			if (typeSymbol.ImplementsInterface(pxContext.IBqlTableType))    //Should work for named types and type parameters in most cases
 				return true;
@@ -72,7 +72,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic.Dac
 
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static bool IsDacExtension(this ITypeSymbol typeSymbol, PXContext pxContext) => 
-			typeSymbol.CheckIfNull(nameof(typeSymbol))
+			typeSymbol.CheckIfNull()
 					  .InheritsFrom(pxContext.PXCacheExtensionType);
 
 		/// <summary>
@@ -105,7 +105,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic.Dac
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static bool IsDacField(this ITypeSymbol typeSymbol, PXContext pxContext)
 		{
-			typeSymbol.ThrowOnNull(nameof(typeSymbol));
+			typeSymbol.ThrowOnNull();
 
 			if (typeSymbol.ImplementsInterface(pxContext.IBqlFieldType))    
 				return true;
@@ -128,7 +128,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic.Dac
 		/// </returns>
 		public static ITypeSymbol? GetDacFromView(this ITypeSymbol pxView, PXContext pxContext)
 		{
-			pxContext.ThrowOnNull(nameof(pxContext));
+			pxContext.ThrowOnNull();
 
 			if (pxView?.InheritsFrom(pxContext.PXSelectBase.Type!) != true)
 				return null;
@@ -193,7 +193,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic.Dac
 		/// </returns>
 		public static ITypeSymbol? GetDacFromDacExtension(this ITypeSymbol dacExtension, PXContext pxContext)
 		{
-			pxContext.ThrowOnNull(nameof(pxContext));
+			pxContext.ThrowOnNull();
 
 			if (dacExtension == null || !dacExtension.IsDacExtension(pxContext))
 				return null;
@@ -260,8 +260,8 @@ namespace Acuminator.Utilities.Roslyn.Semantic.Dac
 		/// </returns>
 		public static AttributeData? GetProjectionAttributeApplication(this ITypeSymbol dac, PXContext pxContext, bool checkTypeIsDac)
 		{
-			pxContext.ThrowOnNull(nameof(pxContext));
-			dac.ThrowOnNull(nameof(dac));
+			pxContext.ThrowOnNull();
+			dac.ThrowOnNull();
 
 			if (checkTypeIsDac && !dac.IsDAC(pxContext))
 				return null;

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/PXGraph/Infos/ActionHandlerInfo.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/PXGraph/Infos/ActionHandlerInfo.cs
@@ -1,5 +1,9 @@
-﻿using System.Diagnostics;
+﻿#nullable enable
+
+using System.Diagnostics;
+
 using Acuminator.Utilities.Common;
+
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
@@ -13,13 +17,13 @@ namespace Acuminator.Utilities.Roslyn.Semantic.PXGraph
 		/// <summary>
 		/// The overriden handler if any
 		/// </summary>
-		public ActionHandlerInfo Base
+		public ActionHandlerInfo? Base
 		{
 			get;
 			internal set;
 		}
 
-		ActionHandlerInfo IWriteableBaseItem<ActionHandlerInfo>.Base
+		ActionHandlerInfo? IWriteableBaseItem<ActionHandlerInfo>.Base
 		{
 			get => Base;
 			set => Base = value;
@@ -34,8 +38,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic.PXGraph
 		public ActionHandlerInfo(MethodDeclarationSyntax node, IMethodSymbol symbol, int declarationOrder, ActionHandlerInfo baseInfo) :
 							this(node, symbol, declarationOrder)
 		{
-			baseInfo.ThrowOnNull(nameof(baseInfo));
-			Base = baseInfo;
+			Base = baseInfo.CheckIfNull();
 		}
 	}
 }

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/PXGraph/Infos/ActionInfo.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/PXGraph/Infos/ActionInfo.cs
@@ -1,7 +1,11 @@
-﻿using System.Diagnostics;
-using Acuminator.Utilities.Common;
-using Microsoft.CodeAnalysis;
+﻿#nullable enable
+
 using System.Collections.Immutable;
+using System.Diagnostics;
+
+using Acuminator.Utilities.Common;
+
+using Microsoft.CodeAnalysis;
 
 namespace Acuminator.Utilities.Roslyn.Semantic.PXGraph
 {
@@ -13,13 +17,13 @@ namespace Acuminator.Utilities.Roslyn.Semantic.PXGraph
 		/// <summary>
 		/// The overriden action if any
 		/// </summary>
-		public ActionInfo Base
+		public ActionInfo? Base
 		{
 			get;
 			internal set;
 		}
 
-		ActionInfo IWriteableBaseItem<ActionInfo>.Base
+		ActionInfo? IWriteableBaseItem<ActionInfo>.Base
 		{
 			get => Base;
 			set => Base = value;
@@ -42,18 +46,14 @@ namespace Acuminator.Utilities.Roslyn.Semantic.PXGraph
 		public ActionInfo(ISymbol symbol, INamedTypeSymbol type, int declarationOrder, bool isSystem) :
 					 base(symbol, declarationOrder)
 		{
-			type.ThrowOnNull(nameof(type));
-
-			Type = type;
+			Type = type.CheckIfNull();
 			IsSystem = isSystem;
 		}
 
 		public ActionInfo(ISymbol symbol, INamedTypeSymbol type, int declarationOrder, bool isSystem, ActionInfo baseInfo) :
 					 this(symbol, type, declarationOrder, isSystem)
 		{
-			baseInfo.ThrowOnNull(nameof(baseInfo));
-
-			Base = baseInfo;
+			Base = baseInfo.CheckIfNull();
 		}
 	}
 }

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/PXGraph/Infos/DataViewDelegateInfo.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/PXGraph/Infos/DataViewDelegateInfo.cs
@@ -1,6 +1,10 @@
-﻿using System;
+﻿#nullable enable
+
+using System;
 using System.Collections.Generic;
+
 using Acuminator.Utilities.Common;
+
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
@@ -11,13 +15,13 @@ namespace Acuminator.Utilities.Roslyn.Semantic.PXGraph
 		/// <summary>
 		/// The overriden item if any
 		/// </summary>
-		public DataViewDelegateInfo Base
+		public DataViewDelegateInfo? Base
 		{
 			get;
 			internal set;
 		}
 
-		DataViewDelegateInfo IWriteableBaseItem<DataViewDelegateInfo>.Base
+		DataViewDelegateInfo? IWriteableBaseItem<DataViewDelegateInfo>.Base
 		{
 			get => Base;
 			set => Base = value;
@@ -31,8 +35,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic.PXGraph
 		public DataViewDelegateInfo(MethodDeclarationSyntax node, IMethodSymbol symbol, int declarationOrder, DataViewDelegateInfo baseInfo)
 			: this(node, symbol, declarationOrder)
 		{
-			baseInfo.ThrowOnNull(nameof(baseInfo));
-			Base = baseInfo;
+			Base = baseInfo.CheckIfNull();
 		}
 
 		/// <summary>
@@ -45,7 +48,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic.PXGraph
 		{
 			const int recursionMax = 100;
 			int counter = 0;
-			DataViewDelegateInfo currentDelegate = includeSelf 
+			DataViewDelegateInfo? currentDelegate = includeSelf 
 					? this 
 					: Base;
 

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/PXGraph/Infos/DataViewInfo.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/PXGraph/Infos/DataViewInfo.cs
@@ -1,7 +1,11 @@
-﻿using Microsoft.CodeAnalysis;
+﻿#nullable enable
+
 using System.Collections.Immutable;
+
 using Acuminator.Utilities.Common;
 using Acuminator.Utilities.Roslyn.Semantic.Dac;
+
+using Microsoft.CodeAnalysis;
 
 namespace Acuminator.Utilities.Roslyn.Semantic.PXGraph
 {
@@ -42,7 +46,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic.PXGraph
 		/// </summary>
 		public INamedTypeSymbol Type { get; }
 		
-		public ITypeSymbol DAC { get; }
+		public ITypeSymbol? DAC { get; }
 
 		/// <summary>
 		/// The process delegates
@@ -67,13 +71,13 @@ namespace Acuminator.Utilities.Roslyn.Semantic.PXGraph
 		/// <summary>
 		/// The overriden item if any
 		/// </summary>
-		public DataViewInfo Base
+		public DataViewInfo? Base
 		{
 			get;
 			internal set;
 		}
 
-		DataViewInfo IWriteableBaseItem<DataViewInfo>.Base
+		DataViewInfo? IWriteableBaseItem<DataViewInfo>.Base
 		{
 			get => Base;
 			set => Base = value;
@@ -82,17 +86,16 @@ namespace Acuminator.Utilities.Roslyn.Semantic.PXGraph
 		public DataViewInfo(ISymbol symbol, INamedTypeSymbol type, PXContext pxContext, int declarationOrder)
 					 : base(symbol, declarationOrder)
 		{
-			type.ThrowOnNull(nameof(type));
-			pxContext.ThrowOnNull(nameof(pxContext));
+			pxContext.ThrowOnNull();
 
-			Type = type;
+			Type = type.CheckIfNull();
 
-			IsProcessing = type.IsProcessingView(pxContext);
-			IsSetup = type.IsPXSetupBqlCommand(pxContext);
-			IsFilter = type.InheritsFromOrEqualsGeneric(pxContext.BQL.PXFilter);
-			IsFBQL = type.IsFbqlView(pxContext);
-			IsCustomView = !IsProcessing && !IsSetup && !IsFilter && !IsFBQL && type.IsCustomBqlCommand(pxContext);
-			IsPXSelectReadOnly = type.IsPXSelectReadOnlyCommand();
+			IsProcessing 	   = Type.IsProcessingView(pxContext);
+			IsSetup 		   = Type.IsPXSetupBqlCommand(pxContext);
+			IsFilter 		   = Type.InheritsFromOrEqualsGeneric(pxContext.BQL.PXFilter);
+			IsFBQL 			   = Type.IsFbqlView(pxContext);
+			IsCustomView 	   = !IsProcessing && !IsSetup && !IsFilter && !IsFBQL && Type.IsCustomBqlCommand(pxContext);
+			IsPXSelectReadOnly = Type.IsPXSelectReadOnlyCommand();
 
 			DAC = Type.GetDacFromView(pxContext);
 		}
@@ -100,9 +103,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic.PXGraph
 		public DataViewInfo(ISymbol symbol, INamedTypeSymbol type, PXContext pxContext, int declarationOrder, DataViewInfo baseInfo)
 					 : this(symbol, type, pxContext, declarationOrder)
 		{
-			baseInfo.ThrowOnNull(nameof(baseInfo));
-
-			Base = baseInfo;
+			Base = baseInfo.CheckIfNull(nameof(baseInfo));
 		}
 	}
 }

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/PXGraph/Infos/Events/Base/GraphEventInfoBaseGeneric.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/PXGraph/Infos/Events/Base/GraphEventInfoBaseGeneric.cs
@@ -1,5 +1,7 @@
-﻿using System.Diagnostics;
+﻿#nullable enable
+
 using Acuminator.Utilities.Common;
+
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
@@ -22,13 +24,13 @@ namespace Acuminator.Utilities.Roslyn.Semantic.PXGraph
 		/// This will lead to a two concrete implementations of collection for <see cref="GraphRowEventInfo"/> and <see cref="GraphFieldEventInfo"/> 
 		/// or to a hard to read code in the <see cref="PXGraphEventSemanticModel.EventsCollector"/> if we choose to pass the delegates to the generic collection class. 
 		/// </remarks>
-		public TEventInfoType Base
+		public TEventInfoType? Base
 		{
 			get;
 			internal set;
 		}
 
-		TEventInfoType IWriteableBaseItem<TEventInfoType>.Base
+		TEventInfoType? IWriteableBaseItem<TEventInfoType>.Base
 		{
 			get => Base;
 			set => Base = value;
@@ -44,9 +46,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic.PXGraph
 									 EventHandlerSignatureType signatureType, EventType eventType, TEventInfoType baseEventInfo)
 							  : base(node, symbol, declarationOrder, signatureType, eventType)
 		{
-			baseEventInfo.ThrowOnNull(nameof(baseEventInfo));
-
-			Base = baseEventInfo;
-		}	
+			Base = baseEventInfo.CheckIfNull();
+		}
 	}
 }

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/PXGraph/Infos/InitDelegateInfo.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/PXGraph/Infos/InitDelegateInfo.cs
@@ -13,7 +13,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic.PXGraph
 		public InitDelegateInfo(INamedTypeSymbol graphSymbol, ISymbol delegateSymbol, SyntaxNode delegateNode, int declarationOrder)
 			: base(delegateNode, delegateSymbol, declarationOrder)
 		{
-			GraphTypeSymbol = graphSymbol.CheckIfNull(nameof(graphSymbol));
+			GraphTypeSymbol = graphSymbol.CheckIfNull();
 		}
 	}
 }

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/PXGraph/PXGraphEventSemanticModel.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/PXGraph/PXGraphEventSemanticModel.cs
@@ -222,7 +222,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic.PXGraph
 
 		public static PXGraphEventSemanticModel EnrichGraphModelWithEvents(PXGraphSemanticModel baseGraphModel, 
 																		   CancellationToken cancellationToken = default) =>
-			new PXGraphEventSemanticModel(baseGraphModel.CheckIfNull(nameof(baseGraphModel)), 
+			new PXGraphEventSemanticModel(baseGraphModel.CheckIfNull(), 
 										  cancellationToken);
 
 		public static IEnumerable<PXGraphEventSemanticModel> InferModels(PXContext pxContext, INamedTypeSymbol typeSymbol, 

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/PXGraph/PXGraphSemanticModel.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/PXGraph/PXGraphSemanticModel.cs
@@ -260,9 +260,9 @@ namespace Acuminator.Utilities.Roslyn.Semantic.PXGraph
 																	GraphSemanticModelCreationOptions modelCreationOptions,
 																	CancellationToken cancellation = default)
 		{
+			pxContext.ThrowOnNull();
+			typeSymbol.ThrowOnNull();
 			cancellation.ThrowIfCancellationRequested();
-			pxContext.ThrowOnNull(nameof(pxContext));
-			typeSymbol.ThrowOnNull(nameof(typeSymbol));
 
 			var models = new List<PXGraphSemanticModel>(capacity: 1);
 			var explicitModel = InferExplicitModel(pxContext, typeSymbol, modelCreationOptions, cancellation);
@@ -313,9 +313,9 @@ namespace Acuminator.Utilities.Roslyn.Semantic.PXGraph
 															  GraphSemanticModelCreationOptions modelCreationOptions,
 															  CancellationToken cancellation)
 		{
+			pxContext.ThrowOnNull();
+			typeSymbol.ThrowOnNull();
 			cancellation.ThrowIfCancellationRequested();
-			pxContext.ThrowOnNull(nameof(pxContext));
-			typeSymbol.ThrowOnNull(nameof(typeSymbol));
 
 			GraphType graphType = GraphType.None;
 

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/PXGraph/ProcessingDelegatesWalker.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/PXGraph/ProcessingDelegatesWalker.cs
@@ -31,7 +31,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic.PXGraph
 		public ProcessingDelegatesWalker(PXContext pxContext, ImmutableHashSet<ISymbol> processingViewSymbols, CancellationToken cancellation)
 			: base(pxContext, cancellation)
 		{
-			_processingViewSymbols = processingViewSymbols.CheckIfNull(nameof(processingViewSymbols));
+			_processingViewSymbols = processingViewSymbols.CheckIfNull();
 		}
 
 		public override void VisitInvocationExpression(InvocationExpressionSyntax node)

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/PXGraph/Utils/GraphActionSymbolUtils.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/PXGraph/Utils/GraphActionSymbolUtils.cs
@@ -1,10 +1,14 @@
-﻿using Acuminator.Utilities.Common;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
+﻿#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+
+using Acuminator.Utilities.Common;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 using ActionSymbolWithTypeCollection = System.Collections.Generic.IEnumerable<(Microsoft.CodeAnalysis.ISymbol ActionSymbol, Microsoft.CodeAnalysis.INamedTypeSymbol ActionType)>;
 
@@ -40,8 +44,6 @@ namespace Acuminator.Utilities.Roslyn.Semantic.PXGraph
 		public static OverridableItemsCollection<ActionInfo> GetActionSymbolsWithTypesFromGraph(this ITypeSymbol graph, PXContext pxContext,
 																								bool includeActionsFromInheritanceChain = true)
 		{
-			pxContext.ThrowOnNull(nameof(pxContext));
-
 			if (!graph.IsPXGraph(pxContext))
 				return new OverridableItemsCollection<ActionInfo>();
 
@@ -64,9 +66,6 @@ namespace Acuminator.Utilities.Roslyn.Semantic.PXGraph
 		public static OverridableItemsCollection<ActionInfo> GetActionsFromGraphOrGraphExtensionAndBaseGraph(this ITypeSymbol graphOrExtension,
 																											 PXContext pxContext)
 		{
-			pxContext.ThrowOnNull(nameof(pxContext));
-			graphOrExtension.ThrowOnNull(nameof(graphOrExtension));
-
 			bool isGraph = graphOrExtension.IsPXGraph(pxContext);
 
 			if (!isGraph && !graphOrExtension.IsPXGraphExtension(pxContext))
@@ -85,8 +84,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic.PXGraph
 		/// <returns/>
 		public static OverridableItemsCollection<ActionInfo> GetActionsFromGraphExtensionAndBaseGraph(this ITypeSymbol graphExtension, PXContext pxContext)
 		{
-			graphExtension.ThrowOnNull(nameof(graphExtension));
-			pxContext.ThrowOnNull(nameof(pxContext));
+			graphExtension.ThrowOnNull();
 
 			var systemActionsRegister = new PXSystemActions.PXSystemActionsRegister(pxContext);
 			return GetActionInfoFromGraphExtension<ActionInfo>(graphExtension, pxContext, AddActionsFromGraph, AddActionsFromGraphExtension);
@@ -153,9 +151,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic.PXGraph
 																							   PXContext pxContext, bool inheritance = true, 
 																							   CancellationToken cancellation = default)
 		{
-			graph.ThrowOnNull(nameof(graph));
-			actionsByName.ThrowOnNull(nameof(actionsByName));
-			pxContext.ThrowOnNull(nameof(pxContext));
+			actionsByName.ThrowOnNull();
 
 			if (!graph.IsPXGraph(pxContext))
 			{
@@ -183,9 +179,9 @@ namespace Acuminator.Utilities.Roslyn.Semantic.PXGraph
 																							IDictionary<string, ActionInfo> actionsByName, PXContext pxContext,
 																							CancellationToken cancellation)
 		{
-			graphExtension.ThrowOnNull(nameof(graphExtension));
-			actionsByName.ThrowOnNull(nameof(actionsByName));
-			pxContext.ThrowOnNull(nameof(pxContext));
+			graphExtension.ThrowOnNull();
+			actionsByName.ThrowOnNull();
+			pxContext.ThrowOnNull();
 
 			return GetActionInfoFromGraphExtension<ActionHandlerInfo>(graphExtension, pxContext, AddHandlersFromGraph, AddHandlersFromGraphExtension);
 
@@ -249,7 +245,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic.PXGraph
 																		AddActionInfoWithOrderDelegate<TInfo> addGraphExtensionActionInfoWithOrder)
 		where TInfo : IOverridableItem<TInfo>
 		{
-			if (!graphExtension.InheritsFrom(pxContext.PXGraphExtension.Type))
+			if (!graphExtension.InheritsFrom(pxContext.PXGraphExtension.Type!))
 				return new OverridableItemsCollection<TInfo>();
 
 			var graphType = graphExtension.GetGraphFromGraphExtension(pxContext);

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/PXGraph/Utils/GraphSymbolHierarchyUtils.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/PXGraph/Utils/GraphSymbolHierarchyUtils.cs
@@ -1,9 +1,13 @@
-﻿using System.Collections.Generic;
+﻿#nullable enable
+
+using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
+
 using Acuminator.Utilities.Common;
-using Microsoft.CodeAnalysis;
 using Acuminator.Utilities.Roslyn.Constants;
+
+using Microsoft.CodeAnalysis;
 
 namespace Acuminator.Utilities.Roslyn.Semantic.PXGraph
 {
@@ -17,34 +21,28 @@ namespace Acuminator.Utilities.Roslyn.Semantic.PXGraph
 		/// </summary>
 		/// <param name="graphType">The graph type to act on.</param>
 		/// <returns/>
-		public static IEnumerable<ITypeSymbol> GetGraphWithBaseTypes(this ITypeSymbol graphType)
-		{
-			graphType.ThrowOnNull(nameof(graphType));
-			return graphType.GetBaseTypesAndThis()
-							.TakeWhile(type => !type.IsGraphBaseType());
-		}
+		public static IEnumerable<ITypeSymbol> GetGraphWithBaseTypes(this ITypeSymbol graphType) =>
+			graphType.GetBaseTypesAndThis()
+					 .TakeWhile(type => !type.IsGraphBaseType());
 
 		/// <summary>
 		/// Gets the extension type with its base types up to first met <see cref="PX.Data.PXGraphExtension"/>.
 		/// </summary>
 		/// <param name="extensionType">The extension type to act on.</param>
 		/// <returns/>
-		public static IEnumerable<ITypeSymbol> GetExtensionWithBaseTypes(this ITypeSymbol extensionType)
-		{
-			extensionType.ThrowOnNull(nameof(extensionType));
-			return extensionType.GetBaseTypesAndThis()
-								.TakeWhile(type => !type.IsGraphExtensionBaseType());
-		}
+		public static IEnumerable<ITypeSymbol> GetExtensionWithBaseTypes(this ITypeSymbol extensionType) =>
+			extensionType.GetBaseTypesAndThis()
+						 .TakeWhile(type => !type.IsGraphExtensionBaseType());
 
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		internal static bool IsGraphOrGraphExtensionBaseType(this ITypeSymbol type) =>
-			type?.Name == TypeNames.PXGraph || type.Name == TypeNames.PXGraphExtension;
+		internal static bool IsGraphOrGraphExtensionBaseType(this ITypeSymbol? type) =>
+			type != null && (type.Name == TypeNames.PXGraph || type.Name == TypeNames.PXGraphExtension);
 		
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static bool IsGraphBaseType(this ITypeSymbol type) => type?.Name == TypeNames.PXGraph;
+		public static bool IsGraphBaseType(this ITypeSymbol? type) => type?.Name == TypeNames.PXGraph;
 
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static bool IsGraphExtensionBaseType(this ITypeSymbol type) => 
+		public static bool IsGraphExtensionBaseType(this ITypeSymbol? type) => 
 			type?.Name == TypeNames.PXGraphExtension;
 
 		/// <summary>
@@ -61,18 +59,18 @@ namespace Acuminator.Utilities.Roslyn.Semantic.PXGraph
 		{
 			pxContext.ThrowOnNull(nameof(pxContext));
 
-			if (graphExtension == null || !graphExtension.InheritsFrom(pxContext.PXGraphExtension.Type))
-				return Enumerable.Empty<ITypeSymbol>();
+			if (graphExtension == null || !graphExtension.InheritsFrom(pxContext.PXGraphExtension.Type!))
+				return [];
 
-			INamedTypeSymbol extensionBaseType = graphExtension.GetBaseTypesAndThis()
-															   .FirstOrDefault(type => type.IsGraphExtensionBaseType()) as INamedTypeSymbol;
+			INamedTypeSymbol? extensionBaseType = graphExtension.GetBaseTypesAndThis()
+																.FirstOrDefault(type => type.IsGraphExtensionBaseType()) as INamedTypeSymbol;
 			if (extensionBaseType == null)
-				return Enumerable.Empty<ITypeSymbol>();
+				return [];
 
 			var graphType = extensionBaseType.TypeArguments.LastOrDefault();
 
 			if (graphType == null || !graphType.IsPXGraph(pxContext))
-				return Enumerable.Empty<ITypeSymbol>();
+				return [];
 
 			return sortDirection == SortDirection.Ascending
 				? GetExtensionInAscendingOrder(graphType, graphExtension, extensionBaseType, pxContext, includeGraph)
@@ -95,7 +93,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic.PXGraph
 				var baseExtension = extensionBaseType.TypeArguments[i];
 
 				if (!baseExtension.IsPXGraphExtension(pxContext))
-					return Enumerable.Empty<ITypeSymbol>();
+					return [];
 
 				extensions.Add(baseExtension);		//According to Platform team we shouldn't consider case when the graph extensions chaining mixes with .Net inheritance
 			}
@@ -116,7 +114,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic.PXGraph
 				var baseExtension = extensionBaseType.TypeArguments[i];
 
 				if (!baseExtension.IsPXGraphExtension(pxContext))
-					return Enumerable.Empty<ITypeSymbol>();
+					return [];
 
 				extensions.Add(baseExtension);		//According to Platform team we shouldn't consider case when the graph extensions chaining mixes with .Net inheritance
 			}

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/PXGraph/Utils/GraphSymbolUtils.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/PXGraph/Utils/GraphSymbolUtils.cs
@@ -26,7 +26,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic.PXGraph
 		/// </returns>
 		public static ITypeSymbol? GetGraphFromGraphExtension(this ITypeSymbol? graphExtension, PXContext pxContext)
 		{
-			pxContext.ThrowOnNull(nameof(pxContext));
+			pxContext.ThrowOnNull();
 
 			if (graphExtension == null || !graphExtension.InheritsFrom(pxContext.PXGraphExtension.Type!))
 				return null;
@@ -66,8 +66,8 @@ namespace Acuminator.Utilities.Roslyn.Semantic.PXGraph
 
 		public static bool IsValidActionHandler(this IMethodSymbol method, PXContext pxContext)
 		{
-			method.ThrowOnNull(nameof(method));
-			pxContext.ThrowOnNull(nameof(pxContext));
+			method.ThrowOnNull();
+			pxContext.ThrowOnNull();
 
 			if (method.Parameters.Length == 0)
 				return method.ReturnsVoid;
@@ -80,8 +80,8 @@ namespace Acuminator.Utilities.Roslyn.Semantic.PXGraph
 
 		public static bool IsValidViewDelegate(this IMethodSymbol method, PXContext pxContext)
 		{
-			method.ThrowOnNull(nameof(method));
-			pxContext.ThrowOnNull(nameof(pxContext));
+			method.ThrowOnNull();
+			pxContext.ThrowOnNull();
 
 			return method.ReturnType.Equals(pxContext.SystemTypes.IEnumerable) &&
 				   method.Parameters.All(p => p.RefKind != RefKind.Ref);
@@ -97,7 +97,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic.PXGraph
 		/// </returns>
 		public static ITypeSymbol? GetDeclaredPrimaryDacFromGraphOrGraphExtension(this ITypeSymbol? graphOrExtension, PXContext pxContext)
 		{
-			pxContext.ThrowOnNull(nameof(pxContext));
+			pxContext.ThrowOnNull();
 
 			if (graphOrExtension == null)
 				return null;
@@ -129,7 +129,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic.PXGraph
 		internal static (MethodDeclarationSyntax Node, IMethodSymbol Symbol) GetGraphExtensionInitialization
 			(this INamedTypeSymbol typeSymbol, PXContext pxContext, CancellationToken cancellation = default)
 		{
-			typeSymbol.ThrowOnNull(nameof(typeSymbol));
+			typeSymbol.ThrowOnNull();
 
 			if (pxContext.PXGraphExtension.Initialize == null)
 				return default;

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/PXGraph/Utils/GraphViewSymbolUtils.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/PXGraph/Utils/GraphViewSymbolUtils.cs
@@ -1,11 +1,15 @@
-﻿using Acuminator.Utilities.Common;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
+﻿#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
+
+using Acuminator.Utilities.Common;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 using ViewSymbolWithTypeCollection = System.Collections.Generic.IEnumerable<(Microsoft.CodeAnalysis.ISymbol ViewSymbol, Microsoft.CodeAnalysis.INamedTypeSymbol ViewType)>;
 
@@ -39,10 +43,9 @@ namespace Acuminator.Utilities.Roslyn.Semantic.PXGraph
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static bool IsProcessingView(this ITypeSymbol view, PXContext pxContext)
 		{
-			view.ThrowOnNull(nameof(view));
-			pxContext.ThrowOnNull(nameof(pxContext));
+			pxContext.ThrowOnNull();
 
-			return view.InheritsFromOrEqualsGeneric(pxContext.PXProcessingBase.Type);
+			return view.CheckIfNull().InheritsFromOrEqualsGeneric(pxContext.PXProcessingBase.Type!);
 		}
 
 		/// <summary>
@@ -56,9 +59,9 @@ namespace Acuminator.Utilities.Roslyn.Semantic.PXGraph
 		public static OverridableItemsCollection<DataViewInfo> GetViewsWithSymbolsFromPXGraph(this ITypeSymbol graph, PXContext pxContext,
 																							  bool includeViewsFromInheritanceChain = true)
 		{
-			pxContext.ThrowOnNull(nameof(pxContext));
+			pxContext.ThrowOnNull();
 
-			if (graph?.InheritsFrom(pxContext.PXGraph.Type) != true)
+			if (graph?.InheritsFrom(pxContext.PXGraph.Type!) != true)
 				return new OverridableItemsCollection<DataViewInfo>();
 
 			var viewsByName = new OverridableItemsCollection<DataViewInfo>(capacity: EstimatedNumberOfViewsInGraph);
@@ -77,9 +80,6 @@ namespace Acuminator.Utilities.Roslyn.Semantic.PXGraph
 		public static OverridableItemsCollection<DataViewInfo> GetViewsFromGraphOrGraphExtensionAndBaseGraph(this ITypeSymbol graphOrExtension,
 																											 PXContext pxContext)
 		{
-			pxContext.ThrowOnNull(nameof(pxContext));
-			graphOrExtension.ThrowOnNull(nameof(graphOrExtension));
-
 			bool isGraph = graphOrExtension.IsPXGraph(pxContext);
 
 			if (!isGraph && !graphOrExtension.IsPXGraphExtension(pxContext))
@@ -98,8 +98,8 @@ namespace Acuminator.Utilities.Roslyn.Semantic.PXGraph
 		/// <returns></returns>
 		public static OverridableItemsCollection<DataViewInfo> GetViewsFromGraphExtensionAndBaseGraph(this ITypeSymbol graphExtension, PXContext pxContext)
 		{
-			graphExtension.ThrowOnNull(nameof(graphExtension));
-			pxContext.ThrowOnNull(nameof(pxContext));
+			graphExtension.ThrowOnNull();
+			pxContext.ThrowOnNull();
 
 			return GetViewInfoFromGraphExtension<DataViewInfo>(graphExtension, pxContext, AddViewsFromGraph, AddViewsFromGraphExtension);
 
@@ -138,10 +138,10 @@ namespace Acuminator.Utilities.Roslyn.Semantic.PXGraph
 		{
 			foreach (ISymbol member in graphOrExtension.GetMembers())
 			{
-				if (!(member is IFieldSymbol field) || field.DeclaredAccessibility != Accessibility.Public)
+				if (member is not IFieldSymbol field || field.DeclaredAccessibility != Accessibility.Public)
 					continue;
 
-				if (!(field.Type is INamedTypeSymbol fieldType) || !fieldType.InheritsFrom(pxContext.PXSelectBase.Type))
+				if (field.Type is not INamedTypeSymbol fieldType || !fieldType.InheritsFrom(pxContext.PXSelectBase.Type!))
 					continue;
 
 				yield return (field, fieldType);
@@ -164,9 +164,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic.PXGraph
 																						   PXContext pxContext, bool inheritance = true, 
 																						   CancellationToken cancellation = default)
 		{
-			graph.ThrowOnNull(nameof(graph));
-			viewsByName.ThrowOnNull(nameof(viewsByName));
-			pxContext.ThrowOnNull(nameof(pxContext));
+			viewsByName.ThrowOnNull();
 
 			if (!graph.IsPXGraph(pxContext))
 				return new OverridableItemsCollection<DataViewDelegateInfo>();
@@ -192,9 +190,9 @@ namespace Acuminator.Utilities.Roslyn.Semantic.PXGraph
 																							IDictionary<string, DataViewInfo> viewsByName,
 																							PXContext pxContext, CancellationToken cancellation)
 		{
-			graphExtension.ThrowOnNull(nameof(graphExtension));
-			viewsByName.ThrowOnNull(nameof(viewsByName));
-			pxContext.ThrowOnNull(nameof(pxContext));
+			graphExtension.ThrowOnNull();
+			viewsByName.ThrowOnNull();
+			pxContext.ThrowOnNull();
 
 			return GetViewInfoFromGraphExtension<DataViewDelegateInfo>(graphExtension, pxContext, AddDelegatesFromGraph, AddDelegatesFromGraphExtension);
 
@@ -258,7 +256,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic.PXGraph
 																						AddViewInfoWithOrderDelegate<TInfo> addGraphExtensionViewInfo)
 		where TInfo : IOverridableItem<TInfo>
 		{
-			if (!graphExtension.InheritsFrom(pxContext.PXGraphExtension.Type))
+			if (!graphExtension.InheritsFrom(pxContext.PXGraphExtension.Type!))
 				return new OverridableItemsCollection<TInfo>();
 
 			var graphType = graphExtension.GetGraphFromGraphExtension(pxContext);

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SematicModelUtils.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SematicModelUtils.cs
@@ -26,8 +26,8 @@ namespace Acuminator.Utilities.Roslyn.Semantic
 		/// </returns>
 		public static DataFlowAnalysis? TryAnalyzeDataFlow(this SemanticModel semanticModel, SyntaxNode node)
 		{
-			semanticModel.ThrowOnNull(nameof(semanticModel));
-			node.ThrowOnNull(nameof(node));
+			semanticModel.ThrowOnNull();
+			node.ThrowOnNull();
 
 			DataFlowAnalysis? dataFlowAnalysis;
 
@@ -56,10 +56,9 @@ namespace Acuminator.Utilities.Roslyn.Semantic
 		/// </returns>
 		public static ISymbol? GetSymbolOrFirstCandidate(this SemanticModel semanticModel, SyntaxNode node, CancellationToken cancellation)
 		{
-			semanticModel.ThrowOnNull(nameof(semanticModel));
-			node.ThrowOnNull(nameof(node));
+			node.ThrowOnNull();
 
-			var symbolInfo = semanticModel.GetSymbolInfo(node, cancellation);
+			var symbolInfo = semanticModel.CheckIfNull().GetSymbolInfo(node, cancellation);
 			return symbolInfo.Symbol ?? symbolInfo.CandidateSymbols.FirstOrDefault();
 		}
 
@@ -67,9 +66,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic
 		public static async Task<(SemanticModel? SemanticModel, SyntaxNode? Root)> GetSemanticModelAndRootAsync(this Document document, 
 																												CancellationToken cancellation = default)
 		{
-			document.ThrowOnNull(nameof(document));
-
-			var semanticModelTask = document.GetSemanticModelAsync(cancellation);
+			var semanticModelTask = document.CheckIfNull().GetSemanticModelAsync(cancellation);
 			var syntaxRootTask = document.GetSyntaxRootAsync(cancellation);
 
 			await Task.WhenAll(semanticModelTask, syntaxRootTask).ConfigureAwait(false);

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/Symbols/Base/SymbolsSetBase.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/Symbols/Base/SymbolsSetBase.cs
@@ -16,7 +16,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic.Symbols
 
 		private protected SymbolsSetBase(Compilation compilation)
 		{
-			Compilation = compilation.CheckIfNull(nameof(compilation));
+			Compilation = compilation.CheckIfNull();
 		}
 	}
 }

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/Symbols/PXCacheSymbols.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/Symbols/PXCacheSymbols.cs
@@ -23,7 +23,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic.Symbols
 
 		internal PXCacheSymbols(Compilation compilation) : base(compilation, TypeFullNames.PXCache)
 		{
-			Type.ThrowOnNull(nameof(Type));
+			Type.ThrowOnNull();
 
 			GenericType = Compilation.GetTypeByMetadataName(TypeFullNames.PXCache1);
 

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/Symbols/PXGraphExtensionSymbols.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/Symbols/PXGraphExtensionSymbols.cs
@@ -21,7 +21,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic.Symbols
 
 		internal PXGraphExtensionSymbols(PXContext pxContext) : base(pxContext.Compilation, TypeFullNames.PXGraphExtension)
         {
-			Initialize = Type!.CheckIfNull(nameof(Type))
+			Initialize = Type!.CheckIfNull()
 							  .GetMethods(DelegateNames.Initialize).FirstOrDefault();
 			Configure  = Type.GetConfigureMethodFromBaseGraphOrGraphExtension(pxContext);
 		}

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/Symbols/PXGraphSymbols.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/Symbols/PXGraphSymbols.cs
@@ -38,7 +38,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic.Symbols
 
 		internal PXGraphSymbols(PXContext pxContext) : base(pxContext.Compilation, TypeFullNames.PXGraph)
         {
-			Type.ThrowOnNull(nameof(Type));
+			Type.ThrowOnNull();
 
 			GenericTypeGraph = Compilation.GetTypeByMetadataName(TypeFullNames.PXGraph1);
 			GenericTypeGraphDac = Compilation.GetTypeByMetadataName(TypeFullNames.PXGraph2);

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Syntax/LowestCommonAncestor/LowestCommonAncestor.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Syntax/LowestCommonAncestor/LowestCommonAncestor.cs
@@ -16,8 +16,8 @@ namespace Acuminator.Utilities.Roslyn.Syntax
 	{
 		public static LCAResultForTwoStatements GetCommonAncestorForSyntaxStatements(StatementSyntax x, StatementSyntax y)
 		{
-			x.ThrowOnNull(nameof(x));
-			y.ThrowOnNull(nameof(y));
+			x.ThrowOnNull();
+			y.ThrowOnNull();
 
 			//Depth is average O(log n) operation, worst case is O(n) but it isn't the case for the syntax tree which is wide but not very deep.
 			//For statements we could consider depth constrained by BaseMethodDeclarationSyntax
@@ -56,8 +56,8 @@ namespace Acuminator.Utilities.Roslyn.Syntax
 
 		public static LCAResultForTwoNodes GetCommonAncestorForSyntaxNodesInsideMethods(SyntaxNode x, SyntaxNode y)
 		{
-			x.ThrowOnNull(nameof(x));
-			y.ThrowOnNull(nameof(y));
+			x.ThrowOnNull();
+			y.ThrowOnNull();
 
 			//Depth is average O(log n) operation, worst case is O(n) but it isn't the case for the syntax tree which is wide but not very deep.
 			//For nodes inside methods we could consider depth constrained by BaseMethodDeclarationSyntax

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Syntax/MethodDeclarationUtils.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Syntax/MethodDeclarationUtils.cs
@@ -41,7 +41,7 @@ namespace Acuminator.Utilities.Roslyn.Syntax
 		/// </returns>
 		public static Location GetMethodNameLocation(this InvocationExpressionSyntax invocation)
 		{
-			invocation.ThrowOnNull(nameof(invocation));
+			invocation.ThrowOnNull();
 
 			if (invocation.Expression is MemberAccessExpressionSyntax memberAccessNode)
 			{
@@ -58,7 +58,7 @@ namespace Acuminator.Utilities.Roslyn.Syntax
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static bool DoesArgumentsContainIdentifier(this InvocationExpressionSyntax invocation, string? identifier)
 		{
-			invocation.ThrowOnNull(nameof(invocation));
+			invocation.ThrowOnNull();
 
 			if (identifier.IsNullOrWhiteSpace())
 				return false;
@@ -75,7 +75,7 @@ namespace Acuminator.Utilities.Roslyn.Syntax
 
 		public static IEnumerable<ArgumentSyntax> GetArgumentsContainingIdentifier(this InvocationExpressionSyntax invocation, string? identifier)
 		{
-			invocation.ThrowOnNull(nameof(invocation));
+			invocation.ThrowOnNull();
 
 			if (identifier.IsNullOrWhiteSpace())
 				yield break;
@@ -179,13 +179,13 @@ namespace Acuminator.Utilities.Roslyn.Syntax
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool IsStatic(this BaseMethodDeclarationSyntax node) =>
-			node.CheckIfNull(nameof(node))
+			node.CheckIfNull()
 				.Modifiers
 				.Any(m => m.IsKind(SyntaxKind.StaticKeyword));
 
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static bool IsStatic(this LocalFunctionStatementSyntax node) =>
-			node.CheckIfNull(nameof(node))
+			node.CheckIfNull()
 				.Modifiers
 				.Any(m => m.IsKind(SyntaxKind.StaticKeyword));
 	}

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Syntax/MultipleParametersUsagesRewriter.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Syntax/MultipleParametersUsagesRewriter.cs
@@ -25,8 +25,8 @@ namespace Acuminator.Utilities.Roslyn.Syntax
 		public MultipleParametersUsagesRewriter(IDictionary<IParameterSymbol, SyntaxNode> parametersWithReplacements, SemanticModel semanticModel,
 												CancellationToken cancellation)
 		{
-			_parametersWithReplacements = parametersWithReplacements.CheckIfNull(nameof(parametersWithReplacements));
-			_semanticModel 				= semanticModel.CheckIfNull(nameof(semanticModel));
+			_parametersWithReplacements = parametersWithReplacements.CheckIfNull();
+			_semanticModel 				= semanticModel.CheckIfNull();
 			_cancellation  				= cancellation;
 		}
 

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Syntax/PXGraph/GraphSyntaxUtils.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Syntax/PXGraph/GraphSyntaxUtils.cs
@@ -19,9 +19,9 @@ namespace Acuminator.Utilities.Roslyn.Syntax.PXGraph
 		public static GraphInstantiationType GetGraphInstantiationType(this SyntaxNode node, SemanticModel semanticModel, 
 			PXContext pxContext)
 		{
-			node.ThrowOnNull(nameof (node));
-			semanticModel.ThrowOnNull(nameof (semanticModel));
-			pxContext.ThrowOnNull(nameof (pxContext));
+			node.ThrowOnNull();
+			semanticModel.ThrowOnNull();
+			pxContext.ThrowOnNull();
 
 			// new PXGraph()
 			if (node is ObjectCreationExpressionSyntax objCreationSyntax && objCreationSyntax.Type != null
@@ -55,14 +55,14 @@ namespace Acuminator.Utilities.Roslyn.Syntax.PXGraph
 																						this SyntaxNode root, SemanticModel semanticModel,
 																						PXContext context, CancellationToken cancellationToken = default)
 		{
-			root.ThrowOnNull(nameof(root));
-			context.ThrowOnNull(nameof(context));
-			semanticModel.ThrowOnNull(nameof(semanticModel));
+			root.ThrowOnNull();
+			context.ThrowOnNull();
+			semanticModel.ThrowOnNull();
 			cancellationToken.ThrowIfCancellationRequested();
 
 			return context.IsPlatformReferenced 
 				? GetDeclaredGraphsAndExtensionsImpl()
-				: Enumerable.Empty<(ITypeSymbol, SyntaxNode)>();
+				: [];
 
 
 			IEnumerable<(ITypeSymbol GraphSymbol, SyntaxNode GraphNode)> GetDeclaredGraphsAndExtensionsImpl()
@@ -84,8 +84,8 @@ namespace Acuminator.Utilities.Roslyn.Syntax.PXGraph
 		public static ITypeSymbol GetTypeSymbolFromClassDeclaration(this ClassDeclarationSyntax classDeclaration, SemanticModel semanticModel,
 																	CancellationToken cancellationToken = default)
 		{
-			classDeclaration.ThrowOnNull(nameof(classDeclaration));
-			semanticModel.ThrowOnNull(nameof(semanticModel));
+			classDeclaration.ThrowOnNull();
+			semanticModel.ThrowOnNull();
 			cancellationToken.ThrowIfCancellationRequested();
 
 			var typeSymbol = semanticModel.GetDeclaredSymbol(classDeclaration, cancellationToken) as ITypeSymbol;

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Syntax/ParameterUsagesRewriter.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Syntax/ParameterUsagesRewriter.cs
@@ -25,9 +25,9 @@ namespace Acuminator.Utilities.Roslyn.Syntax
 
 		public ParameterUsagesRewriter(IParameterSymbol parameter, SyntaxNode replaceWith, SemanticModel semanticModel, CancellationToken cancellation)
 		{
-			_parameter = parameter.CheckIfNull(nameof(parameter));
-			_replaceWith = replaceWith.CheckIfNull(nameof(replaceWith));
-			_semanticModel = semanticModel.CheckIfNull(nameof(semanticModel));
+			_parameter = parameter.CheckIfNull();
+			_replaceWith = replaceWith.CheckIfNull();
+			_semanticModel = semanticModel.CheckIfNull();
 			_cancellation = cancellation;
 		}
 

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Syntax/RoslynSyntaxUtils.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Syntax/RoslynSyntaxUtils.cs
@@ -18,8 +18,8 @@ namespace Acuminator.Utilities.Roslyn.Syntax
 	{
 		public static bool IsLocalVariable(this SemanticModel semanticModel, MethodDeclarationSyntax containingMethod, string? variableName)
 		{
-			semanticModel.ThrowOnNull(nameof(semanticModel));
-			containingMethod.ThrowOnNull(nameof(containingMethod));
+			semanticModel.ThrowOnNull();
+			containingMethod.ThrowOnNull();
 
 			if (variableName.IsNullOrWhiteSpace())
 				return false;
@@ -148,25 +148,25 @@ namespace Acuminator.Utilities.Roslyn.Syntax
 		public static IEnumerable<SyntaxToken> GetIdentifiers(this MemberDeclarationSyntax? member) =>
 			member switch
 			{
-				PropertyDeclarationSyntax propertyDeclaration       => propertyDeclaration.Identifier.ToEnumerable(),
-				FieldDeclarationSyntax fieldDeclaration             => fieldDeclaration.Declaration.Variables.Select(variable => variable.Identifier),
-				MethodDeclarationSyntax methodDeclaration           => methodDeclaration.Identifier.ToEnumerable(),
-				EventDeclarationSyntax eventDeclaration             => eventDeclaration.Identifier.ToEnumerable(),                                           //for explicit event declaration with "add" and "remove"
-				EventFieldDeclarationSyntax eventFieldDeclaration   => eventFieldDeclaration.Declaration.Variables.Select(variable => variable.Identifier),  //for field event declaration
-				DelegateDeclarationSyntax delegateDeclaration       => delegateDeclaration.Identifier.ToEnumerable(),
-				ClassDeclarationSyntax nestedClassDeclaration       => nestedClassDeclaration.Identifier.ToEnumerable(),
-				EnumDeclarationSyntax enumDeclaration               => enumDeclaration.Identifier.ToEnumerable(),
-				StructDeclarationSyntax structDeclaration           => structDeclaration.Identifier.ToEnumerable(),
-				InterfaceDeclarationSyntax interfaceDeclaration     => interfaceDeclaration.Identifier.ToEnumerable(),
+				PropertyDeclarationSyntax propertyDeclaration 		=> propertyDeclaration.Identifier.ToEnumerable(),
+				FieldDeclarationSyntax fieldDeclaration 			=> fieldDeclaration.Declaration.Variables.Select(variable => variable.Identifier),
+				MethodDeclarationSyntax methodDeclaration 			=> methodDeclaration.Identifier.ToEnumerable(),
+				EventDeclarationSyntax eventDeclaration 			=> eventDeclaration.Identifier.ToEnumerable(),                                           //for explicit event declaration with "add" and "remove"
+				EventFieldDeclarationSyntax eventFieldDeclaration 	=> eventFieldDeclaration.Declaration.Variables.Select(variable => variable.Identifier),  //for field event declaration
+				DelegateDeclarationSyntax delegateDeclaration 		=> delegateDeclaration.Identifier.ToEnumerable(),
+				ClassDeclarationSyntax nestedClassDeclaration 		=> nestedClassDeclaration.Identifier.ToEnumerable(),
+				EnumDeclarationSyntax enumDeclaration 				=> enumDeclaration.Identifier.ToEnumerable(),
+				StructDeclarationSyntax structDeclaration 			=> structDeclaration.Identifier.ToEnumerable(),
+				InterfaceDeclarationSyntax interfaceDeclaration 	=> interfaceDeclaration.Identifier.ToEnumerable(),
 				ConstructorDeclarationSyntax constructorDeclaration => constructorDeclaration.Identifier.ToEnumerable(),
-				_                                                   => Enumerable.Empty<SyntaxToken>()
+				_ 													=> []
 			};
 
 		public static Accessibility? GetAccessibility(this MemberDeclarationSyntax member, SemanticModel semanticModel,
 													 CancellationToken cancellationToken = default)
 		{
-			member.ThrowOnNull(nameof(member));
-			semanticModel.ThrowOnNull(nameof(semanticModel));
+			member.ThrowOnNull();
+			semanticModel.ThrowOnNull();
 			
 			switch (member)
 			{		
@@ -210,7 +210,7 @@ namespace Acuminator.Utilities.Roslyn.Syntax
 		}
 
 		public static bool IsPartial(this TypeDeclarationSyntax typeDeclaration) =>
-			typeDeclaration.CheckIfNull(nameof(typeDeclaration))
+			typeDeclaration.CheckIfNull()
 						   .Modifiers
 						   .Any(SyntaxKind.PartialKeyword);
 		
@@ -223,15 +223,15 @@ namespace Acuminator.Utilities.Roslyn.Syntax
 		}
 
 		public static SyntaxTokenList GetModifiers(this SyntaxNode member) =>
-			member.CheckIfNull(nameof(member)) switch
+			member.CheckIfNull() switch
 			{
 				BasePropertyDeclarationSyntax basePropertyDeclaration => basePropertyDeclaration.Modifiers,
-				BaseMethodDeclarationSyntax baseMethodDeclaration     => baseMethodDeclaration.Modifiers,
-				BaseTypeDeclarationSyntax baseTypeDeclaration         => baseTypeDeclaration.Modifiers,
-				BaseFieldDeclarationSyntax baseFieldDeclaration       => baseFieldDeclaration.Modifiers,
-				DelegateDeclarationSyntax delegateDeclaration         => delegateDeclaration.Modifiers,
+				BaseMethodDeclarationSyntax baseMethodDeclaration 	  => baseMethodDeclaration.Modifiers,
+				BaseTypeDeclarationSyntax baseTypeDeclaration 		  => baseTypeDeclaration.Modifiers,
+				BaseFieldDeclarationSyntax baseFieldDeclaration 	  => baseFieldDeclaration.Modifiers,
+				DelegateDeclarationSyntax delegateDeclaration 		  => delegateDeclaration.Modifiers,
 				LocalFunctionStatementSyntax localFunctionStatement   => localFunctionStatement.Modifiers,
-				_                                                     => SyntaxFactory.TokenList()
+				_ 													  => SyntaxFactory.TokenList()
 			};
 
 		/// <summary>
@@ -259,7 +259,7 @@ namespace Acuminator.Utilities.Roslyn.Syntax
 
 		public static IEnumerable<AttributeSyntax> GetAttributes(this MemberDeclarationSyntax member)
 		{
-			member.ThrowOnNull(nameof(member));
+			member.ThrowOnNull();
 			return GetAttributesImpl();
 
 			IEnumerable<AttributeSyntax> GetAttributesImpl()
@@ -281,18 +281,18 @@ namespace Acuminator.Utilities.Roslyn.Syntax
 		public static SyntaxList<AttributeListSyntax> GetAttributeLists(this MemberDeclarationSyntax? member) =>
 			member switch
 			{
-				PropertyDeclarationSyntax propertyDeclaration       => propertyDeclaration.AttributeLists,
-				FieldDeclarationSyntax fieldDeclaration             => fieldDeclaration.AttributeLists,
-				MethodDeclarationSyntax methodDeclaration           => methodDeclaration.AttributeLists,
-				EventDeclarationSyntax eventDeclaration             => eventDeclaration.AttributeLists,
-				EventFieldDeclarationSyntax eventFieldDeclaration   => eventFieldDeclaration.AttributeLists,
-				DelegateDeclarationSyntax delegateDeclaration       => delegateDeclaration.AttributeLists,
-				ClassDeclarationSyntax nestedClassDeclaration       => nestedClassDeclaration.AttributeLists,
-				EnumDeclarationSyntax enumDeclaration               => enumDeclaration.AttributeLists,
-				StructDeclarationSyntax structDeclaration           => structDeclaration.AttributeLists,
-				InterfaceDeclarationSyntax interfaceDeclaration     => interfaceDeclaration.AttributeLists,
+				PropertyDeclarationSyntax propertyDeclaration 		=> propertyDeclaration.AttributeLists,
+				FieldDeclarationSyntax fieldDeclaration 			=> fieldDeclaration.AttributeLists,
+				MethodDeclarationSyntax methodDeclaration 			=> methodDeclaration.AttributeLists,
+				EventDeclarationSyntax eventDeclaration 			=> eventDeclaration.AttributeLists,
+				EventFieldDeclarationSyntax eventFieldDeclaration 	=> eventFieldDeclaration.AttributeLists,
+				DelegateDeclarationSyntax delegateDeclaration 		=> delegateDeclaration.AttributeLists,
+				ClassDeclarationSyntax nestedClassDeclaration 		=> nestedClassDeclaration.AttributeLists,
+				EnumDeclarationSyntax enumDeclaration 				=> enumDeclaration.AttributeLists,
+				StructDeclarationSyntax structDeclaration 			=> structDeclaration.AttributeLists,
+				InterfaceDeclarationSyntax interfaceDeclaration 	=> interfaceDeclaration.AttributeLists,
 				ConstructorDeclarationSyntax constructorDeclaration => constructorDeclaration.AttributeLists,
-				_                                                   => new SyntaxList<AttributeListSyntax>()
+				_ 													=> new SyntaxList<AttributeListSyntax>()
 			};
 
 		public static SyntaxTrivia ToSingleLineComment(this string? commentContent)
@@ -308,11 +308,11 @@ namespace Acuminator.Utilities.Roslyn.Syntax
 		public static BaseArgumentListSyntax? GetArgumentsList(this SyntaxNode callSite) =>
 			callSite switch
 			{
-				InvocationExpressionSyntax invocation                           => invocation.ArgumentList,
-				ElementAccessExpressionSyntax elementAccess                     => elementAccess.ArgumentList,
-				ObjectCreationExpressionSyntax objectCreation                   => objectCreation.ArgumentList,
-				ElementBindingExpressionSyntax elementBinding                   => elementBinding.ArgumentList,
-				_                                                               => null
+				InvocationExpressionSyntax invocation 		  => invocation.ArgumentList,
+				ElementAccessExpressionSyntax elementAccess   => elementAccess.ArgumentList,
+				ObjectCreationExpressionSyntax objectCreation => objectCreation.ArgumentList,
+				ElementBindingExpressionSyntax elementBinding => elementBinding.ArgumentList,
+				_ 											  => null
 			};
 
 		public static string? GetDocTagName(this XmlNodeSyntax docTagNode) => docTagNode switch

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Syntax/SyntaxNodeGenerationUtils.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Syntax/SyntaxNodeGenerationUtils.cs
@@ -1,4 +1,7 @@
-﻿using Acuminator.Utilities.Common;
+﻿#nullable enable
+
+using Acuminator.Utilities.Common;
+
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -15,7 +18,7 @@ namespace Acuminator.Utilities.Roslyn.Syntax
 		/// <returns></returns>
 		public static AttributeListSyntax GetAttributeList(this INamedTypeSymbol type, AttributeArgumentListSyntax argumentList = null)
 		{
-			type.ThrowOnNull(nameof(type));
+			type.ThrowOnNull();
 
 			var node = SyntaxFactory.Attribute(
 				SyntaxFactory.IdentifierName(

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Syntax/SyntaxTreeUtils.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Syntax/SyntaxTreeUtils.cs
@@ -82,7 +82,7 @@ namespace Acuminator.Utilities.Roslyn.Syntax
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static int Depth(this SyntaxNode node)
 		{
-			node.ThrowOnNull(nameof(node));
+			node.ThrowOnNull();
 
 			int depth = 0;
 			SyntaxNode curNode = node.Parent;
@@ -107,7 +107,7 @@ namespace Acuminator.Utilities.Roslyn.Syntax
 		public static int Depth<TRoot>(this SyntaxNode node)
 		where TRoot : SyntaxNode
 		{
-			node.ThrowOnNull(nameof(node));
+			node.ThrowOnNull();
 
 			if (node is TRoot)
 				return 0;
@@ -138,7 +138,7 @@ namespace Acuminator.Utilities.Roslyn.Syntax
 		where TRoot : SyntaxNode
 		where TNode : SyntaxNode
 		{
-			node.ThrowOnNull(nameof(node));
+			node.ThrowOnNull();
 
 			if (node is TRoot)
 				return 0;
@@ -157,9 +157,6 @@ namespace Acuminator.Utilities.Roslyn.Syntax
 
 		public static SyntaxNode LowestCommonAncestor(SyntaxNode nodeX, SyntaxNode nodeY)
 		{
-			nodeX.ThrowOnNull(nameof(nodeX));
-			nodeY.ThrowOnNull(nameof(nodeY));
-
 			int depthX = nodeX.Depth();            //Depth is average O(log n) operation, worst case is O(n) but it isn't the case for the syntax tree which is wide but not very deep
 			int depthY = nodeY.Depth();
 

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Walkers/DelegatesWalkerBase.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Walkers/DelegatesWalkerBase.cs
@@ -35,7 +35,7 @@ namespace Acuminator.Utilities.Roslyn.Walkers
 		/// </returns>
 		protected (ISymbol? DelegateSymbol, SyntaxNode? DelegateNode) GetDelegateSymbolAndNode(ExpressionSyntax delegateExpression)
 		{
-			delegateExpression.ThrowOnNull(nameof(delegateExpression));
+			delegateExpression.ThrowOnNull();
 			ThrowIfCancellationRequested();
 
 			switch (delegateExpression)
@@ -88,7 +88,7 @@ namespace Acuminator.Utilities.Roslyn.Walkers
 		/// </returns>
 		protected SyntaxNode? GetDelegateNode(ExpressionSyntax delegateExpression)
 		{
-			delegateExpression.ThrowOnNull(nameof(delegateExpression));
+			delegateExpression.ThrowOnNull();
 			ThrowIfCancellationRequested();
 
 			switch (delegateExpression)

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Walkers/PXGraphCreateInstanceWalker.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Walkers/PXGraphCreateInstanceWalker.cs
@@ -28,7 +28,7 @@ namespace Acuminator.Utilities.Roslyn.Walkers
 			: base(pxContext, context.CancellationToken)
 		{
 			_context = context;
-			_descriptor = descriptor.CheckIfNull(nameof(descriptor));
+			_descriptor = descriptor.CheckIfNull();
 		}
 
 		public override void VisitMemberAccessExpression(MemberAccessExpressionSyntax node)

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Walkers/ParametersReassignedFinder.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Walkers/ParametersReassignedFinder.cs
@@ -42,9 +42,9 @@ namespace Acuminator.Utilities.Roslyn.Walkers
 																	  IReadOnlyCollection<string> parametersToCheck, SemanticModel semanticModel,
 																	  CancellationToken cancellation)
 		{
-			declarationNode.ThrowOnNull(nameof(declarationNode));
-			parametersToCheck.ThrowOnNull(nameof(parametersToCheck));
-			semanticModel.ThrowOnNull(nameof(semanticModel));
+			declarationNode.ThrowOnNull();
+			parametersToCheck.ThrowOnNull();
+			semanticModel.ThrowOnNull();
 
 			if (callSite != null && !declarationNode.Contains(callSite))
 				throw new ArgumentOutOfRangeException(nameof(callSite), "The call site node must be a descendant of the declaration node");

--- a/src/Acuminator/Acuminator.Utilities/Settings/GlobalCodeAnalysisSettings.cs
+++ b/src/Acuminator/Acuminator.Utilities/Settings/GlobalCodeAnalysisSettings.cs
@@ -23,7 +23,7 @@ namespace Acuminator.Utilities
 		/// <param name="instance">The instance.</param>
 		public static void InitializeGlobalSettingsOnce(CodeAnalysisSettings instance)
 		{
-			instance.ThrowOnNull(nameof(instance));
+			instance.ThrowOnNull();
 
 			if (Interlocked.CompareExchange(ref _isInitialized, value: INITIALIZED, comparand: NOT_INITIALIZED) == NOT_INITIALIZED)
 			{

--- a/src/Acuminator/Acuminator.Utilities/Settings/OutOfProcess/CodeAnalysisSettingsBinaryWriter.cs
+++ b/src/Acuminator/Acuminator.Utilities/Settings/OutOfProcess/CodeAnalysisSettingsBinaryWriter.cs
@@ -19,7 +19,7 @@ namespace Acuminator.Utilities.Settings.OutOfProcess
 
 		public void WriteCodeAnalysisSettings(CodeAnalysisSettings codeAnalysisSettings)
 		{
-			codeAnalysisSettings.ThrowOnNull(nameof(codeAnalysisSettings));
+			codeAnalysisSettings.ThrowOnNull();
 
 			if (_isDisposed)
 				throw new ObjectDisposedException(objectName: nameof(CodeAnalysisSettingsBinaryWriter));

--- a/src/Acuminator/Acuminator.Utilities/Settings/VSVersion.cs
+++ b/src/Acuminator/Acuminator.Utilities/Settings/VSVersion.cs
@@ -10,7 +10,7 @@ namespace Acuminator.Utilities
 	/// <summary>
 	/// The Visual Studio version information.
 	/// </summary>
-	public class VSVersion
+	public class VSVersion(Version version)
 	{
 		public const int UnknownVersion = 0;
 
@@ -24,7 +24,7 @@ namespace Acuminator.Utilities
 		public const int VS2019 = 16;
 		public const int VS2022 = 17;
 
-		public Version FullVersion { get; }
+		public Version FullVersion { get; } = version.CheckIfNull();
 
 		public bool VS2013OrOlder => FullVersion.Major <= VS2013 && FullVersion.Major != UnknownVersion;
 
@@ -55,10 +55,5 @@ namespace Acuminator.Utilities
 		public bool IsVS2019 => FullVersion.Major == VS2019;
 
 		public bool IsVS2022 => FullVersion.Major == VS2022;
-
-		public VSVersion(Version version)
-		{
-			FullVersion = version.CheckIfNull(nameof(version));
-		}
 	}
 }

--- a/src/Acuminator/Acuminator.Vsix/Code Snippets/CodeSnippetsInitializer.cs
+++ b/src/Acuminator/Acuminator.Vsix/Code Snippets/CodeSnippetsInitializer.cs
@@ -65,7 +65,7 @@ namespace Acuminator.Vsix.CodeSnippets
 		/// </returns>
 		public bool InitializeCodeSnippets(Version packageVersion)
 		{
-			packageVersion.ThrowOnNull(nameof(packageVersion));
+			packageVersion.ThrowOnNull();
 			
 			if (!IsSnippetsFolderInitialized)
 				return false;

--- a/src/Acuminator/Acuminator.Vsix/Code Snippets/SnippetsVersionFile.cs
+++ b/src/Acuminator/Acuminator.Vsix/Code Snippets/SnippetsVersionFile.cs
@@ -27,8 +27,8 @@ namespace Acuminator.Vsix.CodeSnippets
 
 		public bool WriteVersionFile(string snippetsRootFolder, Version version)
 		{
-			version.ThrowOnNull(nameof(version));
-			snippetsRootFolder.ThrowOnNullOrWhiteSpace(nameof(snippetsRootFolder));
+			version.ThrowOnNull();
+			snippetsRootFolder.ThrowOnNullOrWhiteSpace();
 
 			string snippetsVersionFilePath = Path.Combine(snippetsRootFolder, VersionFileName);
 			var root = new XElement(RootNode, version);

--- a/src/Acuminator/Acuminator.Vsix/Coloriser/AsyncTagging/BackgroundTagging.cs
+++ b/src/Acuminator/Acuminator.Vsix/Coloriser/AsyncTagging/BackgroundTagging.cs
@@ -16,7 +16,7 @@ namespace Acuminator.Vsix.Coloriser
     {
         private static TaskScheduler _vsTaskScheduler;
 
-        private CancellationTokenSource _cancellationTokenSource = new CancellationTokenSource();
+        private CancellationTokenSource _cancellationTokenSource = new();
 
         public CancellationToken CancellationToken => _cancellationTokenSource.Token;
 
@@ -31,9 +31,9 @@ namespace Acuminator.Vsix.Coloriser
 
         public static BackgroundTagging StartBackgroundTagging(PXColorizerTaggerBase tagger)
         {
-            tagger.ThrowOnNull(nameof(tagger));
+            tagger.ThrowOnNull();
 
-            BackgroundTagging backgroundTagging = new BackgroundTagging();
+            var backgroundTagging = new BackgroundTagging();
             var taggingTask = tagger.GetTagsAsyncImplementationAsync(tagger.Snapshot, backgroundTagging.CancellationToken);
 
             if (taggingTask == null)

--- a/src/Acuminator/Acuminator.Vsix/Coloriser/Base/PXTaggerBase.cs
+++ b/src/Acuminator/Acuminator.Vsix/Coloriser/Base/PXTaggerBase.cs
@@ -64,11 +64,8 @@ namespace Acuminator.Vsix.Coloriser
 
         protected PXTaggerBase(ITextBuffer buffer, PXTaggerProviderBase provider, bool subscribeToSettingsChanges, bool useCacheChecking)
         {
-            buffer.ThrowOnNull(nameof(buffer));
-            provider.ThrowOnNull(nameof(provider));
-
-            Buffer = buffer;
-            ProviderBase = provider;
+            Buffer = buffer.CheckIfNull();
+            ProviderBase = provider.CheckIfNull();
             SubscribedToSettingsChanges = subscribeToSettingsChanges;
             CacheCheckingEnabled = useCacheChecking;
 

--- a/src/Acuminator/Acuminator.Vsix/Coloriser/Formats/Theme/AcuminatorThemeChangedEventArgs.cs
+++ b/src/Acuminator/Acuminator.Vsix/Coloriser/Formats/Theme/AcuminatorThemeChangedEventArgs.cs
@@ -10,20 +10,14 @@ using Acuminator.Utilities.Common;
 
 namespace Acuminator.Vsix.Coloriser
 {
-    internal class AcuminatorThemeChangedEventArgs : EventArgs
+    internal class AcuminatorThemeChangedEventArgs(IVsFontAndColorStorage fontAndColorStorage, 
+												   IClassificationTypeRegistryService classificationTypeRegistry,
+												   IClassificationFormatMap formatMap) : EventArgs
     {
-        public IVsFontAndColorStorage FontAndColorStorage { get; }
+		public IVsFontAndColorStorage FontAndColorStorage { get; } = fontAndColorStorage.CheckIfNull();
 
-        public IClassificationTypeRegistryService ClassificationTypeRegistry { get; }
+		public IClassificationTypeRegistryService ClassificationTypeRegistry { get; } = classificationTypeRegistry.CheckIfNull();
 
-        public IClassificationFormatMap FormatMap { get; }
-
-        public AcuminatorThemeChangedEventArgs(IVsFontAndColorStorage fontAndColorStorage, IClassificationTypeRegistryService classificationTypeRegistry,
-                                               IClassificationFormatMap formatMap)
-		{
-            FontAndColorStorage = fontAndColorStorage.CheckIfNull(nameof(fontAndColorStorage));
-            ClassificationTypeRegistry = classificationTypeRegistry.CheckIfNull(nameof(classificationTypeRegistry));
-            FormatMap = formatMap;
-        }
-    }
+		public IClassificationFormatMap FormatMap { get; } = formatMap;
+	}
 }

--- a/src/Acuminator/Acuminator.Vsix/Coloriser/Formats/Theme/ThemeUpdater.cs
+++ b/src/Acuminator/Acuminator.Vsix/Coloriser/Formats/Theme/ThemeUpdater.cs
@@ -41,7 +41,7 @@ namespace Acuminator.Vsix.Coloriser
 			ThreadHelper.ThrowIfNotOnUIThread();
 
 			_serviceProvider = (AcuminatorVSPackage.Instance as IServiceProvider) ?? ServiceProvider.GlobalProvider;
-			_serviceProvider.ThrowOnNull(nameof(_serviceProvider));
+			_serviceProvider.ThrowOnNull();
 
 			VSColorTheme.ThemeChanged += VSColorTheme_ThemeChanged;
 		}

--- a/src/Acuminator/Acuminator.Vsix/Coloriser/Roslyn/PXColoriserSyntaxWalker.cs
+++ b/src/Acuminator/Acuminator.Vsix/Coloriser/Roslyn/PXColoriserSyntaxWalker.cs
@@ -42,11 +42,8 @@ namespace Acuminator.Vsix.Coloriser
             public PXColoriserSyntaxWalker(PXRoslynColorizerTagger tagger, ParsedDocument parsedDocument, CancellationToken cToken) :
                                       base(SyntaxWalkerDepth.Node)
 			{
-				tagger.ThrowOnNull(nameof(tagger));
-				parsedDocument.ThrowOnNull(nameof(parsedDocument));
-
-				_tagger = tagger;
-				_document = parsedDocument;
+				_tagger = tagger.CheckIfNull();
+				_document = parsedDocument.CheckIfNull();
                 _cancellationToken = cToken;
             }
 
@@ -94,7 +91,7 @@ namespace Acuminator.Vsix.Coloriser
                 if (!_cancellationToken.IsCancellationRequested)
                     base.VisitIdentifierName(node);
 
-                UpdateCodeEditorIfNecessary();				
+                UpdateCodeEditorIfNecessary();
             }
 
             public override void VisitGenericName(GenericNameSyntax genericNode)

--- a/src/Acuminator/Acuminator.Vsix/Commands/BQL Fixer/FixBqlCommand.cs
+++ b/src/Acuminator/Acuminator.Vsix/Commands/BQL Fixer/FixBqlCommand.cs
@@ -139,8 +139,8 @@ namespace Acuminator.Vsix.BqlFixer
 
 		private void ApplyChanges(Document oldDocument, Document newDocument)
 		{
-			oldDocument.ThrowOnNull(nameof(oldDocument));
-			newDocument.ThrowOnNull(nameof(newDocument));
+			oldDocument.ThrowOnNull();
+			newDocument.ThrowOnNull();
 
 			Workspace workspace = oldDocument.Project?.Solution?.Workspace;
 			Solution newSolution = newDocument.Project?.Solution;

--- a/src/Acuminator/Acuminator.Vsix/Commands/DiagnosticSuppression/BuildAction/VsixBuildActionSetterVS2019.cs
+++ b/src/Acuminator/Acuminator.Vsix/Commands/DiagnosticSuppression/BuildAction/VsixBuildActionSetterVS2019.cs
@@ -20,8 +20,8 @@ namespace Acuminator.Vsix.DiagnosticSuppression
 	{
 		public bool SetBuildAction(string roslynSuppressionFilePath, string buildActionToSet)
 		{
-			roslynSuppressionFilePath.ThrowOnNullOrWhiteSpace(nameof(roslynSuppressionFilePath));
-			buildActionToSet.ThrowOnNullOrWhiteSpace(nameof(buildActionToSet));
+			roslynSuppressionFilePath.ThrowOnNullOrWhiteSpace();
+			buildActionToSet.ThrowOnNullOrWhiteSpace();
 
 			if (SharedVsSettings.VSVersion.VS2022OrNewer)
 				return false;

--- a/src/Acuminator/Acuminator.Vsix/Commands/DiagnosticSuppression/BuildAction/VsixBuildActionSetterVS2022.cs
+++ b/src/Acuminator/Acuminator.Vsix/Commands/DiagnosticSuppression/BuildAction/VsixBuildActionSetterVS2022.cs
@@ -22,8 +22,8 @@ namespace Acuminator.Vsix.DiagnosticSuppression
 	{
 		public bool SetBuildAction(string roslynSuppressionFilePath, string buildActionToSet)
 		{
-			roslynSuppressionFilePath.ThrowOnNullOrWhiteSpace(nameof(roslynSuppressionFilePath));
-			buildActionToSet.ThrowOnNullOrWhiteSpace(nameof(buildActionToSet));
+			roslynSuppressionFilePath.ThrowOnNullOrWhiteSpace();
+			buildActionToSet.ThrowOnNullOrWhiteSpace();
 
 			if (!SharedVsSettings.VSVersion.VS2022OrNewer)
 				return false;

--- a/src/Acuminator/Acuminator.Vsix/Commands/DiagnosticSuppression/Diagnostic Service/DiagnosticData.cs
+++ b/src/Acuminator/Acuminator.Vsix/Commands/DiagnosticSuppression/Diagnostic Service/DiagnosticData.cs
@@ -61,7 +61,7 @@ namespace Acuminator.Vsix.DiagnosticSuppression
 
 		public static DiagnosticData Create(object roslynDiagnosticDTO)
 		{
-			roslynDiagnosticDTO.ThrowOnNull(nameof(roslynDiagnosticDTO));
+			roslynDiagnosticDTO.ThrowOnNull();
 
 			InitializeSharedStaticData(roslynDiagnosticDTO);
 

--- a/src/Acuminator/Acuminator.Vsix/Commands/DiagnosticSuppression/Diagnostic Service/DiagnosticDataLocation.cs
+++ b/src/Acuminator/Acuminator.Vsix/Commands/DiagnosticSuppression/Diagnostic Service/DiagnosticDataLocation.cs
@@ -60,7 +60,7 @@ namespace Acuminator.Vsix.DiagnosticSuppression
 
 		public static DiagnosticDataLocation Create(object roslynLocationDTO)
 		{
-			roslynLocationDTO.ThrowOnNull(nameof(roslynLocationDTO));
+			roslynLocationDTO.ThrowOnNull();
 
 			InitializeSharedStaticData(roslynLocationDTO);
 

--- a/src/Acuminator/Acuminator.Vsix/Commands/DiagnosticSuppression/Diagnostic Service/RoslynDTOWrapperBase.cs
+++ b/src/Acuminator/Acuminator.Vsix/Commands/DiagnosticSuppression/Diagnostic Service/RoslynDTOWrapperBase.cs
@@ -45,7 +45,7 @@ namespace Acuminator.Vsix.DiagnosticSuppression
 
 		protected static void InitializeSharedStaticData(object roslynDTO)
 		{
-			roslynDTO.ThrowOnNull(nameof(roslynDTO));
+			roslynDTO.ThrowOnNull();
 
 			if (Interlocked.CompareExchange(ref _areStaticMembersInitialized, value: INITIALIZED, comparand: NOT_INITIALIZED) == NOT_INITIALIZED)
 			{

--- a/src/Acuminator/Acuminator.Vsix/Commands/DiagnosticSuppression/VsixIOErrorProcessor.cs
+++ b/src/Acuminator/Acuminator.Vsix/Commands/DiagnosticSuppression/VsixIOErrorProcessor.cs
@@ -15,7 +15,7 @@ namespace Acuminator.Vsix.DiagnosticSuppression
 	{
 		public void ProcessError(Exception exception, [CallerMemberName]string reportedFrom = null)
 		{
-			exception.ThrowOnNull(nameof(exception));
+			exception.ThrowOnNull();
 
 			string errorMsg = Resources.FailedToLoadTheSuppressionFile + Environment.NewLine + Environment.NewLine +
 							  string.Format(Resources.FailedToLoadTheSuppressionFileDetails, Environment.NewLine + exception.Message);

--- a/src/Acuminator/Acuminator.Vsix/Commands/Formatter/BqlFormatter.cs
+++ b/src/Acuminator/Acuminator.Vsix/Commands/Formatter/BqlFormatter.cs
@@ -43,7 +43,7 @@ namespace Acuminator.Vsix.Formatter
 
 		public static BqlFormatter FromTextView(IWpfTextView textView)
 		{
-			textView.ThrowOnNull(nameof(textView));
+			textView.ThrowOnNull();
 
 			int indentSize = textView.Options.GetOptionValue(DefaultOptions.IndentSizeOptionId);
 			int tabSize = textView.Options.GetOptionValue(DefaultOptions.TabSizeOptionId);

--- a/src/Acuminator/Acuminator.Vsix/Commands/Formatter/FormatBqlCommand.cs
+++ b/src/Acuminator/Acuminator.Vsix/Commands/Formatter/FormatBqlCommand.cs
@@ -130,8 +130,8 @@ namespace Acuminator.Vsix.Formatter
 
 		private void ApplyChanges(Document oldDocument, Document newDocument)
 		{
-			oldDocument.ThrowOnNull(nameof(oldDocument));
-			newDocument.ThrowOnNull(nameof(newDocument));
+			oldDocument.ThrowOnNull();
+			newDocument.ThrowOnNull();
 
 			Workspace workspace = oldDocument.Project?.Solution?.Workspace;
 			Solution newSolution = newDocument.Project?.Solution;

--- a/src/Acuminator/Acuminator.Vsix/Commands/VSCommandBase.cs
+++ b/src/Acuminator/Acuminator.Vsix/Commands/VSCommandBase.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#nullable enable
+
+using System;
 using System.ComponentModel.Design;
 using System.Linq;
 using EnvDTE;
@@ -44,23 +46,19 @@ namespace Acuminator.Vsix
 		/// <param name="package">Owner package, not null.</param>
 		protected VSCommandBase(AsyncPackage package, OleMenuCommandService commandService, int commandID, Guid? customCommandSet = null)
 		{
-			package.ThrowOnNull(nameof(package));
-			commandService.ThrowOnNull(nameof(commandService));
+			commandService.ThrowOnNull();
 
-			Package = package;
+			Package = package.CheckIfNull();
 			Guid commandSet = customCommandSet ?? DefaultCommandSet;
 
-			if (commandService != null)
+			var menuCommandID = new CommandID(commandSet, commandID);
+			var menuItem = new OleMenuCommand(CommandCallback, menuCommandID)
 			{
-				var menuCommandID = new CommandID(commandSet, commandID);
-				var menuItem = new OleMenuCommand(CommandCallback, menuCommandID)
-				{
-					// This defers the visibility logic back to the VisibilityConstraints in the .vsct file
-					Supported = false
-				};
+				// This defers the visibility logic back to the VisibilityConstraints in the .vsct file
+				Supported = false
+			};
 
-				commandService.AddCommand(menuItem);
-			}
+			commandService.AddCommand(menuItem);
 		}
 
 		/// <summary>

--- a/src/Acuminator/Acuminator.Vsix/Settings/OutOfProcess/OutOfProcessSettingValueProvider.cs
+++ b/src/Acuminator/Acuminator.Vsix/Settings/OutOfProcess/OutOfProcessSettingValueProvider.cs
@@ -20,7 +20,7 @@ namespace Acuminator.Vsix.Settings
 	{
 		internal static bool IsOutOfProcessEnabled(this AcuminatorVSPackage package, Workspace workspace)
 		{
-			package.ThrowOnNull(nameof(package));
+			package.ThrowOnNull();
 			package.VSVersion.ThrowOnNull($"{nameof(AcuminatorVSPackage)}.{nameof(AcuminatorVSPackage.VSVersion)}");
 
 			if (!package.VSVersion.VS2019OrNewer)
@@ -44,7 +44,7 @@ namespace Acuminator.Vsix.Settings
 				MethodInfo isUsingServiceHubOutOfProcess = remoteHostOptionsType?.GetMethod("IsUsingServiceHubOutOfProcess",
 																							BindingFlags.Static | BindingFlags.Public);
 
-				object isOutOfProcessFromRoslynInternalsObj = isUsingServiceHubOutOfProcess?.Invoke(null, new object[] { workspace.Services });
+				object isOutOfProcessFromRoslynInternalsObj = isUsingServiceHubOutOfProcess?.Invoke(null, [workspace.Services]);
 
 				if (isOutOfProcessFromRoslynInternalsObj is bool isOutOfProcessFromRoslynInternals)
 					return isOutOfProcessFromRoslynInternals;

--- a/src/Acuminator/Acuminator.Vsix/Settings/OutOfProcess/OutOfProcessSettingsUpdater.cs
+++ b/src/Acuminator/Acuminator.Vsix/Settings/OutOfProcess/OutOfProcessSettingsUpdater.cs
@@ -23,9 +23,9 @@ namespace Acuminator.Vsix.Settings
 
 		public OutOfProcessSettingsUpdater(ISettingsEvents settingsEvents, CodeAnalysisSettings initialSettings)
 		{
-			initialSettings.ThrowOnNull(nameof(initialSettings));
+			initialSettings.ThrowOnNull();
 
-			_settingsEvents = settingsEvents.CheckIfNull(nameof(settingsEvents));
+			_settingsEvents = settingsEvents.CheckIfNull();
 			_memoryMappedFile = CreateOrOpenMemoryMappedFile();
 
 			WriteSettingsToSharedMemory(initialSettings);

--- a/src/Acuminator/Acuminator.Vsix/Settings/SettingChangedEventArgs.cs
+++ b/src/Acuminator/Acuminator.Vsix/Settings/SettingChangedEventArgs.cs
@@ -12,7 +12,7 @@ namespace Acuminator.Vsix.Settings
 
         public SettingChangedEventArgs(string settingName) 
         {
-            SettingName = settingName.CheckIfNullOrWhiteSpace(nameof(settingName));
+            SettingName = settingName.CheckIfNullOrWhiteSpace();
         }
     }
 }

--- a/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/Model/DocumentModel.cs
+++ b/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/Model/DocumentModel.cs
@@ -48,11 +48,8 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 
 		public DocumentModel(IWpfTextView wpfTextView, Document document)
 		{
-			wpfTextView.ThrowOnNull(nameof(wpfTextView));
-			document.ThrowOnNull(nameof(document));
-			
-			WpfTextView = wpfTextView;
-			Document = document;
+			WpfTextView = wpfTextView.CheckIfNull();
+			Document = document.CheckIfNull();
 			CodeMapSemanticModels = _codeMapSemanticModels.AsReadOnly();
 		}
 

--- a/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/Model/GraphSemanticModelForCodeMap.cs
+++ b/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/Model/GraphSemanticModelForCodeMap.cs
@@ -26,10 +26,9 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 
 		public GraphSemanticModelForCodeMap(PXGraphEventSemanticModel graphEventSemanticModel, PXContext context)
 		{
-			graphEventSemanticModel.ThrowOnNull(nameof(graphEventSemanticModel));
-			context.ThrowOnNull(nameof(context));
+			context.ThrowOnNull();
 
-			GraphModel = graphEventSemanticModel;
+			GraphModel = graphEventSemanticModel.CheckIfNull();
 			InstanceConstructors = GetInstanceConstructors(graphEventSemanticModel.Symbol, context).ToImmutableArray();
 			BaseMemberOverrides = GetBaseMemberOverrides(graphEventSemanticModel.Symbol, context).ToImmutableArray();
 		}

--- a/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/Model/SemanticModelCreation/RootCandidateSymbolsRetrieverDefault.cs
+++ b/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/Model/SemanticModelCreation/RootCandidateSymbolsRetrieverDefault.cs
@@ -28,9 +28,9 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 																								SemanticModel semanticModel,
 																								CancellationToken cancellationToken = default)
 		{
-			treeRoot.ThrowOnNull(nameof(treeRoot));
-			context.ThrowOnNull(nameof(context));
-			semanticModel.ThrowOnNull(nameof(semanticModel));
+			treeRoot.ThrowOnNull();
+			context.ThrowOnNull();
+			semanticModel.ThrowOnNull();
 
 			cancellationToken.ThrowIfCancellationRequested();
 			return GetDeclaredCodeMapRoots(treeRoot, context, semanticModel, cancellationToken);

--- a/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/Model/SemanticModelCreation/SemanticModelFactoryDefault.cs
+++ b/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/Model/SemanticModelCreation/SemanticModelFactoryDefault.cs
@@ -31,8 +31,8 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 		public virtual bool TryToInferSemanticModel(INamedTypeSymbol rootSymbol, SyntaxNode rootNode, PXContext context, out ISemanticModel semanticModel, 
 													CancellationToken cancellationToken = default)
 		{
-			rootSymbol.ThrowOnNull(nameof(rootSymbol));
-			context.ThrowOnNull(nameof(context));
+			rootSymbol.ThrowOnNull();
+			context.ThrowOnNull();
 			cancellationToken.ThrowIfCancellationRequested();
 
 			if (rootSymbol.IsPXGraphOrExtension(context))

--- a/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/Utils/CodeMapDocChangesClassifier.cs
+++ b/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/Utils/CodeMapDocChangesClassifier.cs
@@ -25,7 +25,7 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 
 		public CodeMapDocChangesClassifier(CodeMapWindowViewModel codeMapWindowViewModel)
 		{
-			_codeMapViewModel = codeMapWindowViewModel.CheckIfNull(nameof(codeMapWindowViewModel));
+			_codeMapViewModel = codeMapWindowViewModel.CheckIfNull();
 		}
 
 		public async Task<CodeMapRefreshMode> ShouldRefreshCodeMapAsync(Document oldDocument, SyntaxNode newRoot, Document newDocument,

--- a/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/VSEventsAdapter/VS2022/VSEventsAdapterVS2022.cs
+++ b/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/VSEventsAdapter/VS2022/VSEventsAdapterVS2022.cs
@@ -163,9 +163,9 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 
 				// Following objects should not be null. Null will indicate a corrupted state so ArgumentNullException will be thrown here. 
 				// If these ogjects are null the adapter mechanism will log ArgumentNullException in VS ActivityLog
-				adapterHandlerMethodInfo.ThrowOnNull(nameof(adapterHandlerMethodInfo));
-				eventObject.ThrowOnNull(nameof(eventObject));
-				eventInfo.ThrowOnNull(nameof(eventInfo));	
+				adapterHandlerMethodInfo.ThrowOnNull();
+				eventObject.ThrowOnNull();
+				eventInfo.ThrowOnNull();	
 
 				try
 				{

--- a/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/Base/TreeNodeViewModel.cs
+++ b/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/Base/TreeNodeViewModel.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#nullable enable
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -6,7 +8,6 @@ using System.Threading.Tasks;
 using System.Windows;
 using Acuminator.Utilities.Common;
 using Acuminator.Vsix.Utilities;
-
 
 namespace Acuminator.Vsix.ToolWindows.CodeMap
 {
@@ -26,7 +27,7 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 		/// </summary>
 		public abstract Icon NodeIcon { get; }
 
-		public virtual ExtendedObservableCollection<ExtraInfoViewModel> ExtraInfos => null;
+		public virtual ExtendedObservableCollection<ExtraInfoViewModel>? ExtraInfos => null;
 
 		private SortType? _childrenSortType;
 
@@ -64,7 +65,7 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 			}
 		}
 
-		public TreeNodeViewModel Parent { get; }
+		public TreeNodeViewModel? Parent { get; }
 
 		public bool IsRoot => Parent == null;
 
@@ -82,7 +83,7 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 					_isExpanded = value;
 					NotifyPropertyChanged();
 
-					Descendants().ForEach(node => node.NotifyPropertyChanged(nameof(AreDetailsVisible)));
+					Descendants().ForEach(node => node!.NotifyPropertyChanged(nameof(AreDetailsVisible)));
 				}
 			}
 		}
@@ -122,11 +123,9 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 
 		public virtual bool AreDetailsVisible => ShouldShowDetails();
 
-		protected TreeNodeViewModel(TreeViewModel tree, TreeNodeViewModel parent, bool isExpanded = true)
+		protected TreeNodeViewModel(TreeViewModel tree, TreeNodeViewModel? parent, bool isExpanded = true)
 		{
-			tree.ThrowOnNull(nameof(tree));
-
-			Tree = tree;
+			Tree = tree.CheckIfNull();
 			Parent = parent;
 			_isExpanded = isExpanded;
 		}
@@ -142,7 +141,7 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 		public virtual void ExpandOrCollapseAll(bool expand)
 		{
 			IsExpanded = expand;
-			Children.ForEach(childNode => childNode.ExpandOrCollapseAll(expand));
+			Children.ForEach(childNode => childNode!.ExpandOrCollapseAll(expand));
 		}
 
 		public IEnumerable<TreeNodeViewModel> Descendants()
@@ -167,7 +166,7 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 			if (IsRoot)
 				return true;
 
-			TreeNodeViewModel curAncestor = Parent;
+			TreeNodeViewModel? curAncestor = Parent;
 
 			while (curAncestor != null)
 			{

--- a/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/Builders/Base/TreeBuilderBase.cs
+++ b/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/Builders/Base/TreeBuilderBase.cs
@@ -34,7 +34,7 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 
 		public TreeViewModel? BuildCodeMapTree(CodeMapWindowViewModel windowViewModel, bool expandRoots, bool expandChildren, CancellationToken cancellation)
 		{
-			windowViewModel.ThrowOnNull(nameof(windowViewModel));
+			windowViewModel.ThrowOnNull();
 
 			try
 			{

--- a/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/Builders/Dac/DefaultCodeMapTreeBuilder_Dac.cs
+++ b/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/Builders/Dac/DefaultCodeMapTreeBuilder_Dac.cs
@@ -57,14 +57,14 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 
 		public override IEnumerable<TreeNodeViewModel> VisitNode(DacKeysCategoryNodeViewModel dacKeysCategory)
 		{
-			dacKeysCategory.ThrowOnNull(nameof(dacKeysCategory));
+			dacKeysCategory.ThrowOnNull();
 			return CreateDacMemberCategoryChildren<DacPropertyInfo>(dacKeysCategory,
 																	propertyInfo => new PropertyNodeViewModel(dacKeysCategory, propertyInfo, ExpandCreatedNodes));
 		}
 
 		public override IEnumerable<TreeNodeViewModel> VisitNode(DacPropertiesCategoryNodeViewModel dacPropertiesCategory)
 		{
-			dacPropertiesCategory.ThrowOnNull(nameof(dacPropertiesCategory));
+			dacPropertiesCategory.ThrowOnNull();
 			return CreateDacMemberCategoryChildren<DacPropertyInfo>(dacPropertiesCategory, 
 																	propertyInfo => new PropertyNodeViewModel(dacPropertiesCategory, propertyInfo, ExpandCreatedNodes));
 		}
@@ -92,10 +92,7 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 			}
 		}
 
-		public override IEnumerable<TreeNodeViewModel> VisitNode(PropertyNodeViewModel property)
-		{
-			property.ThrowOnNull(nameof(property));
-			return property.PropertyInfo.Attributes.Select(a => new AttributeNodeViewModel(property, a.AttributeData, ExpandCreatedNodes));
-		}
+		public override IEnumerable<TreeNodeViewModel> VisitNode(PropertyNodeViewModel property) =>
+			property.CheckIfNull().PropertyInfo.Attributes.Select(a => new AttributeNodeViewModel(property, a.AttributeData, ExpandCreatedNodes));
 	}
 }

--- a/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/Builders/Graph/DefaultCodeMapTreeBuilder_Graph.cs
+++ b/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/Builders/Graph/DefaultCodeMapTreeBuilder_Graph.cs
@@ -101,7 +101,7 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 																								  Func<TSymbolInfo, TreeNodeViewModel> constructor)
 		where TSymbolInfo : SymbolItem
 		{
-			IEnumerable<SymbolItem> categoryTreeNodes = graphMemberCategory.CheckIfNull(nameof(graphMemberCategory))
+			IEnumerable<SymbolItem> categoryTreeNodes = graphMemberCategory.CheckIfNull()
 																		   .GetCategoryGraphNodeSymbols();
 			if (categoryTreeNodes.IsNullOrEmpty())
 				return DefaultValue;
@@ -132,7 +132,7 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 																									   DacVmConstructor<TGraphEventInfo> constructor)
 		where TGraphEventInfo : GraphEventInfoBase<TGraphEventInfo>
 		{
-			graphEventCategory.ThrowOnNull(nameof(graphEventCategory));
+			graphEventCategory.ThrowOnNull();
 
 			var graphSemanticModel = graphEventCategory.GraphViewModel.GraphSemanticModel;
 			var graphCategoryEvents = graphEventCategory.GetCategoryGraphNodeSymbols()

--- a/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/CodeMapWindowViewModel.cs
+++ b/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/CodeMapWindowViewModel.cs
@@ -61,7 +61,7 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 				{
 					_documentModel = value;
 					NotifyPropertyChanged();
-					NotifyPropertyChanged(nameof(Document));
+					NotifyPropertyChanged();
 				}
 			}
 		}
@@ -151,7 +151,7 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 		/// </summary>
 		private CodeMapWindowViewModel(Workspace workspace)
 		{
-			Workspace = workspace.CheckIfNull(nameof(workspace));
+			Workspace = workspace.CheckIfNull();
 
 			RootSymbolsRetriever = new RootCandidateSymbolsRetrieverDefault();
 			SemanticModelFactory = new SemanticModelFactoryDefault();

--- a/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/ExtraInfo/Base/ExtraInfoViewModel.cs
+++ b/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/ExtraInfo/Base/ExtraInfoViewModel.cs
@@ -15,7 +15,7 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 
 		protected ExtraInfoViewModel(TreeNodeViewModel node)
 		{
-			Node = node.CheckIfNull(nameof(node));
+			Node = node.CheckIfNull();
 		}
 	}
 }

--- a/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/ExtraInfo/TextViewModel.cs
+++ b/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/ExtraInfo/TextViewModel.cs
@@ -36,7 +36,7 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 		public TextViewModel(TreeNodeViewModel node, string text, Color? darkThemeForeground = null, Color? lightThemeForeground = null) :
 						base(node)
 		{
-			Text = text.CheckIfNull(nameof(text));
+			Text = text.CheckIfNull();
 			DarkThemeForeground = darkThemeForeground;
 			LightThemeForeground = lightThemeForeground;
 		}

--- a/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/Nodes/AttributeNodeViewModel.cs
+++ b/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/Nodes/AttributeNodeViewModel.cs
@@ -36,9 +36,7 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 		public AttributeNodeViewModel(TreeNodeViewModel nodeVM, AttributeData attribute, bool isExpanded = false) :
 								 base(nodeVM?.Tree, nodeVM, isExpanded)
 		{
-			attribute.ThrowOnNull(nameof(attribute));
-
-			Attribute = attribute;
+			Attribute = attribute.CheckIfNull();
 			int lastDotIndex = Attribute.AttributeClass.Name.LastIndexOf('.');
 			string attributeName = lastDotIndex >= 0 && lastDotIndex < Attribute.AttributeClass.Name.Length - 1
 				? Attribute.AttributeClass.Name.Substring(lastDotIndex + 1)

--- a/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/Nodes/Dac/DacMembers/Base/DacMemberNodeViewModel.cs
+++ b/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/Nodes/Dac/DacMembers/Base/DacMemberNodeViewModel.cs
@@ -1,13 +1,17 @@
-﻿using System;
+﻿#nullable enable
+
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
-using Microsoft.CodeAnalysis;
+using System.Threading.Tasks;
+
 using Acuminator.Utilities.Common;
 using Acuminator.Utilities.Roslyn.Semantic;
 using Acuminator.Vsix.Utilities;
 using Acuminator.Vsix.Utilities.Navigation;
-using System.Threading.Tasks;
+
+using Microsoft.CodeAnalysis;
 
 namespace Acuminator.Vsix.ToolWindows.CodeMap
 {
@@ -35,10 +39,8 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 									  SymbolItem memberInfo, bool isExpanded = false) :
 								 base(dacMemberCategoryVM?.Tree, parent, isExpanded)
 		{
-			memberInfo.ThrowOnNull(nameof(memberInfo));
-
-			MemberInfo = memberInfo;
-			MemberCategory = dacMemberCategoryVM;		
+			MemberInfo = memberInfo.CheckIfNull();
+			MemberCategory = dacMemberCategoryVM!;
 		}
 
 		public override Task NavigateToItemAsync() => MemberSymbol.NavigateToAsync();

--- a/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/Nodes/Dac/DacNodeViewModel.cs
+++ b/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/Nodes/Dac/DacNodeViewModel.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#nullable enable
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -34,8 +36,7 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 		public DacNodeViewModel(DacSemanticModel dacModel, TreeViewModel tree, bool isExpanded) : 
 						   base(tree, parent: null, isExpanded)
 		{
-			dacModel.ThrowOnNull(nameof(dacModel));
-			DacModel = dacModel;
+			DacModel = dacModel.CheckIfNull();
 			ExtraInfos = new ExtendedObservableCollection<ExtraInfoViewModel>(GetDacExtraInfos());
 		}
 

--- a/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/Nodes/Graph/GraphEventsGrouping/Dac/DacGroupingNodeBaseViewModel.cs
+++ b/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/Nodes/Graph/GraphEventsGrouping/Dac/DacGroupingNodeBaseViewModel.cs
@@ -54,7 +54,7 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 		protected DacGroupingNodeBaseViewModel(GraphEventCategoryNodeViewModel graphEventsCategoryVM, string dacName, bool isExpanded) :
 												base(graphEventsCategoryVM?.Tree, graphEventsCategoryVM, isExpanded)
 		{
-			dacName.ThrowOnNullOrWhiteSpace(nameof(dacName));
+			dacName.ThrowOnNullOrWhiteSpace();
 
 			GraphEventsCategoryVM = graphEventsCategoryVM;
 			DacName = dacName;

--- a/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/Nodes/Graph/GraphEventsGrouping/DacField/DacFieldGroupingNodeBaseViewModel.cs
+++ b/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/Nodes/Graph/GraphEventsGrouping/DacField/DacFieldGroupingNodeBaseViewModel.cs
@@ -42,10 +42,8 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 													bool isExpanded) :
 											  base(dacVM?.Tree, dacVM, isExpanded)
 		{
-			dacFieldName.ThrowOnNullOrWhiteSpace(nameof(dacFieldName));
-
 			DacVM = dacVM;
-			DacFieldName = dacFieldName;
+			DacFieldName = dacFieldName.CheckIfNullOrWhiteSpace();
 			FieldEvents = dacFieldEvents?.ToImmutableArray() ?? ImmutableArray.Create<GraphFieldEventInfo>();
 		}
 

--- a/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/Nodes/Graph/GraphMemberInfos/GraphMemberInfoNodeViewModel.cs
+++ b/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/Nodes/Graph/GraphMemberInfos/GraphMemberInfoNodeViewModel.cs
@@ -1,14 +1,17 @@
-﻿using System;
+﻿#nullable enable
+
+using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Linq;
-using Microsoft.CodeAnalysis;
+using System.Threading;
+using System.Threading.Tasks;
+
 using Acuminator.Utilities.Common;
 using Acuminator.Utilities.Roslyn.Semantic;
 using Acuminator.Vsix.Utilities;
 using Acuminator.Vsix.Utilities.Navigation;
-using System.Threading.Tasks;
-using System.Threading;
+
+using Microsoft.CodeAnalysis;
 
 namespace Acuminator.Vsix.ToolWindows.CodeMap
 {
@@ -36,12 +39,10 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 
 		public GraphMemberInfoNodeViewModel(GraphMemberNodeViewModel graphMemberVM, SymbolItem memberInfoData, 
 											GraphMemberInfoType graphMemberInfoType, bool isExpanded = false) :
-									  base(graphMemberVM?.Tree, graphMemberVM, isExpanded)
+									  base(graphMemberVM?.Tree!, graphMemberVM, isExpanded)
 		{
-			memberInfoData.ThrowOnNull(nameof(memberInfoData));
-
-			GraphMemberInfoData = memberInfoData;
-			GraphMember = graphMemberVM;
+			GraphMemberInfoData = memberInfoData.CheckIfNull();
+			GraphMember = graphMemberVM!;
 			GraphMemberInfoType = graphMemberInfoType;
 		}
 

--- a/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/Nodes/Graph/GraphMembers/Base/GraphMemberNodeViewModel.cs
+++ b/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/Nodes/Graph/GraphMembers/Base/GraphMemberNodeViewModel.cs
@@ -36,8 +36,8 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 										bool isExpanded = false) :
 								   base(graphMemberCategoryVM?.Tree, parent, isExpanded)
 		{
-			MemberInfo = memberInfo.CheckIfNull(nameof(memberInfo));
-			MemberCategory = graphMemberCategoryVM;		
+			MemberInfo = memberInfo.CheckIfNull();
+			MemberCategory = graphMemberCategoryVM;
 		}
 
 		public override Task NavigateToItemAsync() => MemberSymbol.NavigateToAsync();

--- a/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/TreeViewModel.cs
+++ b/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/TreeViewModel.cs
@@ -1,10 +1,12 @@
-﻿using System;
+﻿#nullable enable
+
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
+
 using Acuminator.Utilities.Common;
 using Acuminator.Vsix.Utilities;
-
 
 namespace Acuminator.Vsix.ToolWindows.CodeMap
 {
@@ -16,14 +18,14 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 
 		public ExtendedObservableCollection<TreeNodeViewModel> AllItems { get; } = new ExtendedObservableCollection<TreeNodeViewModel>();
 
-		private TreeNodeViewModel _selectedItem;
+		private TreeNodeViewModel? _selectedItem;
 
-		public TreeNodeViewModel SelectedItem
+		public TreeNodeViewModel? SelectedItem
 		{
 			get => _selectedItem;
 			set
 			{
-				TreeNodeViewModel previousSelection = _selectedItem;
+				TreeNodeViewModel? previousSelection = _selectedItem;
 				_selectedItem = value;
 
 				if (previousSelection != null)
@@ -63,9 +65,7 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 
 		public TreeViewModel(CodeMapWindowViewModel windowViewModel)
 		{
-			windowViewModel.ThrowOnNull(nameof(windowViewModel));
-
-			CodeMapViewModel = windowViewModel;
+			CodeMapViewModel = windowViewModel.CheckIfNull();
 		}
 
 		public void Clear()

--- a/src/Acuminator/Acuminator.Vsix/Tool Windows/Common/TooltipInfo.cs
+++ b/src/Acuminator/Acuminator.Vsix/Tool Windows/Common/TooltipInfo.cs
@@ -12,7 +12,7 @@ namespace Acuminator.Vsix.ToolWindows.Common
 	/// <summary>
 	/// Information about the tooltip and how to display it.
 	/// </summary>
-	public class TooltipInfo
+	public class TooltipInfo(string tooltip)
 	{
 		/// <summary>
 		/// Gets the tooltip text.
@@ -20,7 +20,7 @@ namespace Acuminator.Vsix.ToolWindows.Common
 		/// <value>
 		/// The tooltip text.
 		/// </value>
-		public string Tooltip { get; }
+		public string Tooltip { get; } = tooltip.NullIfWhiteSpace().CheckIfNull();
 
 		/// <summary>
 		/// Gets or sets a value indicating whether to trim excess <see cref="Tooltip"/>.
@@ -45,10 +45,5 @@ namespace Acuminator.Vsix.ToolWindows.Common
 		/// The overflow suffix added to the end of trimmed tooltip.
 		/// </value>
 		public string? OverflowSuffix { get; set; }
-
-		public TooltipInfo(string tooltip)
-		{
-			Tooltip = tooltip.NullIfWhiteSpace().CheckIfNull(nameof(tooltip));
-		}
 	}
 }

--- a/src/Acuminator/Acuminator.Vsix/Tool Windows/ViewModel/Command.cs
+++ b/src/Acuminator/Acuminator.Vsix/Tool Windows/ViewModel/Command.cs
@@ -41,10 +41,8 @@ namespace Acuminator.Vsix.ToolWindows
 		/// <param name="actionToExecute">The execution logic.</param>
 		/// <param name="canExecute">The predicate to determine if action can execute.</param>
 		public Command(Action<object> actionToExecute, Predicate<object> canExecute)
-		{
-			actionToExecute.ThrowOnNull(nameof(actionToExecute));
-				
-			_actionToExecute = actionToExecute;
+		{				
+			_actionToExecute = actionToExecute.CheckIfNull();
 			_canExecute = canExecute;
 		}	
 	}

--- a/src/Acuminator/Acuminator.Vsix/Utils/ChangesClassification/DocumentChangesClassifier.cs
+++ b/src/Acuminator/Acuminator.Vsix/Utils/ChangesClassification/DocumentChangesClassifier.cs
@@ -33,9 +33,9 @@ namespace Acuminator.Vsix.ChangesClassification
 		public async Task<ChangeInfluenceScope> GetChangesScopeAsync(Document oldDocument, SyntaxNode newRoot, Document newDocument, 
 																  CancellationToken cancellationToken = default)
 		{
-			oldDocument.ThrowOnNull(nameof(oldDocument));
-			newRoot.ThrowOnNull(nameof(newRoot));
-			newDocument.ThrowOnNull(nameof(newDocument));
+			oldDocument.ThrowOnNull();
+			newRoot.ThrowOnNull();
+			newDocument.ThrowOnNull();
 
 			IEnumerable<TextChange> textChanges = await newDocument.GetTextChangesAsync(oldDocument, cancellationToken)
 																   .ConfigureAwait(false);

--- a/src/Acuminator/Acuminator.Vsix/Utils/EditorExtensions.cs
+++ b/src/Acuminator/Acuminator.Vsix/Utils/EditorExtensions.cs
@@ -162,7 +162,7 @@ namespace Acuminator.Vsix.Utilities
 		/// <param name="textBuffer">The textBuffer to act on.</param>
 		public static string GetFilePath(this ITextBuffer textBuffer)
 		{
-			textBuffer.ThrowOnNull(nameof(textBuffer));
+			textBuffer.ThrowOnNull();
 			Microsoft.VisualStudio.Shell.ThreadHelper.ThrowIfNotOnUIThread();
 					
 			textBuffer.Properties.TryGetPropertySafe(typeof(Microsoft.VisualStudio.TextManager.Interop.IVsTextBuffer),
@@ -320,7 +320,7 @@ namespace Acuminator.Vsix.Utilities
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static SnapshotSpan GetOverarchingSpan(this NormalizedSnapshotSpanCollection collection)
         {
-            collection.ThrowOnNull(nameof(collection));
+            collection.ThrowOnNull();
 
             SnapshotSpan start = collection[0];
             SnapshotSpan end = collection[collection.Count - 1];
@@ -337,7 +337,7 @@ namespace Acuminator.Vsix.Utilities
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ITextBuffer CreateTextBuffer(this ITextBufferFactoryService textBufferFactoryService, params string[] lines)
         {
-            textBufferFactoryService.ThrowOnNull(nameof(textBufferFactoryService));
+            textBufferFactoryService.ThrowOnNull();
             return CreateTextBuffer(textBufferFactoryService, null, lines);
         }
 
@@ -347,7 +347,7 @@ namespace Acuminator.Vsix.Utilities
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ITextBuffer CreateTextBuffer(this ITextBufferFactoryService textBufferFactoryService, IContentType contentType, params string[] lines)
         {
-            textBufferFactoryService.ThrowOnNull(nameof(textBufferFactoryService));
+            textBufferFactoryService.ThrowOnNull();
 
             var textBuffer = contentType != null
                 ? textBufferFactoryService.CreateTextBuffer(contentType)

--- a/src/Acuminator/Acuminator.Vsix/Utils/Logger/AcuminatorLogger.cs
+++ b/src/Acuminator/Acuminator.Vsix/Utils/Logger/AcuminatorLogger.cs
@@ -38,8 +38,7 @@ namespace Acuminator.Vsix.Logger
 
 		public AcuminatorLogger(AcuminatorVSPackage acuminatorPackage, bool swallowUnobservedTaskExceptions)
 		{
-			acuminatorPackage.ThrowOnNull(nameof(acuminatorPackage));
-			_package = acuminatorPackage;
+			_package = acuminatorPackage.CheckIfNull();
 			_swallowUnobservedTaskExceptions = swallowUnobservedTaskExceptions;
 
 			AppDomain.CurrentDomain.FirstChanceException += Acuminator_FirstChanceException;

--- a/src/Acuminator/Acuminator.Vsix/Utils/Navigation/VSDocumentNavigation.cs
+++ b/src/Acuminator/Acuminator.Vsix/Utils/Navigation/VSDocumentNavigation.cs
@@ -30,9 +30,7 @@ namespace Acuminator.Vsix.Utilities.Navigation
 																									bool selectSpan = true,
 																									CancellationToken cToken = default)
 		{
-			symbol.ThrowOnNull(nameof(symbol));
-
-			var syntaxReferences = symbol.DeclaringSyntaxReferences;
+			var syntaxReferences = symbol.CheckIfNull().DeclaringSyntaxReferences;
 
 			if (syntaxReferences.Length != 1)
 				return Task.FromResult(default((IWpfTextView, CaretPosition)));
@@ -44,8 +42,8 @@ namespace Acuminator.Vsix.Utilities.Navigation
 																										  SyntaxReference reference, bool selectSpan = true,
 																										  CancellationToken cToken = default)
 		{
-			symbol.ThrowOnNull(nameof(symbol));
-			reference.ThrowOnNull(nameof(reference));
+			symbol.ThrowOnNull();
+			reference.ThrowOnNull();
 			var filePath = reference.SyntaxTree?.FilePath;
 
 			await Shell.ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
@@ -78,7 +76,7 @@ namespace Acuminator.Vsix.Utilities.Navigation
 																									 Solution solution, string filePath,
 																									 int lineNumber, int character)
 		{
-			serviceProvider.ThrowOnNull(nameof(serviceProvider));
+			serviceProvider.ThrowOnNull();
 
 			if (lineNumber < 0)
 			{
@@ -129,7 +127,7 @@ namespace Acuminator.Vsix.Utilities.Navigation
 																					TextSpan? spanToNavigate = null,
 																					bool selectSpan = true)
 		{
-			serviceProvider.ThrowOnNull(nameof(serviceProvider));
+			serviceProvider.ThrowOnNull();
 
 			IWpfTextView wpfTextView = await OpenCodeWindowAsync(serviceProvider, solution, filePath);
 
@@ -177,8 +175,8 @@ namespace Acuminator.Vsix.Utilities.Navigation
 
 		public static async Task<IWpfTextView> OpenCodeWindowAsync(this Shell.IAsyncServiceProvider serviceProvider, Solution solution, string filePath)
 		{
-			serviceProvider.ThrowOnNull(nameof(serviceProvider));
-			solution.ThrowOnNull(nameof(solution));
+			serviceProvider.ThrowOnNull();
+			solution.ThrowOnNull();
 
 			if (!Shell.ThreadHelper.CheckAccess() || !File.Exists(filePath))
 				return null;
@@ -223,7 +221,7 @@ namespace Acuminator.Vsix.Utilities.Navigation
 																									this Shell.IAsyncServiceProvider serviceProvider, 
 																									string filePath)
 		{
-			serviceProvider.ThrowOnNull(nameof(serviceProvider));
+			serviceProvider.ThrowOnNull();
 
 			if (!File.Exists(filePath) )
 				return default;

--- a/src/Acuminator/Acuminator.Vsix/Utils/PolyfillsForVS2017.cs
+++ b/src/Acuminator/Acuminator.Vsix/Utils/PolyfillsForVS2017.cs
@@ -42,8 +42,8 @@ namespace Acuminator.Vsix.Utilities
 		public static void FileAndForget(this Task task, string faultEventName, string faultDescription = null,
 										 Func<Exception, bool> fileOnlyIf = null)
 		{
-			task.ThrowOnNull(nameof(task));
-			faultEventName.ThrowOnNullOrEmpty(nameof(faultEventName));
+			task.ThrowOnNull();
+			faultEventName.ThrowOnNullOrEmpty();
 
 #pragma warning disable VSTHRD003 // Avoid awaiting foreign Tasks
 #pragma warning disable VSTHRD110 // Observe result of async calls

--- a/src/Acuminator/Acuminator.Vsix/Utils/UIAttributes/CategoryFromResourcesAttribute.cs
+++ b/src/Acuminator/Acuminator.Vsix/Utils/UIAttributes/CategoryFromResourcesAttribute.cs
@@ -27,8 +27,7 @@ namespace Acuminator.Vsix
 
 		public CategoryFromResourcesAttribute(string resourceKey, string nonLocalizedCategoryName) : base(nonLocalizedCategoryName) 
 		{			
-			resourceKey.ThrowOnNullOrWhiteSpace(nameof(resourceKey));
-			ResourceKey = resourceKey;
+			ResourceKey = resourceKey.CheckIfNullOrWhiteSpace();
 		}	
 	}
 }

--- a/src/Acuminator/Acuminator.Vsix/Utils/UIAttributes/DescriptionFromResourcesAttribute.cs
+++ b/src/Acuminator/Acuminator.Vsix/Utils/UIAttributes/DescriptionFromResourcesAttribute.cs
@@ -20,8 +20,7 @@ namespace Acuminator.Vsix
 
 		public DescriptionFromResourcesAttribute(string resourceKey)
 		{
-			resourceKey.ThrowOnNullOrWhiteSpace(nameof(resourceKey));
-			ResourceKey = resourceKey;
+			ResourceKey = resourceKey.CheckIfNullOrWhiteSpace();
 		}	
 	}
 }

--- a/src/Acuminator/Acuminator.Vsix/Utils/UIAttributes/DisplayNameFromResourcesAttribute.cs
+++ b/src/Acuminator/Acuminator.Vsix/Utils/UIAttributes/DisplayNameFromResourcesAttribute.cs
@@ -20,8 +20,7 @@ namespace Acuminator.Vsix
 
 		public DisplayNameFromResourcesAttribute(string resourceKey)
 		{
-			resourceKey.ThrowOnNullOrWhiteSpace(nameof(resourceKey));
-			ResourceKey = resourceKey;
+			ResourceKey = resourceKey.CheckIfNullOrWhiteSpace();
 		}	
 	}
 }

--- a/src/Acuminator/Acuminator.Vsix/Utils/Version/VSVersionProvider.cs
+++ b/src/Acuminator/Acuminator.Vsix/Utils/Version/VSVersionProvider.cs
@@ -23,7 +23,7 @@ namespace Acuminator.Vsix.Utilities
 	{
 		public static async Task<VSVersion> GetVersionAsync(IAsyncServiceProvider serviceProvider)
 		{
-			serviceProvider.ThrowOnNull(nameof(serviceProvider));
+			serviceProvider.ThrowOnNull();
 
 			if (!ThreadHelper.CheckAccess())
 			{

--- a/src/Acuminator/Acuminator.Vsix/Utils/WPF/Collection/ExtendedObservableCollection.cs
+++ b/src/Acuminator/Acuminator.Vsix/Utils/WPF/Collection/ExtendedObservableCollection.cs
@@ -35,7 +35,7 @@ namespace Acuminator.Vsix.Utilities
 		/// <param name="item">The item.</param>
 		public ExtendedObservableCollection(T item) : base()
 		{
-			item.ThrowOnNull(nameof(item));
+			item.ThrowOnNull();
 			Items.Add(item);
 		}
 
@@ -46,7 +46,7 @@ namespace Acuminator.Vsix.Utilities
 		/// <exception cref="System.ArgumentNullException"></exception>
 		public void AddRange(IEnumerable<T> range)
 		{
-			range.ThrowOnNull(nameof(range));
+			range.ThrowOnNull();
 			CheckReentrancy();
 
 			foreach (T item in range)
@@ -69,7 +69,7 @@ namespace Acuminator.Vsix.Utilities
 		/// <exception cref="System.ArgumentOutOfRangeException"></exception>
 		public void InsertRange(int index, IEnumerable<T> range)
 		{
-			range.ThrowOnNull(nameof(range));
+			range.ThrowOnNull();
 
 			if (index < 0 || index >= Count)
 				throw new ArgumentOutOfRangeException(nameof(index));
@@ -95,7 +95,7 @@ namespace Acuminator.Vsix.Utilities
 		/// <exception cref="System.ArgumentNullException"></exception>
 		public void RemoveRange(IEnumerable<T> range)
 		{
-			range.ThrowOnNull(nameof(range));
+			range.ThrowOnNull();
 			CheckReentrancy();
 
 			foreach (T item in range)

--- a/src/Acuminator/Acuminator.Vsix/Utils/WPF/VisualTreeUtils.cs
+++ b/src/Acuminator/Acuminator.Vsix/Utils/WPF/VisualTreeUtils.cs
@@ -21,7 +21,7 @@ namespace Acuminator.Vsix.Utilities
 		/// <returns/>
 		public static IEnumerable<FrameworkElement> GetVisualAncestors(this FrameworkElement uiElement)
 		{
-			uiElement.ThrowOnNull(nameof(uiElement));
+			uiElement.ThrowOnNull();
 
 			return GetVisualAncestorsImpl();
 
@@ -46,7 +46,7 @@ namespace Acuminator.Vsix.Utilities
 		/// <returns/>
 		public static IEnumerable<FrameworkElement> GetVisualDescendants(this FrameworkElement uiElement)
 		{
-			uiElement.ThrowOnNull(nameof(uiElement));
+			uiElement.ThrowOnNull();
 
 			int elementChildrenCount = VisualTreeHelper.GetChildrenCount(uiElement);
 


### PR DESCRIPTION
Changes overview:
- Integrated `CallerArgumentExpression` attribute to throw helpers
- Removed `nameof` from calls to throw helpers
- Refactoring + integrated C# 12 syntax
- Reworked and optimized PX1012 - removed small bugs, integrated pre-calced data from graph model