### PR TITLE
Bugfix/atr 808 dev fix type comparisons

### DIFF
--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/DacKeyFieldDeclaration/KeyFieldDeclarationAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/DacKeyFieldDeclaration/KeyFieldDeclarationAnalyzer.cs
@@ -37,7 +37,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.DacKeyFieldDeclaration
 
 				keyAttributes.AddRange(propertyKeyAttributes);
 
-				if (property.Symbol.ContainingType == dac.Symbol)
+				if (dac.Symbol.Equals(property.Symbol.ContainingType))
 				{
 					declaredInDacKeyAttributes.AddRange(propertyKeyAttributes);
 				}

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/DacReferentialIntegrity/DacForeignKeyDeclaration/CodeFixes/DacMissingForeignKeyFix.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/DacReferentialIntegrity/DacForeignKeyDeclaration/CodeFixes/DacMissingForeignKeyFix.cs
@@ -185,7 +185,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.DacReferentialIntegrity
 
 				var selectorAttributeCandidateMemberTypes = 
 					from type in attribute.AttributeType.GetBaseTypesAndThis()
-														.TakeWhile(attrType => attrType != pxContext.AttributeTypes.PXEventSubscriberAttribute)
+														.TakeWhile(attrType => !pxContext.AttributeTypes.PXEventSubscriberAttribute.Equals(attrType))
 					from member in type.GetMembers(selectorAttributeProperty)
 					select member switch
 					{

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/DacReferentialIntegrity/DacForeignKeyDeclaration/DacForeignKeyDeclarationAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/DacReferentialIntegrity/DacForeignKeyDeclaration/DacForeignKeyDeclarationAnalyzer.cs
@@ -372,7 +372,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.DacReferentialIntegrity
 
 			return containerDeclaredIncorrectly
 				? keyDeclarations
-				: keyDeclarations.Where(key => key.ContainingType != foreignKeysContainer && !key.GetContainingTypes().Contains(foreignKeysContainer))
+				: keyDeclarations.Where(key => !foreignKeysContainer!.Equals(key.ContainingType) && !key.GetContainingTypes().Contains(foreignKeysContainer))
 								 .ToList(capacity: keyDeclarations.Count);
 		}
 	}

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/DacReferentialIntegrity/DacPrimaryKeyDeclaration/DacPrimaryAndUniqueKeyDeclarationAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/DacReferentialIntegrity/DacPrimaryKeyDeclaration/DacPrimaryAndUniqueKeyDeclarationAnalyzer.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#nullable enable
+
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Collections.Generic;
@@ -7,10 +9,8 @@ using System.Linq;
 
 using Acuminator.Utilities.Common;
 using Acuminator.Utilities.DiagnosticSuppression;
-using Acuminator.Utilities.Roslyn.Constants;
 using Acuminator.Utilities.Roslyn.Semantic;
 using Acuminator.Utilities.Roslyn.Semantic.Dac;
-using Acuminator.Utilities.Roslyn.Syntax;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -66,9 +66,9 @@ namespace Acuminator.Analyzers.StaticAnalysis.DacReferentialIntegrity
 						 ?? new List<ITypeSymbol>();
 		}
 
-		protected override ITypeSymbol GetParentDacFromKey(PXContext context, INamedTypeSymbol primaryOrUniqueKey)
+		protected override ITypeSymbol? GetParentDacFromKey(PXContext context, INamedTypeSymbol primaryOrUniqueKey)
 		{
-			ITypeSymbol parentDAC = null;
+			ITypeSymbol? parentDAC = null;
 
 			if (context.ReferentialIntegritySymbols.IPrimaryKeyOf1 != null)
 			{
@@ -96,14 +96,14 @@ namespace Acuminator.Analyzers.StaticAnalysis.DacReferentialIntegrity
 				: null;
 		}
 
-		protected override Location GetUnboundDacFieldLocation(ClassDeclarationSyntax keyNode, ITypeSymbol unboundDacFieldInKey)
+		protected override Location? GetUnboundDacFieldLocation(ClassDeclarationSyntax keyNode, ITypeSymbol unboundDacFieldInKey)
 		{
 			if (keyNode.BaseList.Types.Count == 0)
 				return null;
 
 			BaseTypeSyntax baseTypeNode = keyNode.BaseList.Types[0];
 
-			if (!(baseTypeNode.Type is QualifiedNameSyntax qualifiedName) || !(qualifiedName.Right is GenericNameSyntax byTypeNode))
+			if (baseTypeNode.Type is not QualifiedNameSyntax qualifiedName || qualifiedName.Right is not GenericNameSyntax byTypeNode)
 				return null;
 
 			return GetUnboundDacFieldLocationFromTypeArguments(byTypeNode, unboundDacFieldInKey);
@@ -141,7 +141,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.DacReferentialIntegrity
 
 		private void ReportNoPrimaryKeyDeclarationsInDac(SymbolAnalysisContext symbolContext, PXContext context, DacSemanticModel dac)
 		{
-			Location location = dac.Node.Identifier.GetLocation() ?? dac.Node.GetLocation();
+			var location = dac.Node.Identifier.GetLocation() ?? dac.Node.GetLocation();
 
 			if (location != null)
 			{
@@ -210,8 +210,8 @@ namespace Acuminator.Analyzers.StaticAnalysis.DacReferentialIntegrity
 				return;
 			}
 
-			INamedTypeSymbol uniqueKeysContainer = dac.Symbol.GetTypeMembers(ReferentialIntegrity.UniqueKeyClassName)
-															 .FirstOrDefault();
+			INamedTypeSymbol? uniqueKeysContainer = dac.Symbol.GetTypeMembers(ReferentialIntegrity.UniqueKeyClassName)
+															  .FirstOrDefault();
 			
 			//We can register code fix only if there is no UK nested type in DAC or there is a public static UK class. Otherwise we will break the code.
 			bool registerCodeFix = uniqueKeysContainer == null || 
@@ -250,7 +250,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.DacReferentialIntegrity
 			}
 		}
 
-		private List<INamedTypeSymbol> GetKeysNotInContainer(List<INamedTypeSymbol> keyDeclarations, INamedTypeSymbol uniqueKeysContainer, INamedTypeSymbol primaryKey)
+		private List<INamedTypeSymbol> GetKeysNotInContainer(List<INamedTypeSymbol> keyDeclarations, INamedTypeSymbol? uniqueKeysContainer, INamedTypeSymbol primaryKey)
 		{
 			bool containerDeclaredIncorrectly = uniqueKeysContainer?.DeclaredAccessibility != Accessibility.Public || !uniqueKeysContainer.IsStatic;
 

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/DacReferentialIntegrity/DacPrimaryKeyDeclaration/DacPrimaryAndUniqueKeyDeclarationAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/DacReferentialIntegrity/DacPrimaryKeyDeclaration/DacPrimaryAndUniqueKeyDeclarationAnalyzer.cs
@@ -256,11 +256,11 @@ namespace Acuminator.Analyzers.StaticAnalysis.DacReferentialIntegrity
 
 			if (containerDeclaredIncorrectly)
 			{
-				return keyDeclarations.Where(key => key != primaryKey).ToList(capacity: keyDeclarations.Count - 1);
+				return keyDeclarations.Where(key => !key.Equals(primaryKey)).ToList(capacity: keyDeclarations.Count - 1);
 			}
 			else
 			{
-				return keyDeclarations.Where(key => key != primaryKey && key.ContainingType != uniqueKeysContainer && 
+				return keyDeclarations.Where(key => !key.Equals(primaryKey) && !Equals(key.ContainingType, uniqueKeysContainer) && 
 													!key.GetContainingTypes().Contains(uniqueKeysContainer))
 									  .ToList(capacity: keyDeclarations.Count - 1);
 			}

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/DacReferentialIntegrity/SharedCodeFixes/IncorrectDeclarationOfDacKeyFix.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/DacReferentialIntegrity/SharedCodeFixes/IncorrectDeclarationOfDacKeyFix.cs
@@ -51,10 +51,10 @@ namespace Acuminator.Analyzers.StaticAnalysis.DacReferentialIntegrity
 
 			var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
 
-			if (!(root?.FindNode(context.Span) is ClassDeclarationSyntax keyNode))
+			if (root?.FindNode(context.Span) is not ClassDeclarationSyntax keyNode)
 				return;
 
-			if (!(root.FindNode(diagnostic.AdditionalLocations[0].SourceSpan) is ClassDeclarationSyntax dacNode))
+			if (root.FindNode(diagnostic.AdditionalLocations[0].SourceSpan) is not ClassDeclarationSyntax dacNode)
 				return;
 
 			switch (dacKeyType)

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/DacReferentialIntegrity/SharedCodeFixes/IncorrectDeclarationOfDacKeyFix.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/DacReferentialIntegrity/SharedCodeFixes/IncorrectDeclarationOfDacKeyFix.cs
@@ -62,7 +62,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.DacReferentialIntegrity
 				case RefIntegrityDacKeyType.PrimaryKey
 				when keyNode.Identifier.Text != ReferentialIntegrity.PrimaryKeyClassName:
 					{
-						bool shouldChangeLocation = keyNode.Parent != dacNode;  //We need to change location for primary key
+						bool shouldChangeLocation = !dacNode.Equals(keyNode.Parent);  //We need to change location for primary key
 						string codeActionResourceName = shouldChangeLocation
 							? nameof(Resources.PX1036PK_ChangeNameAndLocationFix)
 							: nameof(Resources.PX1036PK_ChangeNameFix);

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/ExceptionSerialization/ExceptionSerializationAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/ExceptionSerialization/ExceptionSerializationAnalyzer.cs
@@ -14,7 +14,6 @@ using Acuminator.Utilities.Roslyn.Semantic;
 using Acuminator.Utilities.Roslyn.Syntax;
 
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
@@ -84,9 +83,9 @@ namespace Acuminator.Analyzers.StaticAnalysis.ExceptionSerialization
 						 .Any(constructor => IsSerializationConstructor(constructor, pxContext));
 
 		private static bool IsSerializationConstructor(IMethodSymbol constructor, PXContext pxContext) =>
-			constructor.Parameters.Length == 2 && 
-			constructor.Parameters[0].Type == pxContext.Serialization.SerializationInfo &&
-			constructor.Parameters[1].Type == pxContext.Serialization.StreamingContext;
+			constructor.Parameters.Length == 2 &&
+			pxContext.Serialization.SerializationInfo.Equals(constructor.Parameters[0].Type) &&
+			pxContext.Serialization.StreamingContext.Equals(constructor.Parameters[1].Type);
 
 		private static bool HasGetObjectDataOverride(PXContext pxContext, INamedTypeSymbol exceptionType) =>
 			exceptionType.GetMethods()
@@ -97,8 +96,8 @@ namespace Acuminator.Analyzers.StaticAnalysis.ExceptionSerialization
 			method.DeclaredAccessibility == Accessibility.Public &&
 			method.Name == DelegateNames.Serialization.GetObjectData &&
 			method.Parameters.Length == 2 &&
-			method.Parameters[0].Type == pxContext.Serialization.SerializationInfo &&
-			method.Parameters[1].Type == pxContext.Serialization.StreamingContext;
+			pxContext.Serialization.SerializationInfo.Equals(method.Parameters[0].Type) &&
+			pxContext.Serialization.StreamingContext.Equals(method.Parameters[1].Type);
 
 		private static IEnumerable<ISymbol> GetSerializableFieldsAndProperties(INamedTypeSymbol exceptionType, PXContext pxContext)
 		{
@@ -147,7 +146,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.ExceptionSerialization
 
 			bool hasNonSerializedAttributeDeclared = attributes.IsDefaultOrEmpty
 				? false
-				: attributes.Any(a => a.AttributeClass == pxContext.Serialization.NonSerializedAttribute);
+				: attributes.Any(a => pxContext.Serialization.NonSerializedAttribute.Equals(a.AttributeClass));
 
 			return !hasNonSerializedAttributeDeclared;
 		}

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/ExceptionSerialization/ExceptionSerializationFixBase.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/ExceptionSerialization/ExceptionSerializationFixBase.cs
@@ -114,8 +114,8 @@ namespace Acuminator.Analyzers.StaticAnalysis.ExceptionSerialization
 
 		protected bool IsMethodUsedForSerialization(IMethodSymbol method, PXContext pxContext) =>
 			method.Parameters.Length == 2 &&
-			method.Parameters[0]?.Type == pxContext.Serialization.SerializationInfo &&
-			method.Parameters[1]?.Type == pxContext.Serialization.StreamingContext;
+			pxContext.Serialization.SerializationInfo.Equals(method.Parameters[0]?.Type)  &&
+			pxContext.Serialization.StreamingContext.Equals(method.Parameters[1]?.Type);
 
 		protected SyntaxNode[] GenerateSerializationMemberParameters(SyntaxGenerator generator, PXContext pxContext) =>
 			new[]

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/ForbiddenFieldsInDac/ForbiddenFieldsInDacAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/ForbiddenFieldsInDac/ForbiddenFieldsInDacAnalyzer.cs
@@ -60,7 +60,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.ForbiddenFieldsInDac
 									where dacOrDacExtension.PropertiesByNames.ContainsKey(forbiddenFieldName)
 									select dacOrDacExtension.PropertiesByNames[forbiddenFieldName];
 
-			foreach (DacPropertyInfo property in invalidProperties.Where(p => p.Symbol.ContainingSymbol == dacOrDacExtension.Symbol))
+			foreach (DacPropertyInfo property in invalidProperties.Where(p => dacOrDacExtension.Symbol.Equals(p.Symbol.ContainingSymbol)))
 			{
 				context.CancellationToken.ThrowIfCancellationRequested();
 				RegisterForbiddenFieldDiagnosticForIdentifier(property.Node.Identifier, pxContext, context);

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PublicClassXmlComment/XmlCommentsWalker.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PublicClassXmlComment/XmlCommentsWalker.cs
@@ -233,7 +233,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.PublicClassXmlComment
 			{
 				_syntaxContext.CancellationToken.ThrowIfCancellationRequested();
 
-				if (reference.SyntaxTree == typeDeclaration.SyntaxTree ||
+				if (Equals(reference.SyntaxTree, typeDeclaration.SyntaxTree) ||
 					reference.GetSyntax(_syntaxContext.CancellationToken) is not TypeDeclarationSyntax partialTypeDeclaration)
 				{
 					continue;

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/TypoInViewDelegateName/TypoInViewDelegateNameAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/TypoInViewDelegateName/TypoInViewDelegateNameAnalyzer.cs
@@ -38,7 +38,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.TypoInViewDelegateName
 
 			var delegateCandidates = from method in graphModel.Symbol.GetMethods()
 									 where method.ContainingType.Equals(graphModel.Symbol) && !method.IsOverride &&
-										   (!graphModel.ViewDelegatesByNames.TryGetValue(method.Name, out var delegateInfo) || method != delegateInfo.Symbol) &&
+										   (!graphModel.ViewDelegatesByNames.TryGetValue(method.Name, out DataViewDelegateInfo delegateInfo) || !method.Equals(delegateInfo.Symbol)) &&
 										   method.IsValidViewDelegate(pxContext) && !method.IsValidActionHandler(pxContext)
 									 select method;
 

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/PXFieldAttributes/Infos/AttributeWithApplication.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/PXFieldAttributes/Infos/AttributeWithApplication.cs
@@ -31,7 +31,7 @@ namespace Acuminator.Utilities.Roslyn.PXFieldAttributes
 		public override bool Equals(object obj) => obj is AttributeWithApplication other && Equals(other);
 
 		public bool Equals(AttributeWithApplication other) =>
-			Type == other.Type && Application.Equals(other.Application);
+			Type.Equals(other.Type) && Application.Equals(other.Application);
 
 		public override int GetHashCode()
 		{

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/Dac/DacSemanticModel.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/Dac/DacSemanticModel.cs
@@ -39,14 +39,14 @@ namespace Acuminator.Utilities.Roslyn.Semantic.Dac
 
 		public IEnumerable<DacPropertyInfo> DacProperties => Properties.Where(p => p.IsDacProperty);
 
-		public IEnumerable<DacPropertyInfo> AllDeclaredProperties => Properties.Where(p => p.Symbol.ContainingType == Symbol);
+		public IEnumerable<DacPropertyInfo> AllDeclaredProperties => Properties.Where(p => Symbol.Equals(p.Symbol.ContainingType));
 
-		public IEnumerable<DacPropertyInfo> DeclaredDacProperties => Properties.Where(p => p.IsDacProperty && p.Symbol.ContainingType == Symbol);
+		public IEnumerable<DacPropertyInfo> DeclaredDacProperties => Properties.Where(p => p.IsDacProperty && Symbol.Equals(p.Symbol.ContainingType));
 
 		public ImmutableDictionary<string, DacFieldInfo> FieldsByNames { get; }
 		public IEnumerable<DacFieldInfo> Fields => FieldsByNames.Values;
 
-		public IEnumerable<DacFieldInfo> DeclaredFields => Fields.Where(f => f.Symbol.ContainingType == Symbol);
+		public IEnumerable<DacFieldInfo> DeclaredFields => Fields.Where(f => Symbol.Equals(f.Symbol.ContainingType));
 
 		/// <summary>
 		/// Gets the info about IsActive method for DAC extensions. Can be <c>null</c>. Always <c>null</c> for DACs.

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Syntax/LowestCommonAncestor/LowestCommonAncestor.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Syntax/LowestCommonAncestor/LowestCommonAncestor.cs
@@ -43,7 +43,7 @@ namespace Acuminator.Utilities.Roslyn.Syntax
 				}
 			}
 
-			while (currentX != currentY)          //Then move up the branches until nodes coincide
+			while (!Equals(currentX, currentY))          //Then move up the branches until nodes coincide
 			{
 				prevX = currentX;
 				prevY = currentY;
@@ -83,7 +83,7 @@ namespace Acuminator.Utilities.Roslyn.Syntax
 				}
 			}
 
-			while (currentX != currentY)          //Then move up the branches until nodes coincide
+			while (!Equals(currentX, currentY))          //Then move up the branches until nodes coincide
 			{
 				prevX = currentX;
 				prevY = currentY;

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Syntax/SyntaxTreeUtils.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Syntax/SyntaxTreeUtils.cs
@@ -115,7 +115,7 @@ namespace Acuminator.Utilities.Roslyn.Syntax
 			int depth = 0;
 			SyntaxNode curNode = node.Parent;
 
-			while (curNode != null && !(curNode is TRoot))
+			while (curNode != null && curNode is not TRoot)
 			{
 				depth++;
 				curNode = curNode.Parent;
@@ -146,7 +146,7 @@ namespace Acuminator.Utilities.Roslyn.Syntax
 			int depth = 0;
 			TNode? curNode = node.Parent<TNode>();
 
-			while (curNode != null && !(curNode is TRoot))
+			while (curNode != null && curNode is not TRoot)
 			{
 				depth++;
 				curNode = curNode.Parent<TNode>();
@@ -177,7 +177,7 @@ namespace Acuminator.Utilities.Roslyn.Syntax
 				}
 			}
 
-			while (currentX != currentY)          //Then move up the branches until nodes coincide
+			while (!Equals(currentX, currentY))          //Then move up the branches until nodes coincide
 			{
 				currentX = currentX.Parent;
 				currentY = currentY.Parent;

--- a/src/Acuminator/Acuminator.Vsix/Acuminator.Vsix.csproj
+++ b/src/Acuminator/Acuminator.Vsix/Acuminator.Vsix.csproj
@@ -464,6 +464,7 @@
     <Compile Include="Tool Windows\CodeMap\ViewModel\Nodes\Graph\GraphMembers\InitializationAndActivation\GraphInstanceConstructorNodeViewModel.cs" />
     <Compile Include="Tool Windows\CodeMap\ViewModel\Nodes\Graph\GraphMembers\GraphBaseMembeOverrideNodeViewModel.cs" />
     <Compile Include="Tool Windows\Common\TooltipInfo.cs" />
+    <Compile Include="Utils\Polyfills\MemberNotNullAttribute.cs" />
     <Compile Include="Utils\Text\StringUtils.cs" />
     <Compile Include="Tool Windows\CodeMap\Utils\Visitor\NoResult\CodeMapTreeWalker.cs" />
     <Compile Include="Tool Windows\CodeMap\Utils\Visitor\StackGuard.cs" />

--- a/src/Acuminator/Acuminator.Vsix/Commands/Formatter/FormatBqlCommand.cs
+++ b/src/Acuminator/Acuminator.Vsix/Commands/Formatter/FormatBqlCommand.cs
@@ -121,7 +121,7 @@ namespace Acuminator.Vsix.Formatter
 
 			await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(); // Return to UI thread
 
-			if (!textView.TextBuffer.EditInProgress && formattedRoot != syntaxRoot)
+			if (!textView.TextBuffer.EditInProgress && !syntaxRoot.Equals(formattedRoot))
 			{
 				var formattedDocument = document.WithSyntaxRoot(formattedRoot);
 				ApplyChanges(document, formattedDocument);

--- a/src/Acuminator/Acuminator.Vsix/Commands/Formatter/FormatBqlCommand.cs
+++ b/src/Acuminator/Acuminator.Vsix/Commands/Formatter/FormatBqlCommand.cs
@@ -1,20 +1,22 @@
-﻿using System;
+﻿#nullable enable
+
+using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+
+using Acuminator.Utilities.Common;
+using Acuminator.Utilities.Roslyn;
+using Acuminator.Utilities.Roslyn.Constants;
+using Acuminator.Vsix.Utilities;
+
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Shell;
-using Microsoft.VisualStudio.Threading;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
-using Acuminator.Utilities.Common;
-using Acuminator.Utilities.Roslyn.Constants;
-using Acuminator.Vsix;
-using Acuminator.Utilities.Roslyn;
-using Acuminator.Vsix.Utilities;
-
-
+using Microsoft.VisualStudio.Threading;
 
 namespace Acuminator.Vsix.Formatter
 {
@@ -43,17 +45,19 @@ namespace Acuminator.Vsix.Formatter
 		/// <summary>
 		/// Gets the instance of the command.
 		/// </summary>
-		public static FormatBqlCommand Instance
+		public static FormatBqlCommand? Instance
 		{
 			get;
 			private set;
 		}
 
+#pragma warning disable CS8774 // Member must have a non-null value when exiting.
 		/// <summary>
 		/// Initializes the singleton instance of the command.
 		/// </summary>
 		/// <param name="package">Owner package, not null.</param>
 		/// <param name="commandService">The OLE command service.</param>
+		[MemberNotNull(nameof(Instance))]
 		public static void Initialize(AsyncPackage package, OleMenuCommandService commandService)
 		{
 			if (Interlocked.CompareExchange(ref _isCommandInitialized, value: INITIALIZED, comparand: NOT_INITIALIZED) == NOT_INITIALIZED)
@@ -61,6 +65,7 @@ namespace Acuminator.Vsix.Formatter
 				Instance = new FormatBqlCommand(package, commandService);
 			}
 		}
+#pragma warning restore CS8774
 
 		protected override void CommandCallback(object sender, EventArgs e) =>
 			CommandCallbackAsync()
@@ -133,8 +138,8 @@ namespace Acuminator.Vsix.Formatter
 			oldDocument.ThrowOnNull();
 			newDocument.ThrowOnNull();
 
-			Workspace workspace = oldDocument.Project?.Solution?.Workspace;
-			Solution newSolution = newDocument.Project?.Solution;
+			Workspace? workspace = oldDocument.Project?.Solution?.Workspace;
+			Solution? newSolution = newDocument.Project?.Solution;
 
 			if (workspace != null && newSolution != null)
 			{

--- a/src/Acuminator/Acuminator.Vsix/Commands/GoToDeclarationOrHandler/GoToDeclarationOrHandlerCommand.cs
+++ b/src/Acuminator/Acuminator.Vsix/Commands/GoToDeclarationOrHandler/GoToDeclarationOrHandlerCommand.cs
@@ -1,13 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.ComponentModel.Design;
-using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using EnvDTE;
-using EnvDTE80;
+
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -16,16 +13,16 @@ using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text.Outlining;
 using Microsoft.VisualStudio.Threading;
-using Microsoft.VisualStudio.TextManager.Interop;
+
 using Acuminator.Utilities.Common;
-using Acuminator.Utilities.Roslyn;
 using Acuminator.Utilities.Roslyn.Semantic;
 using Acuminator.Utilities.Roslyn.Semantic.PXGraph;
 using Acuminator.Vsix.Utilities;
+
 using TextSpan = Microsoft.CodeAnalysis.Text.TextSpan;
 using Document = Microsoft.CodeAnalysis.Document;
-
 using Shell =  Microsoft.VisualStudio.Shell;
+
 using static Microsoft.VisualStudio.Shell.VsTaskLibraryHelper;
 
 namespace Acuminator.Vsix.GoToDeclaration
@@ -222,11 +219,11 @@ namespace Acuminator.Vsix.GoToDeclaration
 			}
 			else
 			{
-				viewDelegateInfoToNavigateTo = viewDelegates.Where(vDelegate => vDelegate.Symbol.ContainingType == viewSymbol.ContainingType)
+				viewDelegateInfoToNavigateTo = viewDelegates.Where(vDelegate => vDelegate.Symbol.ContainingType?.Equals(viewSymbol.ContainingType) ?? false)
 															.FirstOrDefault();
 			}
 
-			if (!(viewDelegateInfoToNavigateTo.Node is MethodDeclarationSyntax methodNode) || methodNode.SyntaxTree == null)
+			if (viewDelegateInfoToNavigateTo.Node is not MethodDeclarationSyntax methodNode || methodNode.SyntaxTree == null)
 				return;
 
 			string viewDelegateFilePath = viewDelegateInfoToNavigateTo.Node.SyntaxTree.FilePath;

--- a/src/Acuminator/Acuminator.Vsix/Commands/GoToDeclarationOrHandler/GoToDeclarationOrHandlerCommand.cs
+++ b/src/Acuminator/Acuminator.Vsix/Commands/GoToDeclarationOrHandler/GoToDeclarationOrHandlerCommand.cs
@@ -306,8 +306,9 @@ namespace Acuminator.Vsix.GoToDeclaration
 			}
 			else
 			{
-				return candidates.Where(symbol => symbol.ContainingType == methodSymbol.ContainingType ||
-												  symbol.ContainingType.OriginalDefinition == methodSymbol.ContainingType.OriginalDefinition)
+				return candidates.Where(symbol => (symbol.ContainingType != null && symbol.ContainingType.Equals(methodSymbol.ContainingType) ||
+												  (symbol.ContainingType?.OriginalDefinition != null && 
+												   symbol.ContainingType.OriginalDefinition.Equals(methodSymbol.ContainingType.OriginalDefinition))))
 								 .FirstOrDefault();
 			}
 		}

--- a/src/Acuminator/Acuminator.Vsix/Commands/GoToDeclarationOrHandler/GoToDeclarationOrHandlerCommand.cs
+++ b/src/Acuminator/Acuminator.Vsix/Commands/GoToDeclarationOrHandler/GoToDeclarationOrHandlerCommand.cs
@@ -1,6 +1,9 @@
-﻿using System;
+﻿#nullable enable
+
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -52,18 +55,20 @@ namespace Acuminator.Vsix.GoToDeclaration
 		/// <summary>
 		/// Gets the instance of the command.
 		/// </summary>
-		public static GoToDeclarationOrHandlerCommand Instance
+		public static GoToDeclarationOrHandlerCommand? Instance
 		{
 			get;
 			private set;
 		}
 
+#pragma warning disable CS8774 // Member must have a non-null value when exiting.
 		/// <summary>
 		/// Initializes the singleton instance of the command. Internal method shich should be called only from UI thread.
 		/// </summary>
 		/// <param name="package">Owner package, not null.</param>
 		/// <param name="oleCommandService">The OLE command service.</param>
 		/// <returns/>
+		[MemberNotNull(nameof(Instance))]
 		internal static void Initialize(Shell.AsyncPackage package, Shell.OleMenuCommandService oleCommandService)
 		{
 			if (Interlocked.CompareExchange(ref _isCommandInitialized, value: INITIALIZED, comparand: NOT_INITIALIZED) == NOT_INITIALIZED)
@@ -71,6 +76,7 @@ namespace Acuminator.Vsix.GoToDeclaration
 				Instance = new GoToDeclarationOrHandlerCommand(package, oleCommandService);
 			}
 		}
+#pragma warning restore CS8774
 
 		protected override void CommandCallback(object sender, EventArgs e) =>
 			CommandCallbackAsync()
@@ -107,7 +113,7 @@ namespace Acuminator.Vsix.GoToDeclaration
 
 			TextSpan lineSpan = TextSpan.FromBounds(caretLine.Start.Position, caretLine.End.Position);
 
-			if (!(syntaxRoot.FindNode(lineSpan) is MemberDeclarationSyntax memberNode))
+			if (syntaxRoot.FindNode(lineSpan) is not MemberDeclarationSyntax memberNode)
 				return;
 
 			PXContext context = new PXContext(semanticModel.Compilation, Acuminator.Utilities.CodeAnalysisSettings.Default);
@@ -115,7 +121,7 @@ namespace Acuminator.Vsix.GoToDeclaration
 			if (!context.IsPlatformReferenced || Package.DisposalToken.IsCancellationRequested)
 				return;
 
-			ISymbol memberSymbol = GetMemberSymbol(memberNode, semanticModel, caretPosition);
+			ISymbol? memberSymbol = GetMemberSymbol(memberNode, semanticModel, caretPosition);
 
 			if (memberSymbol == null || !CheckMemberSymbol(memberSymbol, context))
 				return;
@@ -123,9 +129,9 @@ namespace Acuminator.Vsix.GoToDeclaration
 			await NavigateToHandlerOrDeclarationAsync(document, textView, memberSymbol, memberNode, semanticModel, context);
 		}
 
-		private ISymbol GetMemberSymbol(MemberDeclarationSyntax memberDeclaration, SemanticModel semanticModel, SnapshotPoint caretPosition)
+		private ISymbol? GetMemberSymbol(MemberDeclarationSyntax memberDeclaration, SemanticModel semanticModel, SnapshotPoint caretPosition)
 		{
-			if (!(memberDeclaration is FieldDeclarationSyntax fieldDeclaration))
+			if (memberDeclaration is not FieldDeclarationSyntax fieldDeclaration)
 			{
 				return semanticModel.GetDeclaredSymbol(memberDeclaration);
 			}
@@ -144,15 +150,7 @@ namespace Acuminator.Vsix.GoToDeclaration
 			if (memberSymbol.ContainingType == null || !memberSymbol.ContainingType.IsPXGraphOrExtension(context))
 				return false;
 
-			switch (memberSymbol.Kind)
-			{
-				case SymbolKind.Field:
-				case SymbolKind.Method:
-				case SymbolKind.Property:
-					return true;	
-				default:
-					return false;
-			}
+			return memberSymbol.Kind is (SymbolKind.Field or SymbolKind.Method or SymbolKind.Property);
 		}
 
 		private async Task NavigateToHandlerOrDeclarationAsync(Document document, IWpfTextView textView, ISymbol memberSymbol,
@@ -161,8 +159,8 @@ namespace Acuminator.Vsix.GoToDeclaration
 			INamedTypeSymbol graphOrExtensionType = memberSymbol.ContainingType;
 			var modelCreationOptions = GraphSemanticModelCreationOptions.CollectGeneralGraphInfo |
 									   GraphSemanticModelCreationOptions.CollectProcessingDelegates;
-			PXGraphSemanticModel graphSemanticModel = PXGraphSemanticModel.InferModels(context, graphOrExtensionType, modelCreationOptions)
-																		 ?.FirstOrDefault();
+			PXGraphSemanticModel? graphSemanticModel = PXGraphSemanticModel.InferModels(context, graphOrExtensionType, modelCreationOptions)
+																		  ?.FirstOrDefault();
 
 			if (graphSemanticModel == null || graphSemanticModel.Type == GraphType.None)
 				return;
@@ -187,9 +185,9 @@ namespace Acuminator.Vsix.GoToDeclaration
 			if (!graphSemanticModel.ActionHandlersByNames.TryGetValue(actionSymbol.Name, out ActionHandlerInfo actionHandler))
 				return;
 
-			IWpfTextView textViewToNavigateTo = textView;
+			IWpfTextView? textViewToNavigateTo = textView;
 
-			if (!(actionHandler.Node is MethodDeclarationSyntax handlerNode) || handlerNode.SyntaxTree == null)
+			if (actionHandler.Node is not MethodDeclarationSyntax handlerNode || handlerNode.SyntaxTree == null)
 				return;
 
 			if (handlerNode.SyntaxTree.FilePath != document.FilePath)
@@ -206,7 +204,7 @@ namespace Acuminator.Vsix.GoToDeclaration
 		private async Task NavigateToPXViewDelegateAsync(Document document, IWpfTextView textView, ISymbol viewSymbol, 
 														 PXGraphSemanticModel graphSemanticModel, PXContext context)
 		{
-			if (!graphSemanticModel.ViewDelegatesByNames.TryGetValue(viewSymbol.Name, out var viewDelegate))
+			if (!graphSemanticModel.ViewDelegatesByNames.TryGetValue(viewSymbol.Name, out DataViewDelegateInfo viewDelegate))
 				return;
 
 			var viewDelegates = viewDelegate.GetDelegateWithAllOverrides().ToList();
@@ -227,7 +225,7 @@ namespace Acuminator.Vsix.GoToDeclaration
 				return;
 
 			string viewDelegateFilePath = viewDelegateInfoToNavigateTo.Node.SyntaxTree.FilePath;
-			IWpfTextView textViewToNavigateTo = textView;
+			IWpfTextView? textViewToNavigateTo = textView;
 
 			if (viewDelegateFilePath != document.FilePath)
 			{
@@ -241,10 +239,10 @@ namespace Acuminator.Vsix.GoToDeclaration
 			await SetNewPositionInTextViewAsync(textViewToNavigateTo, methodNode.Identifier.Span);
 		}
 
-		private async Task NavigateToActionOrViewDeclarationAsync(Document document, IWpfTextView textView, IMethodSymbol methodSymbol, 
+		private async Task NavigateToActionOrViewDeclarationAsync(Document document, IWpfTextView? textView, IMethodSymbol methodSymbol, 
 																  PXGraphSemanticModel graphSemanticModel, PXContext context)
 		{
-			ISymbol symbolToNavigate = GetActionOrViewSymbolToNavigateTo(methodSymbol, graphSemanticModel, context);
+			ISymbol? symbolToNavigate = GetActionOrViewSymbolToNavigateTo(methodSymbol, graphSemanticModel, context);
 
 			if (symbolToNavigate == null || Package.DisposalToken.IsCancellationRequested)
 				return;
@@ -282,7 +280,7 @@ namespace Acuminator.Vsix.GoToDeclaration
 			await SetNewPositionInTextViewAsync(textView, textSpan);
 		}
 
-		private static ISymbol GetActionOrViewSymbolToNavigateTo(IMethodSymbol methodSymbol, PXGraphSemanticModel graphSemanticModel,
+		private static ISymbol? GetActionOrViewSymbolToNavigateTo(IMethodSymbol methodSymbol, PXGraphSemanticModel graphSemanticModel,
 																 PXContext context)
 		{
 			IEnumerable<ISymbol> candidates;
@@ -314,7 +312,7 @@ namespace Acuminator.Vsix.GoToDeclaration
 			}
 		}
 
-		private async Task<IWpfTextView> OpenOtherDocumentForNavigationAndGetItsTextViewAsync(Document originalDocument, SyntaxTree syntaxTreeToNavigate)
+		private async Task<IWpfTextView?> OpenOtherDocumentForNavigationAndGetItsTextViewAsync(Document originalDocument, SyntaxTree syntaxTreeToNavigate)
 		{
 			DocumentId documentToNavigateId = originalDocument.Project.GetDocumentId(syntaxTreeToNavigate);
 
@@ -340,7 +338,7 @@ namespace Acuminator.Vsix.GoToDeclaration
 
 		private async Task SetNewPositionInTextViewAsync(IWpfTextView textView, TextSpan textSpan)
 		{
-			SnapshotSpan selectedSpan = new SnapshotSpan(textView.TextSnapshot, textSpan.Start, textSpan.Length);
+			var selectedSpan = new SnapshotSpan(textView.TextSnapshot, textSpan.Start, textSpan.Length);
 
 		 	await ExpandAllRegionsContainingSpanAsync(selectedSpan, textView);
 

--- a/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/Utils/CodeMapDocChangesClassifier.cs
+++ b/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/Utils/CodeMapDocChangesClassifier.cs
@@ -131,7 +131,7 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 			if (!dacCandidate.PropertiesByNames.TryGetValue(changedProperty.Identifier.Text, out var dacPropertyInfoCandidate))
 				return false;
 
-			return dacPropertyInfoCandidate.Node.ExplicitInterfaceSpecifier == changedProperty.ExplicitInterfaceSpecifier;
+			return Equals(dacPropertyInfoCandidate.Node.ExplicitInterfaceSpecifier, changedProperty.ExplicitInterfaceSpecifier);
 		}
 	}
 }

--- a/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/Builders/Graph/DefaultCodeMapTreeBuilder_Graph.cs
+++ b/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/Builders/Graph/DefaultCodeMapTreeBuilder_Graph.cs
@@ -109,8 +109,8 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 			Cancellation.ThrowIfCancellationRequested();
 			var graphSemanticModel = graphMemberCategory.GraphSemanticModel;
 			var graphMemberViewModels = from graphMemberInfo in categoryTreeNodes.OfType<TSymbolInfo>()
-										where graphMemberInfo.SymbolBase.ContainingType == graphSemanticModel.Symbol ||
-											  graphMemberInfo.SymbolBase.ContainingType.OriginalDefinition == graphSemanticModel.Symbol.OriginalDefinition
+										where graphSemanticModel.Symbol.Equals(graphMemberInfo.SymbolBase.ContainingType) ||
+											  Equals(graphSemanticModel.Symbol.OriginalDefinition, graphMemberInfo.SymbolBase.ContainingType.OriginalDefinition) 
 										select constructor(graphMemberInfo);
 
 			return graphMemberViewModels;
@@ -143,8 +143,8 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 
 			Cancellation.ThrowIfCancellationRequested();
 			var dacGroupingNodesViewModels = from eventInfo in graphCategoryEvents
-											 where eventInfo.Symbol.ContainingType == graphSemanticModel.Symbol ||
-												   eventInfo.Symbol.ContainingType.OriginalDefinition == graphSemanticModel.Symbol.OriginalDefinition
+											 where graphSemanticModel.Symbol.Equals(eventInfo.Symbol.ContainingType) ||
+												   Equals(eventInfo.Symbol.ContainingType.OriginalDefinition, graphSemanticModel.Symbol.OriginalDefinition)
 											 group eventInfo by eventInfo.DacName into graphEventsForDAC
 											 select constructor(graphEventCategory, graphEventsForDAC.Key, graphEventsForDAC) into dacNodeVM
 											 where dacNodeVM != null

--- a/src/Acuminator/Acuminator.Vsix/Utils/Polyfills/MemberNotNullAttribute.cs
+++ b/src/Acuminator/Acuminator.Vsix/Utils/Polyfills/MemberNotNullAttribute.cs
@@ -1,0 +1,27 @@
+﻿namespace System.Diagnostics.CodeAnalysis
+{
+	/// <summary>
+	/// Specifies that the method or property will ensure that the listed field and property members have not-null values.
+	/// </summary>
+	[AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, Inherited = false, AllowMultiple = true)]
+	[ExcludeFromCodeCoverage]
+	internal sealed class MemberNotNullAttribute : Attribute
+	{
+		/// <summary>
+		/// Initializes the attribute with a field or property member.
+		/// </summary>
+		/// <param name="member">The field or property member that is promised to be not-null.</param>
+		public MemberNotNullAttribute(string member) => Members = new[] { member };
+
+		/// <summary>
+		/// Initializes the attribute with the list of field and property members.
+		/// </summary>
+		/// <param name="members">The list of field and property members that are promised to be not-null.</param>
+		public MemberNotNullAttribute(params string[] members) => Members = members;
+
+		/// <summary>
+		/// Gets field or property member names.
+		/// </summary>
+		public string[] Members { get; }
+	}
+}


### PR DESCRIPTION
Overview:
- fixed symbol and node comparisons by replacing with `Equals` usages of `==` and `!=` operators which check only the reference equality
- added nullability analysis to some files
- minor refactoring
- added `MemberNotNullAttribute` polyfill to VSIX to fix strange build error with polysharp