### PR TITLE
Bugfix/atr 810 dev fix default navigation checks

### DIFF
--- a/docs/diagnostics/PX1033.md
+++ b/docs/diagnostics/PX1033.md
@@ -9,7 +9,7 @@ This document describes the PX1033 diagnostic.
 
 ## Diagnostic Description
 You can define a primary key field in a DAC. The diagnostic suggests adding a primary key definition to a DAC. 
-The warning is shown only for DACs that have the `PXCacheName` or `PXPrimaryGraph` attribute.
+The warning is shown only for DACs that have an attribute derived from the `PXCacheName` attribute, or an attribute derived from the `PXPrimaryGraphBase` attribute like `PXPrimaryGraphAttribute`.
 The diagnostic does not check abstract DACs and DACs which have only unbound DAC properties (fully-unbound DACs used for custom popups and filters for inquiry forms).
 
 To fix the issue, add the PK class to the DAC.
@@ -73,7 +73,7 @@ public class SOOrder : IBqlTable
 
 ## Related Articles
 
-[Primary Key](https://help.acumatica.com/(W(7))/Help?ScreenId=ShowWiki&pageid=9e533998-5a08-452d-9490-a02db1cf4c19)  
-[To Define a Primary Key](https://help.acumatica.com/(W(8))/Help?ScreenId=ShowWiki&pageid=34e875c7-a5c3-496e-9e2b-f7f6f9f20a40)  
-[PXCacheNameAttribute Class](https://help.acumatica.com/(W(9))/Help?ScreenId=ShowWiki&pageid=6e89e21c-b8f4-a16b-d741-2d6e483e9f65)  
-[PXPrimaryGraphAttribute Class](https://help.acumatica.com/(W(10))/Help?ScreenId=ShowWiki&pageid=1dceb511-4e98-3700-7d7f-231688a7ac74)
+[Primary Key](https://help.acumatica.com/Help?ScreenId=ShowWiki&pageid=9e533998-5a08-452d-9490-a02db1cf4c19)  
+[To Define a Primary Key](https://help.acumatica.com/Help?ScreenId=ShowWiki&pageid=34e875c7-a5c3-496e-9e2b-f7f6f9f20a40)  
+[PXCacheNameAttribute Class](https://help.acumatica.com/Help?ScreenId=ShowWiki&pageid=6e89e21c-b8f4-a16b-d741-2d6e483e9f65)  
+[PXPrimaryGraphAttribute Class](https://help.acumatica.com/Help?ScreenId=ShowWiki&pageid=1dceb511-4e98-3700-7d7f-231688a7ac74)

--- a/docs/diagnostics/PX1033.md
+++ b/docs/diagnostics/PX1033.md
@@ -9,7 +9,7 @@ This document describes the PX1033 diagnostic.
 
 ## Diagnostic Description
 You can define a primary key field in a DAC. The diagnostic suggests adding a primary key definition to a DAC. 
-The warning is shown only for DACs that have an attribute derived from the `PXCacheName` attribute, or an attribute derived from the `PXPrimaryGraphBase` attribute like `PXPrimaryGraphAttribute`.
+The warning is shown only for DACs that have an attribute derived from the `PXCacheName` attribute, or an attribute derived from the `PXPrimaryGraphBase` attribute such as `PXPrimaryGraphAttribute`.
 The diagnostic does not check abstract DACs and DACs which have only unbound DAC properties (fully-unbound DACs used for custom popups and filters for inquiry forms).
 
 To fix the issue, add the PK class to the DAC.

--- a/docs/diagnostics/PX1034.md
+++ b/docs/diagnostics/PX1034.md
@@ -8,7 +8,8 @@ This document describes the PX1034 diagnostic.
 | PX1034 | The DAC does not have an explicit foreign key declaration | Warning (ISV Level 3: Informational) | Available | 
 
 ## Diagnostic Description
-You can define foreign keys in a DAC. The diagnostic suggests adding a foreign key definition to a DAC. The warning is shown only for DACs that have the `PXCacheName` or `PXPrimaryGraph` attribute.
+You can define foreign keys in a DAC. The diagnostic suggests adding a foreign key definition to a DAC. 
+The warning is shown only for DACs that have an attribute derived from the `PXCacheName` attribute, or an attribute derived from the `PXPrimaryGraphBase` attribute like `PXPrimaryGraphAttribute`.
 The diagnostic does not check abstract DACs and DACs which have only unbound DAC properties (fully-unbound DACs used for custom popups and filters for inquiry forms).
 
 To fix the issue, add the public static FK class to the DAC.
@@ -70,7 +71,7 @@ public class SOOrder : IBqlTable
 
 ## Related Articles
 
-[Foreign Keys and Nullable Columns](https://help.acumatica.com/(W(12))/Help?ScreenId=ShowWiki&pageid=8da9e9c6-ebbf-409a-b43d-a13d2081a62e)  
-[To Define a Foreign Key](https://help.acumatica.com/(W(11))/Help?ScreenId=ShowWiki&pageid=20b9a017-ff40-42b7-843c-94f2fced764e)  
-[PXCacheNameAttribute Class](https://help.acumatica.com/(W(9))/Help?ScreenId=ShowWiki&pageid=6e89e21c-b8f4-a16b-d741-2d6e483e9f65)  
-[PXPrimaryGraphAttribute Class](https://help.acumatica.com/(W(10))/Help?ScreenId=ShowWiki&pageid=1dceb511-4e98-3700-7d7f-231688a7ac74)
+[Foreign Keys and Nullable Columns](https://help.acumatica.com/Help?ScreenId=ShowWiki&pageid=8da9e9c6-ebbf-409a-b43d-a13d2081a62e)  
+[To Define a Foreign Key](https://help.acumatica.com/Help?ScreenId=ShowWiki&pageid=20b9a017-ff40-42b7-843c-94f2fced764e)  
+[PXCacheNameAttribute Class](https://help.acumatica.com/Help?ScreenId=ShowWiki&pageid=6e89e21c-b8f4-a16b-d741-2d6e483e9f65)  
+[PXPrimaryGraphAttribute Class](https://help.acumatica.com/Help?ScreenId=ShowWiki&pageid=1dceb511-4e98-3700-7d7f-231688a7ac74)

--- a/docs/diagnostics/PX1034.md
+++ b/docs/diagnostics/PX1034.md
@@ -9,7 +9,7 @@ This document describes the PX1034 diagnostic.
 
 ## Diagnostic Description
 You can define foreign keys in a DAC. The diagnostic suggests adding a foreign key definition to a DAC. 
-The warning is shown only for DACs that have an attribute derived from the `PXCacheName` attribute, or an attribute derived from the `PXPrimaryGraphBase` attribute like `PXPrimaryGraphAttribute`.
+The warning is shown only for DACs that have an attribute derived from the `PXCacheName` attribute, or an attribute derived from the `PXPrimaryGraphBase` attribute such as `PXPrimaryGraphAttribute`.
 The diagnostic does not check abstract DACs and DACs which have only unbound DAC properties (fully-unbound DACs used for custom popups and filters for inquiry forms).
 
 To fix the issue, add the public static FK class to the DAC.

--- a/docs/diagnostics/PX1035.md
+++ b/docs/diagnostics/PX1035.md
@@ -90,10 +90,10 @@ public class SOOrder : IBqlTable
 
 ## Related Articles
 
-[Primary Key](https://help.acumatica.com/(W(7))/Help?ScreenId=ShowWiki&pageid=9e533998-5a08-452d-9490-a02db1cf4c19)
+[Primary Key](https://help.acumatica.com/Help?ScreenId=ShowWiki&pageid=9e533998-5a08-452d-9490-a02db1cf4c19)
 
-[To Define a Primary Key](https://help.acumatica.com/(W(8))/Help?ScreenId=ShowWiki&pageid=34e875c7-a5c3-496e-9e2b-f7f6f9f20a40)
+[To Define a Primary Key](https://help.acumatica.com/Help?ScreenId=ShowWiki&pageid=34e875c7-a5c3-496e-9e2b-f7f6f9f20a40)
 
-[PXCacheNameAttribute Class](https://help.acumatica.com/(W(9))/Help?ScreenId=ShowWiki&pageid=6e89e21c-b8f4-a16b-d741-2d6e483e9f65)
+[PXCacheNameAttribute Class](https://help.acumatica.com/Help?ScreenId=ShowWiki&pageid=6e89e21c-b8f4-a16b-d741-2d6e483e9f65)
 
-[PXPrimaryGraphAttribute Class](https://help.acumatica.com/(W(10))/Help?ScreenId=ShowWiki&pageid=1dceb511-4e98-3700-7d7f-231688a7ac74)  
+[PXPrimaryGraphAttribute Class](https://help.acumatica.com/Help?ScreenId=ShowWiki&pageid=1dceb511-4e98-3700-7d7f-231688a7ac74)  

--- a/docs/diagnostics/PX1036.md
+++ b/docs/diagnostics/PX1036.md
@@ -9,7 +9,7 @@ This document describes the PX1036 diagnostic.
 
 ## Diagnostic Description
 The diagnostic checks the correct naming of primary, foreign, and unique key field declarations in DACs. For a primary key, the name should be `PK`. For a foreign key, the name can be arbitrary but the key should be declared in a public static class called `FK`. For a single unique key, the name should be `UK`. Multiple unique keys in the DAC can have arbitrary names but they must be declared in a public static class called `UK`.
-The warning is shown only for DACs that have the `PXCacheName` or `PXPrimaryGraph` attribute.
+The warning is shown only for DACs that have an attribute derived from the `PXCacheName` attribute, or an attribute derived from the `PXPrimaryGraphBase` attribute like `PXPrimaryGraphAttribute`.
 The diagnostic does not check abstract DACs or DACs that have only unbound DAC properties (fully unbound DACs used for custom pop-ups and filters for inquiry forms).
 
 The diagnostic also checks the declaration and implementation of a unique key by using the following rules:
@@ -170,10 +170,10 @@ public partial class INUnitMultipleUniqueKeysNoPK : IBqlTable
 
 ## Related Articles
 
-[Primary Key](https://help.acumatica.com/(W(7))/Help?ScreenId=ShowWiki&pageid=9e533998-5a08-452d-9490-a02db1cf4c19)
+[Primary Key](https://help.acumatica.com/Help?ScreenId=ShowWiki&pageid=9e533998-5a08-452d-9490-a02db1cf4c19)
 
-[To Define a Primary Key](https://help.acumatica.com/(W(8))/Help?ScreenId=ShowWiki&pageid=34e875c7-a5c3-496e-9e2b-f7f6f9f20a40)
+[To Define a Primary Key](https://help.acumatica.com/Help?ScreenId=ShowWiki&pageid=34e875c7-a5c3-496e-9e2b-f7f6f9f20a40)
 
-[PXCacheNameAttribute Class](https://help.acumatica.com/(W(9))/Help?ScreenId=ShowWiki&pageid=6e89e21c-b8f4-a16b-d741-2d6e483e9f65)
+[PXCacheNameAttribute Class](https://help.acumatica.com/Help?ScreenId=ShowWiki&pageid=6e89e21c-b8f4-a16b-d741-2d6e483e9f65)
 
-[PXPrimaryGraphAttribute Class](https://help.acumatica.com/(W(10))/Help?ScreenId=ShowWiki&pageid=1dceb511-4e98-3700-7d7f-231688a7ac74)
+[PXPrimaryGraphAttribute Class](https://help.acumatica.com/Help?ScreenId=ShowWiki&pageid=1dceb511-4e98-3700-7d7f-231688a7ac74)

--- a/docs/diagnostics/PX1036.md
+++ b/docs/diagnostics/PX1036.md
@@ -9,7 +9,7 @@ This document describes the PX1036 diagnostic.
 
 ## Diagnostic Description
 The diagnostic checks the correct naming of primary, foreign, and unique key field declarations in DACs. For a primary key, the name should be `PK`. For a foreign key, the name can be arbitrary but the key should be declared in a public static class called `FK`. For a single unique key, the name should be `UK`. Multiple unique keys in the DAC can have arbitrary names but they must be declared in a public static class called `UK`.
-The warning is shown only for DACs that have an attribute derived from the `PXCacheName` attribute, or an attribute derived from the `PXPrimaryGraphBase` attribute like `PXPrimaryGraphAttribute`.
+The warning is shown only for DACs that have an attribute derived from the `PXCacheName` attribute, or an attribute derived from the `PXPrimaryGraphBase` attribute such as `PXPrimaryGraphAttribute`.
 The diagnostic does not check abstract DACs or DACs that have only unbound DAC properties (fully unbound DACs used for custom pop-ups and filters for inquiry forms).
 
 The diagnostic also checks the declaration and implementation of a unique key by using the following rules:

--- a/docs/diagnostics/PX1037.md
+++ b/docs/diagnostics/PX1037.md
@@ -36,16 +36,16 @@ public partial class SOLine : PX.Data.IBqlTable
 
 ## Related Articles
 
-[Primary Key](https://help.acumatica.com/(W(7))/Help?ScreenId=ShowWiki&pageid=9e533998-5a08-452d-9490-a02db1cf4c19)
+[Primary Key](https://help.acumatica.com/Help?ScreenId=ShowWiki&pageid=9e533998-5a08-452d-9490-a02db1cf4c19)
 
-[To Define a Primary Key](https://help.acumatica.com/(W(8))/Help?ScreenId=ShowWiki&pageid=34e875c7-a5c3-496e-9e2b-f7f6f9f20a40)
+[To Define a Primary Key](https://help.acumatica.com/Help?ScreenId=ShowWiki&pageid=34e875c7-a5c3-496e-9e2b-f7f6f9f20a40)
 
-[PXCacheNameAttribute Class](https://help.acumatica.com/(W(9))/Help?ScreenId=ShowWiki&pageid=6e89e21c-b8f4-a16b-d741-2d6e483e9f65)
+[PXCacheNameAttribute Class](https://help.acumatica.com/Help?ScreenId=ShowWiki&pageid=6e89e21c-b8f4-a16b-d741-2d6e483e9f65)
 
-[PXPrimaryGraphAttribute Class](https://help.acumatica.com/(W(10))/Help?ScreenId=ShowWiki&pageid=1dceb511-4e98-3700-7d7f-231688a7ac74)
+[PXPrimaryGraphAttribute Class](https://help.acumatica.com/Help?ScreenId=ShowWiki&pageid=1dceb511-4e98-3700-7d7f-231688a7ac74)
 
-[Data Access Classes] (https://help.acumatica.com/(W(2))/Help?ScreenId=ShowWiki&pageid=3f6ee8e9-b29e-4dab-b4f8-4406c3ef101d)
+[Data Access Classes] (https://help.acumatica.com/Help?ScreenId=ShowWiki&pageid=3f6ee8e9-b29e-4dab-b4f8-4406c3ef101d)
 
-[Bound Field Data Types] (https://help.acumatica.com/(W(1))/Help?ScreenId=ShowWiki&pageid=61059393-8873-451f-b474-783906330fc6)
+[Bound Field Data Types] (https://help.acumatica.com/Help?ScreenId=ShowWiki&pageid=61059393-8873-451f-b474-783906330fc6)
 
-[Unbound Field Data Types] (https://help.acumatica.com/(W(1))/Help?ScreenId=ShowWiki&pageid=61059393-8873-451f-b474-783906330fc6)
+[Unbound Field Data Types] (https://help.acumatica.com/Help?ScreenId=ShowWiki&pageid=61059393-8873-451f-b474-783906330fc6)

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/DacReferentialIntegrity/DacKeyDeclarationAnalyzerBase.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/DacReferentialIntegrity/DacKeyDeclarationAnalyzerBase.cs
@@ -279,11 +279,11 @@ namespace Acuminator.Analyzers.StaticAnalysis.DacReferentialIntegrity
 				return false;
 
 			var pxCacheNameAttribute = context.AttributeTypes.PXCacheNameAttribute;
-			var pxPrimaryGraphAttribute = context.AttributeTypes.PXPrimaryGraphAttribute;
+			var defaultNavigationAttribute = context.AttributeTypes.PXPrimaryGraphBaseAttribute ?? context.AttributeTypes.PXPrimaryGraphAttribute;
 
 			return dacAttributes.Any(attribute => attribute.AttributeClass != null &&
 												 (attribute.AttributeClass.InheritsFromOrEquals(pxCacheNameAttribute) ||
-												  attribute.AttributeClass.InheritsFromOrEquals(pxPrimaryGraphAttribute)));
+												  attribute.AttributeClass.InheritsFromOrEquals(defaultNavigationAttribute)));
 		}
 
 		protected abstract void MakeSpecificDacKeysAnalysis(SymbolAnalysisContext symbolContext, PXContext context, DacSemanticModel dac, 

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/DacReferentialIntegrity/DacUniqueKeyDeclaration/Sources/WrongUniqueKeyDeclaration/SOOrder_SingleUniqueKey_WrongName.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/DacReferentialIntegrity/DacUniqueKeyDeclaration/Sources/WrongUniqueKeyDeclaration/SOOrder_SingleUniqueKey_WrongName.cs
@@ -3,7 +3,7 @@ using PX.Data.ReferentialIntegrity.Attributes;
 
 namespace Acuminator.Tests.Tests.StaticAnalysis.DacReferentialIntegrity.Sources
 {
-	[PXCacheName("SO Order")]
+	[PX.Objects.CR.CRCacheIndependentPrimaryGraphList(new[] { typeof(PX.Objects.AR.CustomerMaint) }, new[] { typeof(Select<PX.Objects.AR.Customer>) })]
 	public class SOOrderWronglyNamedUniqueKey : IBqlTable
 	{
 		public class PK : PrimaryKeyOf<SOOrderWronglyNamedUniqueKey>.By<orderType, orderNbr>

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/DacReferentialIntegrity/DacUniqueKeyDeclaration/Sources/WrongUniqueKeyDeclaration/SOOrder_SingleUniqueKey_WrongName_Expected.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/DacReferentialIntegrity/DacUniqueKeyDeclaration/Sources/WrongUniqueKeyDeclaration/SOOrder_SingleUniqueKey_WrongName_Expected.cs
@@ -3,7 +3,7 @@ using PX.Data.ReferentialIntegrity.Attributes;
 
 namespace Acuminator.Tests.Tests.StaticAnalysis.DacReferentialIntegrity.Sources
 {
-	[PXCacheName("SO Order")]
+	[PX.Objects.CR.CRCacheIndependentPrimaryGraphList(new[] { typeof(PX.Objects.AR.CustomerMaint) }, new[] { typeof(Select<PX.Objects.AR.Customer>) })]
 	public class SOOrderWronglyNamedUniqueKey : IBqlTable
 	{
 		public class PK : PrimaryKeyOf<SOOrderWronglyNamedUniqueKey>.By<orderType, orderNbr>

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Constants/TypeFullNames.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Constants/TypeFullNames.cs
@@ -86,7 +86,10 @@
 		internal const string PXImportAttribute = "PX.Data.PXImportAttribute";
 		internal const string PXHiddenAttribute = "PX.Data.PXHiddenAttribute";
 		internal const string PXCacheNameAttribute = "PX.Data.PXCacheNameAttribute";
+
 		internal const string PXPrimaryGraphAttribute = "PX.Data.PXPrimaryGraphAttribute";
+		internal const string PXPrimaryGraphBaseAttribute = "PX.Data.PXPrimaryGraphBaseAttribute";
+
 		internal const string PXCopyPasteHiddenViewAttribute = "PX.Data.PXCopyPasteHiddenViewAttribute";
 		internal const string PXOverrideAttribute = "PX.Data.PXOverrideAttribute";
 		internal const string PXEventSubscriberAttribute = "PX.Data.PXEventSubscriberAttribute";

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/Symbols/Attributes/AttributeSymbols.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/Symbols/Attributes/AttributeSymbols.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#nullable enable
+
+using System;
 using Microsoft.CodeAnalysis;
 using Acuminator.Utilities.Roslyn.Constants;
 
@@ -14,6 +16,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic.Symbols
 		public INamedTypeSymbol PXHiddenAttribute => Compilation.GetTypeByMetadataName(TypeFullNames.PXHiddenAttribute);
 		public INamedTypeSymbol PXCacheNameAttribute => Compilation.GetTypeByMetadataName(TypeFullNames.PXCacheNameAttribute);
 		public INamedTypeSymbol PXPrimaryGraphAttribute => Compilation.GetTypeByMetadataName(TypeFullNames.PXPrimaryGraphAttribute);
+		public INamedTypeSymbol? PXPrimaryGraphBaseAttribute => Compilation.GetTypeByMetadataName(TypeFullNames.PXPrimaryGraphBaseAttribute);
 		public INamedTypeSymbol PXCopyPasteHiddenViewAttribute => Compilation.GetTypeByMetadataName(TypeFullNames.PXCopyPasteHiddenViewAttribute);
 		public INamedTypeSymbol PXOverrideAttribute => Compilation.GetTypeByMetadataName(TypeFullNames.PXOverrideAttribute);
 


### PR DESCRIPTION
Overview:
- added symbol for `PXPrimaryGraphBaseAttribute`
- fixed check for default navigation for diagnostics checking PK, FK and UK declarations in DACs
- updated unit tests to check that PX1033-PX1037 diagnostics work for DACs with default navigation
- updated documentation for PX1033-PX1037 diagnostics, fixed broken references in the documentation