### PR TITLE
Feature/atr 548 dev check bql type compatible with property type

### DIFF
--- a/docs/Summary.md
+++ b/docs/Summary.md
@@ -75,6 +75,7 @@ Acuminator does not perform static analysis of projects whose names contain `Tes
 | [PX1065](diagnostics/PX1065.md) | The DAC field property does not have a corresponding BQL field. | Error | Available |
 | [PX1066](diagnostics/PX1066.md) | The name of the BQL field possibly contains mistake. | Warning (ISV Level 3: Informational) | Available |
 | [PX1067](diagnostics/PX1067.md) | DAC does not contain a redeclaration of a BQL field declared in the base DAC. | Warning (ISV Level 3: Informational) | Available |
+| [PX1068](diagnostics/PX1068.md) | The type of the DAC field property does not correspond to the type of the BQL field. | Error | Available |
 | [PX1070](diagnostics/PX1070.md) | The state of fields and actions can be configured only in `RowSelected` event handlers. | Error | Unavailable |
 | [PX1071](diagnostics/PX1071.md) | Actions cannot be executed within event handlers. | Error | Unavailable |
 | [PX1072](diagnostics/PX1072.md) | BQL queries must be executed within the context of an existing `PXGraph` instance. | Warning (ISV Level 1: Significant) | Available |

--- a/docs/diagnostics/PX1068.md
+++ b/docs/diagnostics/PX1068.md
@@ -8,12 +8,12 @@ This document describes the PX1068 diagnostic.
 | PX1068 |  The type of the DAC field property does not correspond to the type of the BQL field.                        | Error | Available |
 
 ## Diagnostic Description
-The DAC field property must have a type that is consistent with the type of the BQL field corresponding to this property. For example, if a DAC field property has the `int?` type, 
-then the type of a corresponding BQL field should be `BqlInt`. 
+The DAC field property must have a type that is consistent with the type of the BQL field that corresponds to this property. For example, if a DAC field property has the `int?` type, 
+then the type of the corresponding BQL field should be `BqlInt`. 
 
 The diagnostic has two available code fixes:
- - Change the property type so that it corresponds to the BQL field type attribute.
- - Change the BQL field type so that it corresponds to the property type.
+ - Change the property type so that it corresponds to the type attribute of the BQL field.
+ - Change the type of the BQL field so that it corresponds to the property type.
 
 ## Example of Incorrect Code
 

--- a/docs/diagnostics/PX1068.md
+++ b/docs/diagnostics/PX1068.md
@@ -1,0 +1,64 @@
+# PX1068
+This document describes the PX1068 diagnostic.
+
+## Summary
+
+| Code   | Short Description                                                                                            | Type  | Code Fix  | 
+| ------ | ------------------------------------------------------------------------------------------------------------ | ----- | --------- | 
+| PX1068 |  The type of the DAC field property does not correspond to the type of the BQL field.                        | Error | Available |
+
+## Diagnostic Description
+The DAC field property must have a type that is consistent with the type of the BQL field corresponding to this property. For example, if a DAC field property has the `int?` type, 
+then the type of a corresponding BQL field should be `BqlInt`. 
+
+The diagnostic has two available code fixes:
+ - Change the property type so that it corresponds to the BQL field type attribute.
+ - Change the BQL field type so that it corresponds to the property type.
+
+## Example of Incorrect Code
+
+```C#
+public class SOOrder : PXBqlTable, IBqlTable
+{
+	#region OrderType
+	[PXUIField]
+	public virtual byte[] OrderType { get; set; }
+
+	public abstract class orderType : PX.Data.BQL.BqlString.Field<orderType> { }
+	#endregion
+
+    #region NoteID
+	public abstract class noteID : PX.Data.BQL.BqlInt.Field<noteID> { }
+
+	[PXGuid]
+	public Guid? NoteID { get; set; }
+	#endregion
+}
+```
+
+## Example of Code Fix
+
+```C#
+public class SOOrder : PXBqlTable, IBqlTable
+{
+	#region OrderType
+	[PXUIField]
+	public virtual string OrderType { get; set; }
+
+	public abstract class orderType : PX.Data.BQL.BqlString.Field<orderType> { }
+	#endregion
+
+	#region NoteID
+	public abstract class noteID : PX.Data.BQL.BqlGuid.Field<noteID> { }
+
+	[PXGuid]
+	public Guid? NoteID { get; set; }
+	#endregion
+}
+```
+
+## Related Articles
+
+ - [Data Access Classes in Fluent BQL](https://help.acumatica.com/Help?ScreenId=ShowWiki&pageid=957f950d-22cd-4b2f-81ca-77464d0c9eff)
+ - [Data Access Classes in Traditional BQL](https://help.acumatica.com/Help?ScreenId=ShowWiki&pageid=a47ddb36-eb85-486f-9d6b-49beac42fc80)
+ - [Data Field](https://help.acumatica.com/Help?ScreenId=ShowWiki&pageid=b3d24079-bda4-4f82-9fbd-c444a8bcb733)

--- a/src/Acuminator/Acuminator.Analyzers/DiagnosticsShortName.Designer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/DiagnosticsShortName.Designer.cs
@@ -727,6 +727,15 @@ namespace Acuminator.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to PropertyAndBqlFieldTypesMismatch.
+        /// </summary>
+        public static string PX1068 {
+            get {
+                return ResourceManager.GetString("PX1068", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to UiPresentationLogicInEventHandlers.
         /// </summary>
         public static string PX1070 {

--- a/src/Acuminator/Acuminator.Analyzers/DiagnosticsShortName.resx
+++ b/src/Acuminator/Acuminator.Analyzers/DiagnosticsShortName.resx
@@ -339,6 +339,9 @@
   <data name="PX1067" xml:space="preserve">
     <value>MissingBqlFieldRedeclarationInDerivedDac</value>
   </data>
+  <data name="PX1068" xml:space="preserve">
+    <value>PropertyAndBqlFieldTypesMismatch</value>
+  </data>
   <data name="PX1070" xml:space="preserve">
     <value>UiPresentationLogicInEventHandlers</value>
   </data>

--- a/src/Acuminator/Acuminator.Analyzers/Resources.Designer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/Resources.Designer.cs
@@ -1537,6 +1537,33 @@ namespace Acuminator.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Change the BQL type so that it corresponds to the property type.
+        /// </summary>
+        public static string PX1068FixBqlType {
+            get {
+                return ResourceManager.GetString("PX1068FixBqlType", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Change the property type so that it corresponds to the BQL type.
+        /// </summary>
+        public static string PX1068FixPropertyType {
+            get {
+                return ResourceManager.GetString("PX1068FixPropertyType", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The type of the DAC field property does not correspond to the type of the BQL field.
+        /// </summary>
+        public static string PX1068Title {
+            get {
+                return ResourceManager.GetString("PX1068Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The state of fields and actions can be configured only in the RowSelected event handler.
         /// </summary>
         public static string PX1070Title {

--- a/src/Acuminator/Acuminator.Analyzers/Resources.resx
+++ b/src/Acuminator/Acuminator.Analyzers/Resources.resx
@@ -615,6 +615,15 @@ public virtual int? SomeDacField{ get; set; }</value>
   <data name="PX1067TitleFormat" xml:space="preserve">
     <value>BQL fields from base DACs should be redeclared in the derived DAC. DAC "{0}" does not contain a redeclaration of BQL field "{1}" declared in the base DAC "{2}".</value>
   </data>
+  <data name="PX1068FixBqlType" xml:space="preserve">
+    <value>Change the BQL type so that it corresponds to the property type</value>
+  </data>
+  <data name="PX1068FixPropertyType" xml:space="preserve">
+    <value>Change the property type so that it corresponds to the BQL type</value>
+  </data>
+  <data name="PX1068Title" xml:space="preserve">
+    <value>The type of the DAC field property does not correspond to the type of the BQL field</value>
+  </data>
   <data name="PX1070Title" xml:space="preserve">
     <value>The state of fields and actions can be configured only in the RowSelected event handler</value>
   </data>

--- a/src/Acuminator/Acuminator.Analyzers/Resources.resx
+++ b/src/Acuminator/Acuminator.Analyzers/Resources.resx
@@ -616,10 +616,10 @@ public virtual int? SomeDacField{ get; set; }</value>
     <value>BQL fields from a base DAC should be redeclared in the derived DAC. The "{0}" DAC does not contain a redeclaration of the "{1}" BQL field declared in the "{2}" base DAC.</value>
   </data>
   <data name="PX1068FixBqlType" xml:space="preserve">
-    <value>Change the BQL type so that it corresponds to the property type</value>
+    <value>Change the type of the BQL field so that it corresponds to the property type</value>
   </data>
   <data name="PX1068FixPropertyType" xml:space="preserve">
-    <value>Change the property type so that it corresponds to the BQL type</value>
+    <value>Change the property type so that it corresponds to the type of the BQL field</value>
   </data>
   <data name="PX1068Title" xml:space="preserve">
     <value>The type of the DAC field property does not correspond to the type of the BQL field</value>

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/BannedApi/BannedApiAnalyzer.ApiNodesWalker.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/BannedApi/BannedApiAnalyzer.ApiNodesWalker.cs
@@ -174,7 +174,7 @@ public partial class BannedApiAnalyzer
 			{
 				var typeName = genericNameNode.Identifier.ValueText;
 				return !typeName.IsNullOrWhiteSpace()
-					? (genericNameNode.Identifier.GetLocation() ?? genericNameNode.GetLocation())
+					? (genericNameNode.Identifier.GetLocation().NullIfLocationKindIsNone() ?? genericNameNode.GetLocation())
 					: genericNameNode.GetLocation();
 			}
 		}

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/CallsToInternalAPI/InternalApiCallsWalker.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/CallsToInternalAPI/InternalApiCallsWalker.cs
@@ -55,7 +55,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.CallsToInternalAPI
 
 			if (IsInternalApiType(typeSymbol))
 			{
-				ReportInternalApiDiagnostic(genericName.Identifier.GetLocation());
+				ReportInternalApiDiagnostic(genericName.Identifier.GetLocation().NullIfLocationKindIsNone());
 			}
 
 			base.VisitGenericName(genericName);
@@ -70,7 +70,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.CallsToInternalAPI
 
 			if (IsInternalApiType(typeSymbol))
 			{
-				ReportInternalApiDiagnostic(identifierName.Identifier.GetLocation());
+				ReportInternalApiDiagnostic(identifierName.Identifier.GetLocation().NullIfLocationKindIsNone());
 			}
 		}
 

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/Dac/DacAnalyzersAggregator.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/Dac/DacAnalyzersAggregator.cs
@@ -20,6 +20,7 @@ using Acuminator.Analyzers.StaticAnalysis.NoBqlFieldForDacFieldProperty;
 using Acuminator.Analyzers.StaticAnalysis.NoIsActiveMethodForExtension;
 using Acuminator.Analyzers.StaticAnalysis.NonNullableTypeForBqlField;
 using Acuminator.Analyzers.StaticAnalysis.NonPublicGraphsDacsAndExtensions;
+using Acuminator.Analyzers.StaticAnalysis.PropertyAndBqlFieldTypesMismatch;
 using Acuminator.Analyzers.StaticAnalysis.PXGraphCreationInGraphInWrongPlaces;
 using Acuminator.Analyzers.StaticAnalysis.PXGraphUsageInDac;
 using Acuminator.Analyzers.StaticAnalysis.UnderscoresInDac;
@@ -50,6 +51,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.Dac
 			new InheritanceFromPXCacheExtensionAnalyzer(),
 			new NoBqlFieldForDacFieldPropertyAnalyzer(),
 			new MissingBqlFieldRedeclarationInDerivedDacAnalyzer(),
+			new PropertyAndBqlFieldTypesMismatchAnalyzer(),
 			new LegacyBqlFieldAnalyzer(),
 			new MethodsUsageInDacAnalyzer(),
 			new KeyFieldDeclarationAnalyzer(),

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/DacPropertyAttributes/DacPropertyAttributesAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/DacPropertyAttributes/DacPropertyAttributesAnalyzer.cs
@@ -266,7 +266,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.DacPropertyAttributes
 				return;
 			}
 
-			if (!dataTypeFromAttribute.Equals(property.EffectivePropertyType, SymbolEqualityComparer.Default))
+			if (!dataTypeFromAttribute.Equals(property.PropertyTypeUnwrappedNullable, SymbolEqualityComparer.Default))
 			{
 				ReportIncompatibleTypesDiagnostics(property, dataTypeAttribute, symbolContext, pxContext, registerCodeFix: true);
 			}

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/DacPropertyAttributes/DacPropertyAttributesAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/DacPropertyAttributes/DacPropertyAttributesAnalyzer.cs
@@ -162,7 +162,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.DacPropertyAttributes
 			// Node not null here because aggregated DAC analysers by default run only on DACs in source 
 			// and these properties are declared in the DAC type itself
 			if (hasUnboundTypeAttribute || (!hasPXDBCalcedAttribute && !hasPXDBScalarAttribute) ||
-				property.Node!.Identifier.GetLocation() is not Location location)
+				property.Node!.Identifier.GetLocation().NullIfLocationKindIsNone() is not Location location)
 			{
 				return;
 			}

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/DacReferentialIntegrity/DacForeignKeyDeclaration/DacForeignKeyDeclarationAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/DacReferentialIntegrity/DacForeignKeyDeclaration/DacForeignKeyDeclarationAnalyzer.cs
@@ -354,7 +354,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.DacReferentialIntegrity
 
 		private void ReportNoForeignKeyDeclarationsInDac(SymbolAnalysisContext symbolContext, PXContext context, DacSemanticModel dac)
 		{
-			var location = dac.Node?.Identifier.GetLocation() ?? dac.Node?.GetLocation();
+			var location = dac.Node?.Identifier.GetLocation().NullIfLocationKindIsNone() ?? dac.Node?.GetLocation();
 
 			if (location != null)
 			{

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/DacReferentialIntegrity/DacKeyDeclarationAnalyzerBase.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/DacReferentialIntegrity/DacKeyDeclarationAnalyzerBase.cs
@@ -110,7 +110,9 @@ namespace Acuminator.Analyzers.StaticAnalysis.DacReferentialIntegrity
 		private bool ReportKeyWithUnboundDacField(SymbolAnalysisContext symbolContext, PXContext context, INamedTypeSymbol key, ClassDeclarationSyntax keyNode,
 												  ITypeSymbol unboundDacFieldInKey)
 		{
-			var location = GetUnboundDacFieldLocation(keyNode, unboundDacFieldInKey) ?? keyNode.Identifier.GetLocation() ?? keyNode.GetLocation();
+			var location = GetUnboundDacFieldLocation(keyNode, unboundDacFieldInKey) ?? 
+						   keyNode.Identifier.GetLocation().NullIfLocationKindIsNone() ?? 
+						   keyNode.GetLocation();
 
 			if (location == null)
 				return false;
@@ -182,7 +184,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.DacReferentialIntegrity
 				allFieldsUnique = false;
 				var locations = duplicateKeys.Select(declaration => declaration.GetSyntax(symbolContext.CancellationToken))
 											 .OfType<ClassDeclarationSyntax>()
-											 .Select(keyClassDeclaration => keyClassDeclaration.Identifier.GetLocation() ??
+											 .Select(keyClassDeclaration => keyClassDeclaration.Identifier.GetLocation().NullIfLocationKindIsNone() ??
 																			keyClassDeclaration.GetLocation())
 											 .Where(location => location != null)
 											 .ToList(capacity: duplicateKeys.Count);
@@ -287,7 +289,8 @@ namespace Acuminator.Analyzers.StaticAnalysis.DacReferentialIntegrity
 																 INamedTypeSymbol keyDeclaration, RefIntegrityDacKeyType dacKeyType)
 		{
 			var keyDeclarationNode = keyDeclaration.GetSyntax(symbolContext.CancellationToken);
-			Location? location = (keyDeclarationNode as ClassDeclarationSyntax)?.Identifier.GetLocation() ?? keyDeclarationNode?.GetLocation();
+			Location? location = (keyDeclarationNode as ClassDeclarationSyntax)?.Identifier.GetLocation().NullIfLocationKindIsNone() ?? 
+								  keyDeclarationNode?.GetLocation();
 			Location? dacLocation = dac.Node?.GetLocation();
 			DiagnosticDescriptor? px1036Descriptor = GetWrongKeyNameDiagnosticDescriptor(dacKeyType);
 
@@ -322,7 +325,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.DacReferentialIntegrity
 		protected IEnumerable<Location> GetKeysLocations(IEnumerable<INamedTypeSymbol> keys, CancellationToken cancellationToken) =>
 			keys.Select(key => key.GetSyntax(cancellationToken))
 				.OfType<ClassDeclarationSyntax>()
-				.Select(keyClassDeclaration => keyClassDeclaration.Identifier.GetLocation() ?? keyClassDeclaration.GetLocation())
+				.Select(keyClassDeclaration => keyClassDeclaration.Identifier.GetLocation().NullIfLocationKindIsNone() ?? keyClassDeclaration.GetLocation())
 				.Where(location => location != null)
 				.OrderBy(location => location.SourceSpan.Start);
 	}

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/DacReferentialIntegrity/DacPrimaryKeyDeclaration/DacPrimaryAndUniqueKeyDeclarationAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/DacReferentialIntegrity/DacPrimaryKeyDeclaration/DacPrimaryAndUniqueKeyDeclarationAnalyzer.cs
@@ -140,7 +140,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.DacReferentialIntegrity
 
 		private void ReportNoPrimaryKeyDeclarationsInDac(SymbolAnalysisContext symbolContext, PXContext context, DacSemanticModel dac)
 		{
-			var location = dac.Node?.Identifier.GetLocation() ?? dac.Node?.GetLocation();
+			var location = dac.Node?.Identifier.GetLocation().NullIfLocationKindIsNone() ?? dac.Node?.GetLocation();
 
 			if (location != null)
 			{

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/Descriptors.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/Descriptors.cs
@@ -367,6 +367,9 @@ namespace Acuminator.Analyzers.StaticAnalysis
 		public static DiagnosticDescriptor PX1067_MissingBqlFieldRedeclarationInDerivedDac { get; } =
 			Rule("PX1067", nameof(Resources.PX1067TitleFormat).GetLocalized(), Category.Acuminator, DiagnosticSeverity.Warning, DiagnosticsShortName.PX1067);
 
+		public static DiagnosticDescriptor PX1068_PropertyAndBqlFieldTypesMismatch { get; } =
+			Rule("PX1068", nameof(Resources.PX1068Title).GetLocalized(), Category.Acuminator, DiagnosticSeverity.Error, DiagnosticsShortName.PX1068);
+
 		public static DiagnosticDescriptor PX1070_UiPresentationLogicInEventHandlers { get; } =
 			Rule("PX1070", nameof(Resources.PX1070Title).GetLocalized(), Category.Acuminator, DiagnosticSeverity.Error, DiagnosticsShortName.PX1070);
 

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/DiagnosticProperty.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/DiagnosticProperty.cs
@@ -24,6 +24,11 @@ namespace Acuminator.Analyzers.StaticAnalysis
 		public const string DacFieldName = nameof(DacFieldName);
 
 		/// <summary>
+		/// The property used to pass the name of the BQL field with the diagnostic.
+		/// </summary>
+		public const string BqlFieldName = nameof(BqlFieldName);
+
+		/// <summary>
 		/// The property used to pass the DAC metadata with the diagnostic.
 		/// </summary>
 		public const string DacMetadataName = nameof(DacMetadataName);

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/DiagnosticProperty.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/DiagnosticProperty.cs
@@ -1,4 +1,5 @@
-﻿
+﻿using System;
+
 namespace Acuminator.Analyzers.StaticAnalysis
 {
 	/// <summary>
@@ -33,7 +34,7 @@ namespace Acuminator.Analyzers.StaticAnalysis
 		public const string IsBoundField = nameof(IsBoundField);
 
 		/// <summary>
-		/// The property used to pass the information about a property type, usually, a DAC property.
+		/// The property used to pass the information about a property data type like <see cref="String"/>. Usually, it is used for a DAC property.
 		/// </summary>
 		public const string PropertyType = nameof(PropertyType);
 
@@ -41,6 +42,11 @@ namespace Acuminator.Analyzers.StaticAnalysis
 		/// The property used to pass the information about a DAC BQL field type like BqlString.
 		/// </summary>
 		public const string BqlFieldType = nameof(BqlFieldType);
+
+		/// <summary>
+		/// The property used to pass the information about a DAC BQL field data type like <see cref="String"/>.
+		/// </summary>
+		public const string BqlFieldDataType = nameof(BqlFieldDataType);
 
 		/// <summary>
 		/// The property used to pass the information that the diagnostic is reported on the property. 

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/DiagnosticProperty.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/DiagnosticProperty.cs
@@ -20,7 +20,7 @@ namespace Acuminator.Analyzers.StaticAnalysis
 		/// <summary>
 		/// The property used to pass the name of the DAC field with the diagnostic.
 		/// </summary>
-		public const string DacFieldName= nameof(DacFieldName);
+		public const string DacFieldName = nameof(DacFieldName);
 
 		/// <summary>
 		/// The property used to pass the DAC metadata with the diagnostic.
@@ -41,5 +41,10 @@ namespace Acuminator.Analyzers.StaticAnalysis
 		/// The property used to pass the information about a DAC BQL field type like BqlString.
 		/// </summary>
 		public const string BqlFieldType = nameof(BqlFieldType);
+
+		/// <summary>
+		/// The property used to pass the information that the diagnostic is reported on the property. 
+		/// </summary>
+		public const string IsProperty = nameof(IsProperty);
 	}
 }

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/ExceptionSerialization/ExceptionSerializationAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/ExceptionSerialization/ExceptionSerializationAnalyzer.cs
@@ -171,7 +171,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.ExceptionSerialization
 
 		private static Location? GetDiagnosticLocation(INamedTypeSymbol exceptionType, CancellationToken cancellation) =>
 			exceptionType.GetSyntax(cancellation) is ClassDeclarationSyntax exceptionDeclaration
-				? exceptionDeclaration.Identifier.GetLocation()
+				? exceptionDeclaration.Identifier.GetLocation().NullIfLocationKindIsNone()
 				: null;
 	}
 }

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/LegacyBqlConstant/LegacyBqlConstantAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/LegacyBqlConstant/LegacyBqlConstantAnalyzer.cs
@@ -76,9 +76,9 @@ namespace Acuminator.Analyzers.StaticAnalysis.LegacyBqlConstant
 			if (constantUnderlyingType == null || constantUnderlyingType.Name.IsNullOrWhiteSpace())
 				return false;
 
-			var constantDataTypeName = new PropertyTypeName(constantUnderlyingType.Name);
+			var constantDataTypeName = new DataTypeName(constantUnderlyingType.Name);
 
-			if (PropertyTypeToBqlFieldTypeMapping.ContainsPropertyType(constantDataTypeName))
+			if (DataTypeToBqlFieldTypeMapping.ContainsDataType(constantDataTypeName))
 			{
 				constantType = constantUnderlyingType.Name;
 				return true;

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/LegacyBqlConstant/LegacyBqlConstantFix.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/LegacyBqlConstant/LegacyBqlConstantFix.cs
@@ -40,8 +40,8 @@ namespace Acuminator.Analyzers.StaticAnalysis.LegacyBqlConstant
 
 			context.CancellationToken.ThrowIfCancellationRequested();
 
-			var strongPropertyTypeName = new PropertyTypeName(propertyTypeName);
-			SimpleBaseTypeSyntax? newBaseType = CreateBaseType(strongPropertyTypeName, constantNode.Identifier.Text);
+			var propertyDataTypeName = new DataTypeName(propertyTypeName);
+			SimpleBaseTypeSyntax? newBaseType = CreateBaseType(propertyDataTypeName, constantNode.Identifier.Text);
 
 			if (newBaseType != null)
 			{
@@ -54,9 +54,9 @@ namespace Acuminator.Analyzers.StaticAnalysis.LegacyBqlConstant
 			}
 		}
 
-		private SimpleBaseTypeSyntax? CreateBaseType(PropertyTypeName propertyTypeName, string constantName)
+		private SimpleBaseTypeSyntax? CreateBaseType(DataTypeName propertyDataTypeName, string constantName)
 		{
-			string? bqlTypeName = PropertyTypeToBqlFieldTypeMapping.GetBqlFieldType(propertyTypeName).NullIfWhiteSpace();
+			string? bqlTypeName = DataTypeToBqlFieldTypeMapping.GetBqlFieldType(propertyDataTypeName).NullIfWhiteSpace();
 
 			if (bqlTypeName == null)
 				return null;

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/LegacyBqlField/LegacyBqlFieldAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/LegacyBqlField/LegacyBqlFieldAnalyzer.cs
@@ -39,11 +39,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.LegacyBqlField
 				if (location == null || !dac.PropertiesByNames.TryGetValue(dacField.Name, out DacPropertyInfo? property))
 					continue;
 
-				string? propertyTypeName = property.EffectivePropertyType.GetSimplifiedName();
-
-				if (propertyTypeName == null)
-					continue;
-
+				string propertyTypeName  = property.PropertyTypeUnwrappedNullable.GetSimplifiedName();
 				var propertyDataTypeName = new DataTypeName(propertyTypeName);
 
 				if (!DataTypeToBqlFieldTypeMapping.ContainsDataType(propertyDataTypeName))

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/LegacyBqlField/LegacyBqlFieldAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/LegacyBqlField/LegacyBqlFieldAnalyzer.cs
@@ -44,9 +44,9 @@ namespace Acuminator.Analyzers.StaticAnalysis.LegacyBqlField
 				if (propertyTypeName == null)
 					continue;
 
-				var strongPropertyTypeName = new PropertyTypeName(propertyTypeName);
+				var propertyDataTypeName = new DataTypeName(propertyTypeName);
 
-				if (!PropertyTypeToBqlFieldTypeMapping.ContainsPropertyType(strongPropertyTypeName))
+				if (!DataTypeToBqlFieldTypeMapping.ContainsDataType(propertyDataTypeName))
 					continue;
 
 				var args = ImmutableDictionary.CreateBuilder<string, string?>();

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/LegacyBqlField/LegacyBqlFieldFix.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/LegacyBqlField/LegacyBqlFieldFix.cs
@@ -42,9 +42,9 @@ namespace Acuminator.Analyzers.StaticAnalysis.LegacyBqlField
 				return;
 			}
 
-			var strongPropertyTypeName = new PropertyTypeName(propertyTypeName);
+			var propertyDataTypeName = new DataTypeName(propertyTypeName);
 			string bqlFieldName = bqlFieldNode.Identifier.Text;
-			SimpleBaseTypeSyntax? newBaseType = BqlFieldGeneration.BaseTypeForBqlField(strongPropertyTypeName, bqlFieldName);
+			SimpleBaseTypeSyntax? newBaseType = BqlFieldGeneration.BaseTypeForBqlField(propertyDataTypeName, bqlFieldName);
 			if (newBaseType == null)
 				return;
 

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/LegacyBqlField/LegacyBqlFieldFix.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/LegacyBqlField/LegacyBqlFieldFix.cs
@@ -27,6 +27,13 @@ namespace Acuminator.Analyzers.StaticAnalysis.LegacyBqlField
 		protected override async Task RegisterCodeFixesForDiagnosticAsync(CodeFixContext context, Diagnostic diagnostic)
 		{
 			context.CancellationToken.ThrowIfCancellationRequested();
+
+			if (!diagnostic.TryGetPropertyValue(DiagnosticProperty.PropertyType, out string? propertyTypeName) ||
+				propertyTypeName.IsNullOrWhiteSpace())
+			{
+				return;
+			}
+
 			var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken)
 											 .ConfigureAwait(false);
 
@@ -35,12 +42,6 @@ namespace Acuminator.Analyzers.StaticAnalysis.LegacyBqlField
 				return;
 
 			context.CancellationToken.ThrowIfCancellationRequested();
-
-			if (!diagnostic.TryGetPropertyValue(DiagnosticProperty.PropertyType, out string? propertyTypeName) || 
-				propertyTypeName.IsNullOrWhiteSpace())
-			{
-				return;
-			}
 
 			var propertyDataTypeName = new DataTypeName(propertyTypeName);
 			string bqlFieldName = bqlFieldNode.Identifier.Text;

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/MissingBqlFieldRedeclarationInDerivedDac/MissingBqlFieldRedeclarationInDerivedDacAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/MissingBqlFieldRedeclarationInDerivedDac/MissingBqlFieldRedeclarationInDerivedDacAnalyzer.cs
@@ -107,8 +107,8 @@ namespace Acuminator.Analyzers.StaticAnalysis.MissingBqlFieldRedeclarationInDeri
 			if (propertyTypeName.IsNullOrWhiteSpace())
 				return GetBqlFieldTypeNameFromPropertyType(notRedeclaredBqlField);
 
-			var strongPropertyTypeName = new PropertyTypeName(propertyTypeName);
-			string? mappedBqlFieldType = PropertyTypeToBqlFieldTypeMapping.GetBqlFieldType(strongPropertyTypeName);
+			var propertyDataTypeName = new DataTypeName(propertyTypeName);
+			string? mappedBqlFieldType = DataTypeToBqlFieldTypeMapping.GetBqlFieldType(propertyDataTypeName);
 			mappedBqlFieldType		 ??= GetBqlFieldTypeNameFromPropertyType(notRedeclaredBqlField);
 
 			return mappedBqlFieldType;
@@ -121,8 +121,8 @@ namespace Acuminator.Analyzers.StaticAnalysis.MissingBqlFieldRedeclarationInDeri
 			if (propertyTypeName == null)
 				return null;
 
-			var strongPropertyTypeName = new PropertyTypeName(propertyTypeName);
-			string? mappedBqlFieldType = PropertyTypeToBqlFieldTypeMapping.GetBqlFieldType(strongPropertyTypeName);
+			var propertyDataTypeName = new DataTypeName(propertyTypeName);
+			string? mappedBqlFieldType = DataTypeToBqlFieldTypeMapping.GetBqlFieldType(propertyDataTypeName);
 
 			return mappedBqlFieldType;
 		}

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/MissingBqlFieldRedeclarationInDerivedDac/MissingBqlFieldRedeclarationInDerivedDacAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/MissingBqlFieldRedeclarationInDerivedDac/MissingBqlFieldRedeclarationInDerivedDacAnalyzer.cs
@@ -116,7 +116,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.MissingBqlFieldRedeclarationInDeri
 
 		private string? GetBqlFieldTypeNameFromPropertyType(DacFieldInfo notRedeclaredBqlField)
 		{
-			string? propertyTypeName = notRedeclaredBqlField.EffectivePropertyType?.GetSimplifiedName();
+			string? propertyTypeName = notRedeclaredBqlField.PropertyTypeUnwrappedNullable?.GetSimplifiedName();
 
 			if (propertyTypeName == null)
 				return null;

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/MissingBqlFieldRedeclarationInDerivedDac/MissingBqlFieldRedeclarationInDerivedDacAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/MissingBqlFieldRedeclarationInDerivedDac/MissingBqlFieldRedeclarationInDerivedDacAnalyzer.cs
@@ -70,7 +70,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.MissingBqlFieldRedeclarationInDeri
 			var properties = new Dictionary<string, string?>
 			{
 				{ DiagnosticProperty.DacName,	   dac.Name},
-				{ DiagnosticProperty.DacFieldName, dacFieldWithDeclaredBqlField.BqlFieldInfo!.Name },
+				{ DiagnosticProperty.BqlFieldName, dacFieldWithDeclaredBqlField.BqlFieldInfo!.Name },
 				{ DiagnosticProperty.BqlFieldType, bqlFieldTypeName}
 			}
 			.ToImmutableDictionary();

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/MissingBqlFieldRedeclarationInDerivedDac/MissingBqlFieldRedeclarationInDerivedDacAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/MissingBqlFieldRedeclarationInDerivedDac/MissingBqlFieldRedeclarationInDerivedDacAnalyzer.cs
@@ -85,15 +85,15 @@ namespace Acuminator.Analyzers.StaticAnalysis.MissingBqlFieldRedeclarationInDeri
 		{
 			if (isDacFieldDeclaredInDac && notRedeclaredBqlField.PropertyInfo?.IsInSource == true)
 			{
-				var location = notRedeclaredBqlField.PropertyInfo.Node.Identifier.GetLocation() ??
+				var location = notRedeclaredBqlField.PropertyInfo.Node.Identifier.GetLocation().NullIfLocationKindIsNone() ??
 							   notRedeclaredBqlField.PropertyInfo.Node.GetLocation() ??
-							   dac.Node!.Identifier.GetLocation();							// Node is not null because aggregated DAC analysis runs only on DACs from the source code
+							   dac.Node!.Identifier.GetLocation().NullIfLocationKindIsNone();	// Node is not null because aggregated DAC analysis runs only on DACs from the source code
 				return location;
 			}
 			else
 			{
 				// Node is not null because aggregated DAC analysis runs only on DACs from the source code
-				return dac.Node!.Identifier.GetLocation();
+				return dac.Node!.Identifier.GetLocation().NullIfLocationKindIsNone();
 			}
 		}
 

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/MissingBqlFieldRedeclarationInDerivedDac/MissingBqlFieldRedeclarationInDerivedDacFix.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/MissingBqlFieldRedeclarationInDerivedDac/MissingBqlFieldRedeclarationInDerivedDacFix.cs
@@ -34,7 +34,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.MissingBqlFieldRedeclarationInDeri
 			context.CancellationToken.ThrowIfCancellationRequested();
 
 			if (!diagnostic.TryGetPropertyValue(DiagnosticProperty.DacName, out string? dacName) ||
-				!diagnostic.TryGetPropertyValue(DiagnosticProperty.DacFieldName, out string? bqlFieldName) ||
+				!diagnostic.TryGetPropertyValue(DiagnosticProperty.BqlFieldName, out string? bqlFieldName) ||
 				dacName.IsNullOrWhiteSpace() || bqlFieldName.IsNullOrWhiteSpace())
 			{
 				return Task.CompletedTask;

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/NoBqlFieldForDacFieldProperty/NoBqlFieldForDacFieldAnalyzerFix.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/NoBqlFieldForDacFieldProperty/NoBqlFieldForDacFieldAnalyzerFix.cs
@@ -78,8 +78,8 @@ namespace Acuminator.Analyzers.StaticAnalysis.NoBqlFieldForDacFieldProperty
 			if (dacNode == null)
 				return document;
 
-			var strongPropertyTypeName = new PropertyTypeName(propertyType);
-			var newDacMembers = CreateMembersListWithBqlField(dacNode, propertyWithoutBqlFieldNode, bqlFieldName, strongPropertyTypeName);
+			var dataTypeName = new DataTypeName(propertyType);
+			var newDacMembers = CreateMembersListWithBqlField(dacNode, propertyWithoutBqlFieldNode, bqlFieldName, dataTypeName);
 
 			if (newDacMembers == null)
 				return document;
@@ -92,13 +92,13 @@ namespace Acuminator.Analyzers.StaticAnalysis.NoBqlFieldForDacFieldProperty
 
 		private SyntaxList<MemberDeclarationSyntax>? CreateMembersListWithBqlField(ClassDeclarationSyntax dacNode, 
 																				   PropertyDeclarationSyntax propertyWithoutBqlFieldNode,
-																				   string bqlFieldName, PropertyTypeName propertyType)
+																				   string bqlFieldName, DataTypeName propertyDataType)
 		{
 			var members = dacNode.Members;
 
 			if (members.Count == 0)
 			{
-				var newSingleBqlFieldNode = BqlFieldGeneration.GenerateTypedBqlField(propertyType, bqlFieldName, isFirstField: true, 
+				var newSingleBqlFieldNode = BqlFieldGeneration.GenerateTypedBqlField(propertyDataType, bqlFieldName, isFirstField: true, 
 																					 isRedeclaration: false, propertyWithoutBqlFieldNode);
 				return newSingleBqlFieldNode != null
 					? SingletonList<MemberDeclarationSyntax>(newSingleBqlFieldNode)
@@ -110,7 +110,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.NoBqlFieldForDacFieldProperty
 			if (propertyMemberIndex < 0)
 				propertyMemberIndex = 0;
 
-			var newBqlFieldNode = BqlFieldGeneration.GenerateTypedBqlField(propertyType, bqlFieldName, isFirstField: propertyMemberIndex == 0,
+			var newBqlFieldNode = BqlFieldGeneration.GenerateTypedBqlField(propertyDataType, bqlFieldName, isFirstField: propertyMemberIndex == 0,
 																		   isRedeclaration: false, propertyWithoutBqlFieldNode);
 			if (newBqlFieldNode == null)
 				return null;

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/NoBqlFieldForDacFieldProperty/NoBqlFieldForDacFieldPropertyAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/NoBqlFieldForDacFieldProperty/NoBqlFieldForDacFieldPropertyAnalyzer.cs
@@ -185,7 +185,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.NoBqlFieldForDacFieldProperty
 				return;
 
 			var properties = ImmutableDictionary<string, string?>.Empty;
-			string? propertyTypeName = dacFieldWithoutBqlField.EffectivePropertyType?.GetSimplifiedName();
+			string? propertyTypeName = dacFieldWithoutBqlField.PropertyTypeUnwrappedNullable?.GetSimplifiedName();
 
 			if (registerCodeFix && propertyTypeName != null)
 			{

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/NoBqlFieldForDacFieldProperty/NoBqlFieldForDacFieldPropertyAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/NoBqlFieldForDacFieldProperty/NoBqlFieldForDacFieldPropertyAnalyzer.cs
@@ -164,7 +164,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.NoBqlFieldForDacFieldProperty
 		private void ReportBqlFieldWithTypo(SymbolAnalysisContext symbolContext, PXContext pxContext, DacBqlFieldInfo bqlFieldWithTypo, 
 											string propertyName)
 		{
-			Location? location = bqlFieldWithTypo.Node!.Identifier.GetLocation() ?? bqlFieldWithTypo.Node.GetLocation();
+			Location? location = bqlFieldWithTypo.Node!.Identifier.GetLocation().NullIfLocationKindIsNone() ?? bqlFieldWithTypo.Node.GetLocation();
 
 			if (location == null)
 				return;
@@ -206,15 +206,15 @@ namespace Acuminator.Analyzers.StaticAnalysis.NoBqlFieldForDacFieldProperty
 		{
 			if (dacField.PropertyInfo?.IsInSource == true && dacField.IsDeclaredInType(dac.Symbol))
 			{
-				var location = dacField.PropertyInfo.Node.Identifier.GetLocation() ??
+				var location = dacField.PropertyInfo.Node.Identifier.GetLocation().NullIfLocationKindIsNone() ??
 							   dacField.PropertyInfo.Node.GetLocation() ??
-							   dac.Node!.Identifier.GetLocation();
+							   dac.Node!.Identifier.GetLocation().NullIfLocationKindIsNone();
 
 				return (location, RegisterCodeFix: true);
 			}
 
 			// Node is not null because aggregated DAC analysis runs only on DACs from the source code
-			return (dac.Node!.Identifier.GetLocation(), RegisterCodeFix: false);
+			return (dac.Node!.Identifier.GetLocation().NullIfLocationKindIsNone(), RegisterCodeFix: false);
 		}
 	}
 }

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/NoIsActiveMethodForExtension/NoIsActiveMethodForExtensionAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/NoIsActiveMethodForExtension/NoIsActiveMethodForExtensionAnalyzer.cs
@@ -37,7 +37,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.NoIsActiveMethodForExtension
 
 			// ShouldAnalyze already filtered everything and left only DAC extensions without IsActive
 			// We just need to report them
-			Location? location = dacExtension.Node?.Identifier.GetLocation();
+			Location? location = dacExtension.Node?.Identifier.GetLocation().NullIfLocationKindIsNone();
 
 			if (location == null)
 				return;
@@ -81,7 +81,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.NoIsActiveMethodForExtension
 
 			// ShouldAnalyze already filtered everything and left only graph extensions without IsActive
 			// We just need to report them
-			Location? location = graphExtension.Node?.Identifier.GetLocation() ?? graphExtension.Node?.GetLocation();
+			Location? location = graphExtension.Node?.Identifier.GetLocation().NullIfLocationKindIsNone() ?? graphExtension.Node?.GetLocation();
 
 			if (location == null)
 				return;

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/NoPrimaryViewForPrimaryDac/NoPrimaryViewForPrimaryDacAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/NoPrimaryViewForPrimaryDac/NoPrimaryViewForPrimaryDacAnalyzer.cs
@@ -56,7 +56,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.NoPrimaryViewForPrimaryDac
 			SemanticModel? semanticModel = context.Compilation.GetSemanticModel(graph.Node!.SyntaxTree);
 
 			if (semanticModel == null)
-				return graph.Node.Identifier.GetLocation();
+				return graph.Node.Identifier.GetLocation().NullIfLocationKindIsNone();
 
 			var baseClassesTypeNodes = graph.Node.BaseList!.Types.Select(baseTypeNode => baseTypeNode.Type)
 																 .OfType<GenericNameSyntax>();
@@ -70,7 +70,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.NoPrimaryViewForPrimaryDac
 					return location;
 			}
 
-			return graph.Node.Identifier.GetLocation();
+			return graph.Node.Identifier.GetLocation().NullIfLocationKindIsNone();
 		}
 
 		private static Location? GetLocationFromBaseClassTypeNode(GenericNameSyntax baseClassTypeNode, INamedTypeSymbol? baseClassTypeSymbol,

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/NonPublicGraphsDacsAndExtensions/NonPublicGraphAndDacAndExtensionsAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/NonPublicGraphsDacsAndExtensions/NonPublicGraphAndDacAndExtensionsAnalyzer.cs
@@ -211,13 +211,13 @@ namespace Acuminator.Analyzers.StaticAnalysis.NonPublicGraphsDacsAndExtensions
 						if (!classIdentifierLocationWasAdded)
 						{
 							classIdentifierLocationWasAdded = true;
-							return classNode.Identifier.GetLocation();
+							return classNode.Identifier.GetLocation().NullIfLocationKindIsNone();
 						}
 
 						return null;
 					}
 					else
-						return modifier.GetLocation();
+						return modifier.GetLocation().NullIfLocationKindIsNone();
 				}
 				else
 				{

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PropertyAndBqlFieldTypesMismatch/PX1068DiagnosticProperty.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PropertyAndBqlFieldTypesMismatch/PX1068DiagnosticProperty.cs
@@ -1,0 +1,6 @@
+﻿namespace Acuminator.Analyzers.StaticAnalysis.PropertyAndBqlFieldTypesMismatch;
+
+public class PX1068DiagnosticProperty
+{
+	public const string PropertyTypeIsNullable = nameof(PropertyTypeIsNullable);
+}

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PropertyAndBqlFieldTypesMismatch/PX1068DiagnosticProperty.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PropertyAndBqlFieldTypesMismatch/PX1068DiagnosticProperty.cs
@@ -2,5 +2,5 @@
 
 public class PX1068DiagnosticProperty
 {
-	public const string PropertyTypeIsNullable = nameof(PropertyTypeIsNullable);
+	public const string MakePropertyTypeNullable = nameof(MakePropertyTypeNullable);
 }

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PropertyAndBqlFieldTypesMismatch/PropertyAndBqlFieldTypesMismatchAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PropertyAndBqlFieldTypesMismatch/PropertyAndBqlFieldTypesMismatchAnalyzer.cs
@@ -61,20 +61,17 @@ public class PropertyAndBqlFieldTypesMismatchAnalyzer : DacAggregatedAnalyzerBas
 		if (propertyTypeLocation == null && bqlTypeLocation == null)
 			return;
 
-		bool isPropertyTypeNullable = declaredDacFieldWithMismatchingTypes.PropertyType != null &&
-									  !SymbolEqualityComparer.Default.Equals(declaredDacFieldWithMismatchingTypes.PropertyType, 
-																			 declaredDacFieldWithMismatchingTypes.PropertyTypeUnwrappedNullable);
-
-		string propertyTypeName		 = declaredDacFieldWithMismatchingTypes.PropertyTypeUnwrappedNullable!.GetSimplifiedName();
-		string? bqlFieldDataTypeName = declaredDacFieldWithMismatchingTypes.BqlFieldDataTypeEffective!.GetSimplifiedName();
-		string? bqlFieldName		 = GetBqlFieldName(declaredDacFieldWithMismatchingTypes);
+		bool makePropertyTypeNullable = declaredDacFieldWithMismatchingTypes.BqlFieldDataTypeEffective!.IsValueType;
+		string propertyTypeName		  = declaredDacFieldWithMismatchingTypes.PropertyTypeUnwrappedNullable!.GetSimplifiedName();
+		string? bqlFieldDataTypeName  = declaredDacFieldWithMismatchingTypes.BqlFieldDataTypeEffective!.GetSimplifiedName();
+		string? bqlFieldName		  = GetBqlFieldName(declaredDacFieldWithMismatchingTypes);
 
 		var sharedProperties = new Dictionary<string, string?>
 		{
-			{ DiagnosticProperty.PropertyType				 , propertyTypeName },
-			{ DiagnosticProperty.BqlFieldDataType			 , bqlFieldDataTypeName },
-			{ DiagnosticProperty.BqlFieldName				 , bqlFieldName },
-			{ PX1068DiagnosticProperty.PropertyTypeIsNullable, isPropertyTypeNullable.ToString() }
+			{ DiagnosticProperty.PropertyType					, propertyTypeName },
+			{ DiagnosticProperty.BqlFieldDataType				, bqlFieldDataTypeName },
+			{ DiagnosticProperty.BqlFieldName					, bqlFieldName },
+			{ PX1068DiagnosticProperty.MakePropertyTypeNullable , makePropertyTypeNullable.ToString() }
 		}
 		.ToImmutableDictionary();
 

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PropertyAndBqlFieldTypesMismatch/PropertyAndBqlFieldTypesMismatchAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PropertyAndBqlFieldTypesMismatch/PropertyAndBqlFieldTypesMismatchAnalyzer.cs
@@ -61,15 +61,20 @@ public class PropertyAndBqlFieldTypesMismatchAnalyzer : DacAggregatedAnalyzerBas
 		if (propertyTypeLocation == null && bqlTypeLocation == null)
 			return;
 
+		bool isPropertyTypeNullable = declaredDacFieldWithMismatchingTypes.PropertyType != null &&
+									  !SymbolEqualityComparer.Default.Equals(declaredDacFieldWithMismatchingTypes.PropertyType, 
+																			 declaredDacFieldWithMismatchingTypes.PropertyTypeUnwrappedNullable);
+
 		string propertyTypeName		 = declaredDacFieldWithMismatchingTypes.PropertyTypeUnwrappedNullable!.GetSimplifiedName();
 		string? bqlFieldDataTypeName = declaredDacFieldWithMismatchingTypes.BqlFieldDataTypeEffective!.GetSimplifiedName();
 		string? bqlFieldName		 = GetBqlFieldName(declaredDacFieldWithMismatchingTypes);
 
 		var sharedProperties = new Dictionary<string, string?>
 		{
-			{ DiagnosticProperty.PropertyType,	   propertyTypeName },
-			{ DiagnosticProperty.BqlFieldDataType, bqlFieldDataTypeName },
-			{ DiagnosticProperty.BqlFieldName,	   bqlFieldName }
+			{ DiagnosticProperty.PropertyType				 , propertyTypeName },
+			{ DiagnosticProperty.BqlFieldDataType			 , bqlFieldDataTypeName },
+			{ DiagnosticProperty.BqlFieldName				 , bqlFieldName },
+			{ PX1068DiagnosticProperty.PropertyTypeIsNullable, isPropertyTypeNullable.ToString() }
 		}
 		.ToImmutableDictionary();
 

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PropertyAndBqlFieldTypesMismatch/PropertyAndBqlFieldTypesMismatchAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PropertyAndBqlFieldTypesMismatch/PropertyAndBqlFieldTypesMismatchAnalyzer.cs
@@ -105,7 +105,9 @@ public class PropertyAndBqlFieldTypesMismatchAnalyzer : DacAggregatedAnalyzerBas
 			return null;
 
 		var propertyNode = declaredDacFieldWithMismatchingTypes.PropertyInfo.Node;
-		return propertyNode.Type?.GetLocation() ?? propertyNode.Identifier.GetLocation() ?? propertyNode.GetLocation();
+		return propertyNode.Type?.GetLocation() ?? 
+			   propertyNode.Identifier.GetLocation().NullIfLocationKindIsNone() ?? 
+			   propertyNode.GetLocation();
 	}
 
 	private Location? GetBqlTypeLocation(DacFieldInfo declaredDacFieldWithMismatchingTypes)
@@ -116,20 +118,16 @@ public class PropertyAndBqlFieldTypesMismatchAnalyzer : DacAggregatedAnalyzerBas
 		var bqlFieldNode = declaredDacFieldWithMismatchingTypes.BqlFieldInfo.Node;
 
 		if (bqlFieldNode.BaseList?.Types.Count is null or 0)
-			return bqlFieldNode.Identifier.GetLocation() ?? bqlFieldNode.GetLocation();
-
+			return bqlFieldNode.Identifier.GetLocation().NullIfLocationKindIsNone() ?? bqlFieldNode.GetLocation();
+		
 		var baseTypeNode = bqlFieldNode.BaseList.Types[0];
 
 		if (baseTypeNode.Type is not QualifiedNameSyntax bqlTypeNameNodeWithMultipleSegments)
-			return baseTypeNode.Type.GetLocation() ?? bqlFieldNode.Identifier.GetLocation() ?? bqlFieldNode.GetLocation();
+			return baseTypeNode.Type.GetLocation();
 
 		if (bqlTypeNameNodeWithMultipleSegments.Left is not QualifiedNameSyntax bqlTypeNameSegments)
-		{
-			return bqlTypeNameNodeWithMultipleSegments.GetLocation() ?? baseTypeNode.Type.GetLocation() ??
-				   bqlFieldNode.Identifier.GetLocation() ?? bqlFieldNode.GetLocation();
-		}
-
-		return bqlTypeNameSegments.Right.GetLocation() ?? bqlTypeNameNodeWithMultipleSegments.GetLocation() ??
-			   baseTypeNode.Type.GetLocation() ?? bqlFieldNode.Identifier.GetLocation() ?? bqlFieldNode.GetLocation();
+			return bqlTypeNameNodeWithMultipleSegments.Left.GetLocation();
+		else
+			return bqlTypeNameSegments.Right.GetLocation();
 	}
 }

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PropertyAndBqlFieldTypesMismatch/PropertyAndBqlFieldTypesMismatchAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PropertyAndBqlFieldTypesMismatch/PropertyAndBqlFieldTypesMismatchAnalyzer.cs
@@ -1,0 +1,137 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+
+using Acuminator.Analyzers.StaticAnalysis.Dac;
+using Acuminator.Utilities.DiagnosticSuppression;
+using Acuminator.Utilities.Roslyn;
+using Acuminator.Utilities.Roslyn.Constants;
+using Acuminator.Utilities.Roslyn.Semantic;
+using Acuminator.Utilities.Roslyn.Semantic.Dac;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Acuminator.Analyzers.StaticAnalysis.PropertyAndBqlFieldTypesMismatch;
+
+public class PropertyAndBqlFieldTypesMismatchAnalyzer : DacAggregatedAnalyzerBase
+{
+	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+		ImmutableArray.Create
+		(
+			Descriptors.PX1068_PropertyAndBqlFieldTypesMismatch
+		);
+
+	public override bool ShouldAnalyze(PXContext pxContext, [NotNullWhen(true)] DacSemanticModel dac) =>
+		base.ShouldAnalyze(pxContext, dac) && dac.BqlFieldsByNames.Count > 0;
+
+	public override void Analyze(SymbolAnalysisContext symbolContext, PXContext pxContext, DacSemanticModel dac)
+	{
+		symbolContext.CancellationToken.ThrowIfCancellationRequested();
+
+		foreach (var dacField in dac.DeclaredDacFields)
+		{
+			symbolContext.CancellationToken.ThrowIfCancellationRequested();
+
+			// Skip all DACs without BQL field or field property - it's impossible to compare their types
+			// Also skip DAC fields without effective BQL field or field property types.
+			// And skip weakly typed BQL fields - there is PX1060 diagnostic to check it
+			if (!dacField.HasBqlFieldEffective || !dacField.HasFieldPropertyEffective ||
+				dacField.PropertyTypeUnwrappedNullable == null || dacField.BqlFieldDataTypeEffective == null)
+			{
+				continue;
+			}
+
+			// Skip DAC fields with matching BQL field and property types
+			if (SymbolEqualityComparer.Default.Equals(dacField.PropertyTypeUnwrappedNullable, dacField.BqlFieldDataTypeEffective))
+				continue;
+
+			// DAC field is declared in DAC, but does not have a BQL field redeclaration in DAC
+			ReportPropertyAndBqlTypeMismatch(symbolContext, pxContext, dac, dacField);
+		}
+	}
+
+	private void ReportPropertyAndBqlTypeMismatch(SymbolAnalysisContext symbolContext, PXContext pxContext, DacSemanticModel dac,
+												  DacFieldInfo declaredDacFieldWithMismatchingTypes)
+	{
+		Location? propertyTypeLocation = GetPropertyTypeLocation(declaredDacFieldWithMismatchingTypes);
+		Location? bqlTypeLocation	   = GetBqlTypeLocation(declaredDacFieldWithMismatchingTypes);
+
+		if (propertyTypeLocation == null || bqlTypeLocation == null)
+			return;
+
+		string propertyTypeName  = declaredDacFieldWithMismatchingTypes.PropertyTypeUnwrappedNullable!.GetSimplifiedName();
+		string? bqlFieldTypeName = GetBqlFieldTypeName(declaredDacFieldWithMismatchingTypes);
+
+		var sharedProperties = new Dictionary<string, string?>
+		{
+			{ DiagnosticProperty.PropertyType, propertyTypeName },
+			{ DiagnosticProperty.BqlFieldType, bqlFieldTypeName },
+		}
+		.ToImmutableDictionary();
+
+		ReportDiagnostic(isProperty: true, symbolContext, pxContext, propertyTypeLocation, bqlTypeLocation, sharedProperties);
+		ReportDiagnostic(isProperty: false, symbolContext, pxContext, propertyTypeLocation, bqlTypeLocation, sharedProperties);
+	}
+
+	private void ReportDiagnostic(bool isProperty, SymbolAnalysisContext symbolContext, PXContext pxContext, Location propertyTypeLocation,
+								  Location bqlTypeLocation, ImmutableDictionary<string, string?> sharedProperties)
+	{
+		var diagnosticProperties = sharedProperties.Add(DiagnosticProperty.IsProperty, isProperty.ToString());
+
+		(Location locationToReport, Location[] extraLocations) = isProperty
+			? (propertyTypeLocation, new[] { bqlTypeLocation })
+			: (bqlTypeLocation,		 new[] { propertyTypeLocation });
+
+		var diagnostic = Diagnostic.Create(
+							Descriptors.PX1068_PropertyAndBqlFieldTypesMismatch, locationToReport, extraLocations, diagnosticProperties);
+		symbolContext.ReportDiagnosticWithSuppressionCheck(diagnostic, pxContext.CodeAnalysisSettings);
+	}
+
+	private Location? GetPropertyTypeLocation(DacFieldInfo declaredDacFieldWithMismatchingTypes)
+	{
+		if (declaredDacFieldWithMismatchingTypes?.PropertyInfo?.Node == null)
+			return null;
+
+		var propertyNode = declaredDacFieldWithMismatchingTypes.PropertyInfo.Node;
+		return propertyNode.Type?.GetLocation() ?? propertyNode.Identifier.GetLocation() ?? propertyNode.GetLocation();
+	}
+
+	private Location? GetBqlTypeLocation(DacFieldInfo declaredDacFieldWithMismatchingTypes)
+	{
+		if (declaredDacFieldWithMismatchingTypes?.BqlFieldInfo?.Node == null)
+			return null;
+
+		var bqlFieldNode = declaredDacFieldWithMismatchingTypes.BqlFieldInfo.Node;
+
+		if (bqlFieldNode.BaseList?.Types.Count is null or 0)
+			return bqlFieldNode.Identifier.GetLocation() ?? bqlFieldNode.GetLocation();
+
+		var baseTypeNode = bqlFieldNode.BaseList.Types[0];
+
+		if (baseTypeNode.Type is not QualifiedNameSyntax bqlTypeNameNodeWithMultipleSegments)
+			return baseTypeNode.Type.GetLocation() ?? bqlFieldNode.Identifier.GetLocation() ?? bqlFieldNode.GetLocation();
+
+		if (bqlTypeNameNodeWithMultipleSegments.Left is not QualifiedNameSyntax bqlTypeNameSegments)
+		{
+			return bqlTypeNameNodeWithMultipleSegments.GetLocation() ?? baseTypeNode.Type.GetLocation() ??
+				   bqlFieldNode.Identifier.GetLocation() ?? bqlFieldNode.GetLocation();
+		}
+
+		return bqlTypeNameSegments.Right.GetLocation() ?? bqlTypeNameNodeWithMultipleSegments.GetLocation() ??
+			   baseTypeNode.Type.GetLocation() ?? bqlFieldNode.Identifier.GetLocation() ?? bqlFieldNode.GetLocation();
+	}
+
+	private string? GetBqlFieldTypeName(DacFieldInfo declaredDacFieldWithMismatchingTypes)
+	{
+		string bqlFieldDataTypeName = declaredDacFieldWithMismatchingTypes.BqlFieldDataTypeEffective!.GetSimplifiedName();
+
+		var dataTypeStrongName	   = new DataTypeName(bqlFieldDataTypeName);
+		string? mappedBqlFieldType = DataTypeToBqlFieldTypeMapping.GetBqlFieldType(dataTypeStrongName);
+
+		return mappedBqlFieldType;
+	}
+}

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PropertyAndBqlFieldTypesMismatch/PropertyAndBqlFieldTypesMismatchFix.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PropertyAndBqlFieldTypesMismatch/PropertyAndBqlFieldTypesMismatchFix.cs
@@ -135,7 +135,12 @@ namespace Acuminator.Analyzers.StaticAnalysis.PropertyAndBqlFieldTypesMismatch
 				var elementTypeName = dataTypeName[..indexOfOpeningSquareBracket];
 				var elementTypeNode = IdentifierName(elementTypeName);
 
-				return ArrayType(elementTypeNode);
+				var arrayRankSpecifier = ArrayRankSpecifier(
+											SingletonSeparatedList<ExpressionSyntax>(
+												OmittedArraySizeExpression()));
+				var arrayType = ArrayType(elementTypeNode,
+										  SingletonList(arrayRankSpecifier));
+				return arrayType;
 			}
 			
 			var dataTypeNode = IdentifierName(dataTypeName);

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PropertyAndBqlFieldTypesMismatch/PropertyAndBqlFieldTypesMismatchFix.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PropertyAndBqlFieldTypesMismatch/PropertyAndBqlFieldTypesMismatchFix.cs
@@ -1,0 +1,121 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Acuminator.Utilities.Common;
+using Acuminator.Utilities.Roslyn;
+using Acuminator.Utilities.Roslyn.CodeGeneration;
+using Acuminator.Utilities.Roslyn.Constants;
+using Acuminator.Utilities.Roslyn.Syntax;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Acuminator.Analyzers.StaticAnalysis.PropertyAndBqlFieldTypesMismatch
+{
+	[ExportCodeFixProvider(LanguageNames.CSharp), Shared]
+	public class PropertyAndBqlFieldTypesMismatchFix : PXCodeFixProvider
+	{
+		public override ImmutableArray<string> FixableDiagnosticIds { get; } =
+			ImmutableArray.Create(Descriptors.PX1068_PropertyAndBqlFieldTypesMismatch.Id);
+
+		protected override async Task RegisterCodeFixesForDiagnosticAsync(CodeFixContext context, Diagnostic diagnostic)
+		{
+			context.CancellationToken.ThrowIfCancellationRequested();
+
+			if (!diagnostic.TryGetPropertyValue(DiagnosticProperty.PropertyType, out string? propertyDataTypeName) ||
+				!diagnostic.TryGetPropertyValue(DiagnosticProperty.BqlFieldDataType, out string? bqlFieldDataTypeName))
+			{
+				return;
+			}
+
+			bqlFieldDataTypeName = bqlFieldDataTypeName.NullIfWhiteSpace();
+			propertyDataTypeName = propertyDataTypeName.NullIfWhiteSpace();
+
+			bool isOnPropertyNode = diagnostic.IsFlagSet(DiagnosticProperty.IsProperty);
+
+			var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+			var nodeWithDiagnostic = root?.FindNode(context.Span);
+
+			if (nodeWithDiagnostic == null)
+				return;
+
+			if (isOnPropertyNode)
+				RegisterFixPropertyTypeAction(context, diagnostic, root!, nodeWithDiagnostic, bqlFieldDataTypeName);
+			else
+				RegisterFixBqlFieldTypeAction(context, diagnostic, root!, nodeWithDiagnostic, propertyDataTypeName);
+		}
+
+		private void RegisterFixPropertyTypeAction(CodeFixContext context, Diagnostic diagnostic, SyntaxNode root, SyntaxNode nodeWithDiagnostic,
+												   string? bqlFieldDataTypeName)
+		{
+			var propertyNode = nodeWithDiagnostic.ParentOrSelf<PropertyDeclarationSyntax>();
+
+			if (propertyNode == null || bqlFieldDataTypeName.IsNullOrWhiteSpace()) 
+				return;
+
+			string codeActionName = nameof(Resources.PX1068FixPropertyType).GetLocalized().ToString();
+			Document document 	  = context.Document;
+
+			var codeAction = CodeAction.Create(codeActionName,
+											   cToken => ChangePropertyTypeToBqlFieldType(document, root, propertyNode, bqlFieldDataTypeName, cToken),
+											   equivalenceKey: codeActionName);
+			context.RegisterCodeFix(codeAction, diagnostic);
+		}
+
+		private void RegisterFixBqlFieldTypeAction(CodeFixContext context, Diagnostic diagnostic, SyntaxNode root, SyntaxNode nodeWithDiagnostic,
+												   string? propertyDataTypeName)
+		{
+			string? bqlFieldTypeName = GetBqlFieldTypeFromPropertyDataType(propertyDataTypeName);
+			
+			if (bqlFieldTypeName == null)
+				return;
+
+			string codeActionName = nameof(Resources.PX1068FixBqlType).GetLocalized().ToString();
+			Document document	  = context.Document;
+
+			var codeAction = CodeAction.Create(codeActionName,
+											   cToken => ChangeBqlFieldTypeToPropertyType(document, root, nodeWithDiagnostic, bqlFieldTypeName, cToken),
+											   equivalenceKey: codeActionName);
+			context.RegisterCodeFix(codeAction, diagnostic);
+		}
+
+		private string? GetBqlFieldTypeFromPropertyDataType(string? propertyDataTypeName)
+		{
+			if (propertyDataTypeName.IsNullOrWhiteSpace())
+				return null;
+
+			var dataTypeName = new DataTypeName(propertyDataTypeName);
+			string? mappedBqlFieldType = DataTypeToBqlFieldTypeMapping.GetBqlFieldType(dataTypeName);
+
+			return mappedBqlFieldType;
+		}
+
+		private async Task<Document> ChangePropertyTypeToBqlFieldType(Document document, SyntaxNode root, PropertyDeclarationSyntax propertyNode,
+																	  string bqlFieldDataTypeName, CancellationToken cancellationToken)
+		{
+			cancellationToken.ThrowIfCancellationRequested();
+
+		
+		
+		}
+
+		private async Task<Document> ChangeBqlFieldTypeToPropertyType(Document document, SyntaxNode root, SyntaxNode nodeWithDiagnostic,
+																	  string bqlFieldTypeName, CancellationToken cancellationToken)
+		{
+			cancellationToken.ThrowIfCancellationRequested();
+
+			bool isInBaseList = nodeWithDiagnostic.ParentOrSelf<BaseListSyntax>() != null;
+
+		}
+	}
+}

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/StaticFieldOrPropertyInGraph/StaticFieldOrPropertyInGraphAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/StaticFieldOrPropertyInGraph/StaticFieldOrPropertyInGraphAnalyzer.cs
@@ -119,7 +119,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.StaticFieldOrPropertyInGraph
 				properties.Add(StaticFieldOrPropertyInGraphDiagnosticProperties.IsViewOrAction, bool.TrueString);
 
 			if (isProperty)
-				properties.Add(StaticFieldOrPropertyInGraphDiagnosticProperties.IsProperty, bool.TrueString);
+				properties.Add(DiagnosticProperty.IsProperty, bool.TrueString);
 
 			return properties.ToImmutable();
 		}

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/StaticFieldOrPropertyInGraph/StaticFieldOrPropertyInGraphAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/StaticFieldOrPropertyInGraph/StaticFieldOrPropertyInGraphAnalyzer.cs
@@ -74,7 +74,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.StaticFieldOrPropertyInGraph
 															.FirstOrDefault(modifier => modifier.IsKind(SyntaxKind.StaticKeyword));
 
 			if (staticModifier != null && staticModifier != default(SyntaxToken))
-				return staticModifier.Value.GetLocation();
+				return staticModifier.Value.GetLocation().NullIfLocationKindIsNone();
 
 			return !staticFieldOrProperty.Locations.IsDefaultOrEmpty
 				? staticFieldOrProperty.Locations[0]

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/StaticFieldOrPropertyInGraph/StaticFieldOrPropertyInGraphDiagnosticProperties.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/StaticFieldOrPropertyInGraph/StaticFieldOrPropertyInGraphDiagnosticProperties.cs
@@ -6,7 +6,6 @@ namespace Acuminator.Analyzers.StaticAnalysis.StaticFieldOrPropertyInGraph
 	internal static class StaticFieldOrPropertyInGraphDiagnosticProperties
 	{
 		public const string IsViewOrAction   = nameof(IsViewOrAction);
-		public const string IsProperty   = nameof(IsProperty);
 		public const string CodeFixFormatArg = nameof(CodeFixFormatArg);
 	}
 }

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/StaticFieldOrPropertyInGraph/StaticFieldOrPropertyInGraphFix.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/StaticFieldOrPropertyInGraph/StaticFieldOrPropertyInGraphFix.cs
@@ -39,7 +39,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.StaticFieldOrPropertyInGraph
 				string makeReadOnlyCodeActionEquivalenceKey = nameof(Resources.PX1062FixMakeReadOnlyFormat).GetLocalized().ToString();
 				string makeReadOnlyCodeActionName = nameof(Resources.PX1062FixMakeReadOnlyFormat).GetLocalized(codeFixFormatArg).ToString();
 
-				bool isProperty = diagnostic.IsFlagSet(StaticFieldOrPropertyInGraphDiagnosticProperties.IsProperty);
+				bool isProperty = diagnostic.IsFlagSet(DiagnosticProperty.IsProperty);
 				Func<CancellationToken, Task<Document>> createChangedDocumentFunc = 
 					isProperty
 						? cToken => MakePropertyReadOnlyAsync(context.Document, context.Span, cToken)

--- a/src/Acuminator/Acuminator.Tests/Acuminator.Tests.csproj
+++ b/src/Acuminator/Acuminator.Tests/Acuminator.Tests.csproj
@@ -357,6 +357,9 @@
     <EmbeddedResource Include="Tests\StaticAnalysis\NonPublicGraphsDacsAndExtensions\Sources\NonPublicGraphWithBadModifiers.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\NonPublicGraphsDacsAndExtensions\Sources\NonPublicPartialGraph_Expected.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\NonPublicGraphsDacsAndExtensions\Sources\NonPublicPartialGraph.cs" />
+    <Compile Include="Tests\StaticAnalysis\PropertyAndBqlFieldTypesMismatch\PropertyAndBqlFieldTypesMismatchTests.cs" />
+    <EmbeddedResource Include="Tests\StaticAnalysis\PropertyAndBqlFieldTypesMismatch\Sources\DacWithInconsistentTypes_BqlFieldFirst_Expected.cs" />
+    <EmbeddedResource Include="Tests\StaticAnalysis\PropertyAndBqlFieldTypesMismatch\Sources\DacWithInconsistentTypes_BqlFieldFirst.cs" />
     <Compile Include="Tests\StaticAnalysis\PXOverrideMismatch\PXOverrideMismatchTests.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\PXOverrideMismatch\Sources\ArgumentsExactlyMatch.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\PXOverrideMismatch\Sources\ArgumentsDoNotMatch.cs" />

--- a/src/Acuminator/Acuminator.Tests/Acuminator.Tests.csproj
+++ b/src/Acuminator/Acuminator.Tests/Acuminator.Tests.csproj
@@ -360,6 +360,8 @@
     <Compile Include="Tests\StaticAnalysis\PropertyAndBqlFieldTypesMismatch\PropertyAndBqlFieldTypesMismatchTests.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\PropertyAndBqlFieldTypesMismatch\Sources\DacWithInconsistentTypes_BqlFieldFirst_Expected.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\PropertyAndBqlFieldTypesMismatch\Sources\DacWithInconsistentTypes_BqlFieldFirst.cs" />
+    <EmbeddedResource Include="Tests\StaticAnalysis\PropertyAndBqlFieldTypesMismatch\Sources\DacWithInconsistentTypes_PropertyFirst_Expected.cs" />
+    <EmbeddedResource Include="Tests\StaticAnalysis\PropertyAndBqlFieldTypesMismatch\Sources\DacWithInconsistentTypes_PropertyFirst.cs" />
     <Compile Include="Tests\StaticAnalysis\PXOverrideMismatch\PXOverrideMismatchTests.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\PXOverrideMismatch\Sources\ArgumentsExactlyMatch.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\PXOverrideMismatch\Sources\ArgumentsDoNotMatch.cs" />

--- a/src/Acuminator/Acuminator.Tests/Acuminator.Tests.csproj
+++ b/src/Acuminator/Acuminator.Tests/Acuminator.Tests.csproj
@@ -364,6 +364,8 @@
     <EmbeddedResource Include="Tests\StaticAnalysis\PropertyAndBqlFieldTypesMismatch\Sources\DacWithInconsistentTypes_PropertyFirst.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\PropertyAndBqlFieldTypesMismatch\Sources\DacExtensionWithInconsistentTypes_Expected.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\PropertyAndBqlFieldTypesMismatch\Sources\DacExtensionWithInconsistentTypes.cs" />
+    <EmbeddedResource Include="Tests\StaticAnalysis\PropertyAndBqlFieldTypesMismatch\Sources\DerivedDacWithInconsistentTypes_Expected.cs" />
+    <EmbeddedResource Include="Tests\StaticAnalysis\PropertyAndBqlFieldTypesMismatch\Sources\DerivedDacWithInconsistentTypes.cs" />
     <Compile Include="Tests\StaticAnalysis\PXOverrideMismatch\PXOverrideMismatchTests.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\PXOverrideMismatch\Sources\ArgumentsExactlyMatch.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\PXOverrideMismatch\Sources\ArgumentsDoNotMatch.cs" />

--- a/src/Acuminator/Acuminator.Tests/Acuminator.Tests.csproj
+++ b/src/Acuminator/Acuminator.Tests/Acuminator.Tests.csproj
@@ -362,6 +362,8 @@
     <EmbeddedResource Include="Tests\StaticAnalysis\PropertyAndBqlFieldTypesMismatch\Sources\DacWithInconsistentTypes_BqlFieldFirst.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\PropertyAndBqlFieldTypesMismatch\Sources\DacWithInconsistentTypes_PropertyFirst_Expected.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\PropertyAndBqlFieldTypesMismatch\Sources\DacWithInconsistentTypes_PropertyFirst.cs" />
+    <EmbeddedResource Include="Tests\StaticAnalysis\PropertyAndBqlFieldTypesMismatch\Sources\DacExtensionWithInconsistentTypes_Expected.cs" />
+    <EmbeddedResource Include="Tests\StaticAnalysis\PropertyAndBqlFieldTypesMismatch\Sources\DacExtensionWithInconsistentTypes.cs" />
     <Compile Include="Tests\StaticAnalysis\PXOverrideMismatch\PXOverrideMismatchTests.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\PXOverrideMismatch\Sources\ArgumentsExactlyMatch.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\PXOverrideMismatch\Sources\ArgumentsDoNotMatch.cs" />

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PropertyAndBqlFieldTypesMismatch/PropertyAndBqlFieldTypesMismatchTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PropertyAndBqlFieldTypesMismatch/PropertyAndBqlFieldTypesMismatchTests.cs
@@ -1,0 +1,47 @@
+﻿#nullable enable
+using System.Threading.Tasks;
+
+using Acuminator.Analyzers.StaticAnalysis;
+using Acuminator.Analyzers.StaticAnalysis.Dac;
+using Acuminator.Analyzers.StaticAnalysis.PropertyAndBqlFieldTypesMismatch;
+using Acuminator.Tests.Helpers;
+using Acuminator.Tests.Verification;
+using Acuminator.Utilities;
+
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using Xunit;
+
+namespace Acuminator.Tests.Tests.StaticAnalysis.PropertyAndBqlFieldTypesMismatch
+{
+	public class PropertyAndBqlFieldTypesMismatchTests : CodeFixVerifier
+	{
+		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer() => 
+			new DacAnalyzersAggregator(
+				CodeAnalysisSettings.Default.WithStaticAnalysisEnabled()
+											.WithSuppressionMechanismDisabled(),
+				new PropertyAndBqlFieldTypesMismatchAnalyzer());
+
+		protected override CodeFixProvider GetCSharpCodeFixProvider() => new PropertyAndBqlFieldTypesMismatchFix();
+
+		[Theory]
+		[EmbeddedFileData("DacWithInconsistentTypes_BqlFieldFirst.cs")]
+		public async Task Dac_WithMismatchingTypes_BqlFieldFirst(string actual) =>
+			await VerifyCSharpDiagnosticAsync(actual,
+				Descriptors.PX1068_PropertyAndBqlFieldTypesMismatch.CreateFor(12, 46),
+				Descriptors.PX1068_PropertyAndBqlFieldTypesMismatch.CreateFor(15, 10),
+				Descriptors.PX1068_PropertyAndBqlFieldTypesMismatch.CreateFor(19, 34),
+				Descriptors.PX1068_PropertyAndBqlFieldTypesMismatch.CreateFor(22, 18));
+
+		[Theory]
+		[EmbeddedFileData("DacWithInconsistentTypes_BqlFieldFirst.cs", "DacWithInconsistentTypes_BqlFieldFirst_Expected.cs")]
+		public async Task Dac_WithMismatchingTypes_FixBqlFieldType_CodeFix(string actual, string expected) =>
+			await VerifyCSharpFixAsync(actual, expected);
+
+		[Theory]
+		[EmbeddedFileData("DacWithInconsistentTypes_BqlFieldFirst_Expected.cs")]
+		public async Task Dac_WithFixedBqlFieldTypes_AfterFix_ShouldNotShowDiagnostic(string actual) =>
+			await VerifyCSharpDiagnosticAsync(actual);
+	}
+}

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PropertyAndBqlFieldTypesMismatch/PropertyAndBqlFieldTypesMismatchTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PropertyAndBqlFieldTypesMismatch/PropertyAndBqlFieldTypesMismatchTests.cs
@@ -37,7 +37,7 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.PropertyAndBqlFieldTypesMismatch
 
 		[Theory]
 		[EmbeddedFileData("DacWithInconsistentTypes_BqlFieldFirst.cs", "DacWithInconsistentTypes_BqlFieldFirst_Expected.cs")]
-		public async Task Dac_WithMismatchingTypes_FixBqlFieldType_CodeFix(string actual, string expected) =>
+		public async Task Dac_WithMismatchingTypes_FixBqlFieldType(string actual, string expected) =>
 			await VerifyCSharpFixAsync(actual, expected);
 
 		[Theory]
@@ -60,7 +60,7 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.PropertyAndBqlFieldTypesMismatch
 
 		[Theory]
 		[EmbeddedFileData("DacWithInconsistentTypes_PropertyFirst.cs", "DacWithInconsistentTypes_PropertyFirst_Expected.cs")]
-		public async Task Dac_WithMismatchingTypes_FixPropertyType_CodeFix(string actual, string expected) =>
+		public async Task Dac_WithMismatchingTypes_FixPropertyType(string actual, string expected) =>
 			await VerifyCSharpFixAsync(actual, expected);
 
 		[Theory]
@@ -89,6 +89,29 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.PropertyAndBqlFieldTypesMismatch
 		[Theory]
 		[EmbeddedFileData("DacExtensionWithInconsistentTypes_Expected.cs")]
 		public async Task DacExtension_WithFixedTypes_AfterFix_ShouldNotShowDiagnostic(string actual) =>
+			await VerifyCSharpDiagnosticAsync(actual);
+		#endregion
+
+		#region Derived DAC
+		[Theory]
+		[EmbeddedFileData("DerivedDacWithInconsistentTypes.cs")]
+		public async Task DerivedDac_WithMismatchingTypes(string actual) =>
+			await VerifyCSharpDiagnosticAsync(actual,
+				Descriptors.PX1068_PropertyAndBqlFieldTypesMismatch.CreateFor(13, 10),
+				Descriptors.PX1068_PropertyAndBqlFieldTypesMismatch.CreateFor(15, 44),
+				Descriptors.PX1068_PropertyAndBqlFieldTypesMismatch.CreateFor(19, 37),
+				Descriptors.PX1068_PropertyAndBqlFieldTypesMismatch.CreateFor(22, 10),
+				Descriptors.PX1068_PropertyAndBqlFieldTypesMismatch.CreateFor(26, 10),
+				Descriptors.PX1068_PropertyAndBqlFieldTypesMismatch.CreateFor(28, 34));
+
+		[Theory]
+		[EmbeddedFileData("DerivedDacWithInconsistentTypes.cs", "DerivedDacWithInconsistentTypes_Expected.cs")]
+		public async Task DerivedDac_WithMismatchingTypes_FixTypes(string actual, string expected) =>
+			await VerifyCSharpFixAsync(actual, expected);
+
+		[Theory]
+		[EmbeddedFileData("DerivedDacWithInconsistentTypes_Expected.cs")]
+		public async Task DerivedDac_WithFixedTypes_AfterFix_ShouldNotShowDiagnostic(string actual) =>
 			await VerifyCSharpDiagnosticAsync(actual);
 		#endregion
 	}

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PropertyAndBqlFieldTypesMismatch/PropertyAndBqlFieldTypesMismatchTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PropertyAndBqlFieldTypesMismatch/PropertyAndBqlFieldTypesMismatchTests.cs
@@ -68,5 +68,28 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.PropertyAndBqlFieldTypesMismatch
 		public async Task Dac_WithFixedPropertyTypes_AfterFix_ShouldNotShowDiagnostic(string actual) =>
 			await VerifyCSharpDiagnosticAsync(actual);
 		#endregion
+
+		#region DAC Extension
+		[Theory]
+		[EmbeddedFileData("DacExtensionWithInconsistentTypes.cs")]
+		public async Task DacExtension_WithMismatchingTypes(string actual) =>
+			await VerifyCSharpDiagnosticAsync(actual,
+				Descriptors.PX1068_PropertyAndBqlFieldTypesMismatch.CreateFor(13, 10),
+				Descriptors.PX1068_PropertyAndBqlFieldTypesMismatch.CreateFor(15, 44),
+				Descriptors.PX1068_PropertyAndBqlFieldTypesMismatch.CreateFor(19, 37),
+				Descriptors.PX1068_PropertyAndBqlFieldTypesMismatch.CreateFor(22, 10),
+				Descriptors.PX1068_PropertyAndBqlFieldTypesMismatch.CreateFor(26, 10),
+				Descriptors.PX1068_PropertyAndBqlFieldTypesMismatch.CreateFor(28, 34));
+
+		[Theory]
+		[EmbeddedFileData("DacExtensionWithInconsistentTypes.cs", "DacExtensionWithInconsistentTypes_Expected.cs")]
+		public async Task DacExtension_WithMismatchingTypes_FixTypes(string actual, string expected) =>
+			await VerifyCSharpFixAsync(actual, expected);
+
+		[Theory]
+		[EmbeddedFileData("DacExtensionWithInconsistentTypes_Expected.cs")]
+		public async Task DacExtension_WithFixedTypes_AfterFix_ShouldNotShowDiagnostic(string actual) =>
+			await VerifyCSharpDiagnosticAsync(actual);
+		#endregion
 	}
 }

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PropertyAndBqlFieldTypesMismatch/PropertyAndBqlFieldTypesMismatchTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PropertyAndBqlFieldTypesMismatch/PropertyAndBqlFieldTypesMismatchTests.cs
@@ -25,6 +25,7 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.PropertyAndBqlFieldTypesMismatch
 
 		protected override CodeFixProvider GetCSharpCodeFixProvider() => new PropertyAndBqlFieldTypesMismatchFix();
 
+		#region BQL field first
 		[Theory]
 		[EmbeddedFileData("DacWithInconsistentTypes_BqlFieldFirst.cs")]
 		public async Task Dac_WithMismatchingTypes_BqlFieldFirst(string actual) =>
@@ -43,5 +44,29 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.PropertyAndBqlFieldTypesMismatch
 		[EmbeddedFileData("DacWithInconsistentTypes_BqlFieldFirst_Expected.cs")]
 		public async Task Dac_WithFixedBqlFieldTypes_AfterFix_ShouldNotShowDiagnostic(string actual) =>
 			await VerifyCSharpDiagnosticAsync(actual);
+		#endregion
+
+		#region Property first
+		[Theory]
+		[EmbeddedFileData("DacWithInconsistentTypes_PropertyFirst.cs")]
+		public async Task Dac_WithMismatchingTypes_PropertyFirst(string actual) =>
+			await VerifyCSharpDiagnosticAsync(actual,
+				Descriptors.PX1068_PropertyAndBqlFieldTypesMismatch.CreateFor(13, 10),
+				Descriptors.PX1068_PropertyAndBqlFieldTypesMismatch.CreateFor(15, 46),
+				Descriptors.PX1068_PropertyAndBqlFieldTypesMismatch.CreateFor(20, 18),
+				Descriptors.PX1068_PropertyAndBqlFieldTypesMismatch.CreateFor(22, 34),
+				Descriptors.PX1068_PropertyAndBqlFieldTypesMismatch.CreateFor(27, 18),
+				Descriptors.PX1068_PropertyAndBqlFieldTypesMismatch.CreateFor(29, 46));
+
+		[Theory]
+		[EmbeddedFileData("DacWithInconsistentTypes_PropertyFirst.cs", "DacWithInconsistentTypes_PropertyFirst_Expected.cs")]
+		public async Task Dac_WithMismatchingTypes_FixPropertyType_CodeFix(string actual, string expected) =>
+			await VerifyCSharpFixAsync(actual, expected);
+
+		[Theory]
+		[EmbeddedFileData("DacWithInconsistentTypes_PropertyFirst_Expected.cs")]
+		public async Task Dac_WithFixedPropertyTypes_AfterFix_ShouldNotShowDiagnostic(string actual) =>
+			await VerifyCSharpDiagnosticAsync(actual);
+		#endregion
 	}
 }

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PropertyAndBqlFieldTypesMismatch/Sources/DacExtensionWithInconsistentTypes.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PropertyAndBqlFieldTypesMismatch/Sources/DacExtensionWithInconsistentTypes.cs
@@ -1,0 +1,45 @@
+﻿using System;
+
+using PX.Data;
+using PX.Data.BQL;
+
+namespace PX.Analyzers.Test.Sources
+{
+	// Acuminator disable once PX1016 ExtensionDoesNotDeclareIsActiveMethod extension should be constantly active
+	public sealed class DacExt : PXCacheExtension<Dac>
+	{
+		#region LineNbr
+		[PXUIField]
+		public byte[] LineNbr { get; set; }
+
+		public abstract class lineNbr : Data.BQL.BqlInt.Field<lineNbr> { }
+		#endregion
+
+		#region OrderType
+		public abstract class orderType : BqlLong.Field<orderType> { }
+
+		[PXUIField]
+		public string OrderType { get; set; }
+		#endregion
+
+		[PXUIField]
+		public string NoteID { get; set; }
+
+		public abstract class Tstamp : BqlByte.Field<Tstamp> { }
+	}
+
+	[PXHidden]
+	public class Dac : IBqlTable
+	{
+		#region NoteID
+		public abstract class noteID : PX.Data.BQL.BqlGuid.Field<noteID> { }
+		#endregion
+
+		#region tstamp
+		public abstract class Tstamp : IBqlField { }
+
+		[PXUIField]
+		public virtual byte[] tstamp { get; set; }
+		#endregion
+	}
+}

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PropertyAndBqlFieldTypesMismatch/Sources/DacExtensionWithInconsistentTypes_Expected.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PropertyAndBqlFieldTypesMismatch/Sources/DacExtensionWithInconsistentTypes_Expected.cs
@@ -1,0 +1,45 @@
+﻿using System;
+
+using PX.Data;
+using PX.Data.BQL;
+
+namespace PX.Analyzers.Test.Sources
+{
+	// Acuminator disable once PX1016 ExtensionDoesNotDeclareIsActiveMethod extension should be constantly active
+	public sealed class DacExt : PXCacheExtension<Dac>
+	{
+		#region LineNbr
+		[PXUIField]
+		public int? LineNbr { get; set; }
+
+		public abstract class lineNbr : Data.BQL.BqlInt.Field<lineNbr> { }
+		#endregion
+
+		#region OrderType
+		public abstract class orderType : BqlString.Field<orderType> { }
+
+		[PXUIField]
+		public string OrderType { get; set; }
+		#endregion
+
+		[PXUIField]
+		public Guid? NoteID { get; set; }
+
+		public abstract class Tstamp : BqlByteArray.Field<Tstamp> { }
+	}
+
+	[PXHidden]
+	public class Dac : IBqlTable
+	{
+		#region NoteID
+		public abstract class noteID : PX.Data.BQL.BqlGuid.Field<noteID> { }
+		#endregion
+
+		#region tstamp
+		public abstract class Tstamp : IBqlField { }
+
+		[PXUIField]
+		public virtual byte[] tstamp { get; set; }
+		#endregion
+	}
+}

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PropertyAndBqlFieldTypesMismatch/Sources/DacWithInconsistentTypes_BqlFieldFirst.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PropertyAndBqlFieldTypesMismatch/Sources/DacWithInconsistentTypes_BqlFieldFirst.cs
@@ -1,0 +1,35 @@
+﻿using System;
+
+using PX.Data;
+using PX.Data.BQL;
+
+namespace PX.Analyzers.Test.Sources
+{
+	[PXHidden]
+	public class DacWithBqlFieldsFirst : IBqlTable
+	{
+		#region NoteID
+		public abstract class noteID : PX.Data.BQL.BqlInt.Field<noteID> { }
+
+		[PXGuid]
+		public Guid? NoteID { get; set; }
+		#endregion
+
+		#region tstamp
+		public abstract class Tstamp : BqlByte.Field<Tstamp> { }
+
+		[PXDBTimestamp(RecordComesFirst = true)]
+		public virtual byte[] tstamp { get; set; }
+		#endregion
+
+		#region Shipment Nbr
+		public abstract class shipmentNbr : IBqlField { }	// no strong BQL type => shouldn't be reported
+
+		[PXInt]
+		public virtual int? ShipmentNbr { get; set; }
+		#endregion
+
+		[System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
+		public bool HasNoteID => NoteID != null;
+	}
+}

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PropertyAndBqlFieldTypesMismatch/Sources/DacWithInconsistentTypes_BqlFieldFirst_Expected.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PropertyAndBqlFieldTypesMismatch/Sources/DacWithInconsistentTypes_BqlFieldFirst_Expected.cs
@@ -1,0 +1,35 @@
+﻿using System;
+
+using PX.Data;
+using PX.Data.BQL;
+
+namespace PX.Analyzers.Test.Sources
+{
+	[PXHidden]
+	public class DacWithBqlFieldsFirst : IBqlTable
+	{
+		#region NoteID
+		public abstract class noteID : PX.Data.BQL.BqlGuid.Field<noteID> { }
+
+		[PXGuid]
+		public Guid? NoteID { get; set; }
+		#endregion
+
+		#region tstamp
+		public abstract class Tstamp : BqlByteArray.Field<Tstamp> { }
+
+		[PXDBTimestamp(RecordComesFirst = true)]
+		public virtual byte[] tstamp { get; set; }
+		#endregion
+
+		#region Shipment Nbr
+		public abstract class shipmentNbr : IBqlField { }	// no strong BQL type => shouldn't be reported
+
+		[PXInt]
+		public virtual int? ShipmentNbr { get; set; }
+		#endregion
+
+		[System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
+		public bool HasNoteID => NoteID != null;
+	}
+}

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PropertyAndBqlFieldTypesMismatch/Sources/DacWithInconsistentTypes_PropertyFirst.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PropertyAndBqlFieldTypesMismatch/Sources/DacWithInconsistentTypes_PropertyFirst.cs
@@ -1,0 +1,42 @@
+﻿using System;
+
+using PX.Data;
+using PX.Data.BQL;
+
+namespace PX.Analyzers.Test.Sources
+{
+	[PXHidden]
+	public class DacWithPropertiesFirst : IBqlTable
+	{
+		#region NoteID
+		[PXUIField]
+		public int? NoteID { get; set; }
+
+		public abstract class noteID : PX.Data.BQL.BqlGuid.Field<noteID> { }
+		#endregion
+
+		#region tstamp
+		[PXUIField]
+		public virtual byte tstamp { get; set; }
+
+		public abstract class Tstamp : BqlByteArray.Field<Tstamp> { }
+		#endregion
+
+		#region OrderType
+		[PXUIField]
+		public virtual byte[] OrderType { get; set; }
+
+		public abstract class orderType : Data.BQL.BqlString.Field<orderType> { }
+		#endregion
+
+		#region Shipment Nbr
+		public abstract class shipmentNbr : IBqlField { }	// no strong BQL type => shouldn't be reported
+
+		[PXInt]
+		public virtual int? ShipmentNbr { get; set; }
+		#endregion
+
+		[System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
+		public bool HasNoteID => NoteID != null;
+	}
+}

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PropertyAndBqlFieldTypesMismatch/Sources/DacWithInconsistentTypes_PropertyFirst_Expected.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PropertyAndBqlFieldTypesMismatch/Sources/DacWithInconsistentTypes_PropertyFirst_Expected.cs
@@ -1,0 +1,42 @@
+﻿using System;
+
+using PX.Data;
+using PX.Data.BQL;
+
+namespace PX.Analyzers.Test.Sources
+{
+	[PXHidden]
+	public class DacWithPropertiesFirst : IBqlTable
+	{
+		#region NoteID
+		[PXUIField]
+		public Guid? NoteID { get; set; }
+
+		public abstract class noteID : PX.Data.BQL.BqlGuid.Field<noteID> { }
+		#endregion
+
+		#region tstamp
+		[PXUIField]
+		public virtual byte[] tstamp { get; set; }
+
+		public abstract class Tstamp : BqlByteArray.Field<Tstamp> { }
+		#endregion
+
+		#region OrderType
+		[PXUIField]
+		public virtual string OrderType { get; set; }
+
+		public abstract class orderType : Data.BQL.BqlString.Field<orderType> { }
+		#endregion
+
+		#region Shipment Nbr
+		public abstract class shipmentNbr : IBqlField { }	// no strong BQL type => shouldn't be reported
+
+		[PXInt]
+		public virtual int? ShipmentNbr { get; set; }
+		#endregion
+
+		[System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
+		public bool HasNoteID => NoteID != null;
+	}
+}

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PropertyAndBqlFieldTypesMismatch/Sources/DerivedDacWithInconsistentTypes.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PropertyAndBqlFieldTypesMismatch/Sources/DerivedDacWithInconsistentTypes.cs
@@ -1,0 +1,46 @@
+﻿using System;
+
+using PX.Data;
+using PX.Data.BQL;
+
+namespace PX.Analyzers.Test.Sources
+{
+	[PXHidden]
+	public class DerivedDac : Dac
+	{
+		#region LineNbr
+		[PXUIField]
+		public byte[] LineNbr { get; set; }
+
+		public abstract class lineNbr : Data.BQL.BqlInt.Field<lineNbr> { }
+		#endregion
+
+		#region OrderType
+		public abstract class orderType : BqlLong.Field<orderType> { }
+
+		[PXUIField]
+		public string OrderType { get; set; }
+		#endregion
+
+		// Acuminator disable once PX1067 MissingBqlFieldRedeclarationInDerivedDac [Justification]
+		[PXUIField]
+		public string NoteID { get; set; }
+
+		public new abstract class Tstamp : BqlByte.Field<Tstamp> { }
+	}
+
+	[PXHidden]
+	public class Dac : IBqlTable
+	{
+		#region NoteID
+		public abstract class noteID : PX.Data.BQL.BqlGuid.Field<noteID> { }
+		#endregion
+
+		#region tstamp
+		public abstract class Tstamp : IBqlField { }
+
+		[PXUIField]
+		public virtual byte[] tstamp { get; set; }
+		#endregion
+	}
+}

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PropertyAndBqlFieldTypesMismatch/Sources/DerivedDacWithInconsistentTypes_Expected.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PropertyAndBqlFieldTypesMismatch/Sources/DerivedDacWithInconsistentTypes_Expected.cs
@@ -1,0 +1,46 @@
+﻿using System;
+
+using PX.Data;
+using PX.Data.BQL;
+
+namespace PX.Analyzers.Test.Sources
+{
+	[PXHidden]
+	public class DerivedDac : Dac
+	{
+		#region LineNbr
+		[PXUIField]
+		public int? LineNbr { get; set; }
+
+		public abstract class lineNbr : Data.BQL.BqlInt.Field<lineNbr> { }
+		#endregion
+
+		#region OrderType
+		public abstract class orderType : BqlString.Field<orderType> { }
+
+		[PXUIField]
+		public string OrderType { get; set; }
+		#endregion
+
+		// Acuminator disable once PX1067 MissingBqlFieldRedeclarationInDerivedDac [Justification]
+		[PXUIField]
+		public Guid? NoteID { get; set; }
+
+		public new abstract class Tstamp : BqlByteArray.Field<Tstamp> { }
+	}
+
+	[PXHidden]
+	public class Dac : IBqlTable
+	{
+		#region NoteID
+		public abstract class noteID : PX.Data.BQL.BqlGuid.Field<noteID> { }
+		#endregion
+
+		#region tstamp
+		public abstract class Tstamp : IBqlField { }
+
+		[PXUIField]
+		public virtual byte[] tstamp { get; set; }
+		#endregion
+	}
+}

--- a/src/Acuminator/Acuminator.Tests/Tests/Utilities/SemanticModels/Dac/DacSemanticModelTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/Utilities/SemanticModels/Dac/DacSemanticModelTests.cs
@@ -41,6 +41,8 @@ namespace Acuminator.Tests.Tests.Utilities.SemanticModels.Dac
 
 				dacField.PropertyInfo.Should().NotBeNull();
 			}
+
+			TestDacFieldAndBqlFieldInfosTypeConsistency(dacSemanticModel.DacFields);
 		}
 
 		[Theory]
@@ -58,9 +60,11 @@ namespace Acuminator.Tests.Tests.Utilities.SemanticModels.Dac
 			{
 				dacField.BqlFieldInfo.Should().NotBeNull();
 				dacField.BqlFieldInfo!.BqlFieldDataTypeDeclared.Should().NotBeNull();
-				
+
 				dacField.PropertyInfo.Should().BeNull();
 			}
+
+			TestDacFieldAndBqlFieldInfosTypeConsistency(dacSemanticModel.DeclaredDacFields);
 
 			dacSemanticModel.BqlFieldsByNames["docType"].BqlFieldDataTypeDeclared!.Name.Should().Be("String");
 			dacSemanticModel.BqlFieldsByNames["refNbr"].BqlFieldDataTypeDeclared!.Name.Should().Be("String");
@@ -83,6 +87,8 @@ namespace Acuminator.Tests.Tests.Utilities.SemanticModels.Dac
 				dacField.BqlFieldInfo.Should().NotBeNull();
 				dacField.PropertyInfo.Should().NotBeNull();
 			}
+
+			TestDacFieldAndBqlFieldInfosTypeConsistency(dacSemanticModel.DacFields);
 		}
 
 		[Theory]
@@ -103,6 +109,8 @@ namespace Acuminator.Tests.Tests.Utilities.SemanticModels.Dac
 				dacField.PropertyInfo.Should().NotBeNull();
 			}
 
+			TestDacFieldAndBqlFieldInfosTypeConsistency(dacSemanticModel.DacFields);
+
 			dacSemanticModel.DacFieldsByNames["CreatedByID"].Base.Should().NotBeNull();
 		}
 
@@ -121,8 +129,10 @@ namespace Acuminator.Tests.Tests.Utilities.SemanticModels.Dac
 			foreach (var dacField in dacSemanticModel.DacFields)
 			{
 				dacField.BqlFieldInfo.Should().NotBeNull();
-				dacField.PropertyInfo.Should().NotBeNull();
+				dacField.PropertyInfo.Should().NotBeNull();	
 			}
+
+			TestDacFieldAndBqlFieldInfosTypeConsistency(dacSemanticModel.DacFields);
 
 			dacSemanticModel.DacFieldsByNames["CreatedByID"].Base.Should().NotBeNull();
 		}
@@ -159,6 +169,17 @@ namespace Acuminator.Tests.Tests.Utilities.SemanticModels.Dac
 			{
 				foreach (var requiredDacField in requiredDacFields)
 					dacModel.DacFieldsByNames.Should().ContainKey(requiredDacField);
+			}
+		}
+
+		private void TestDacFieldAndBqlFieldInfosTypeConsistency(IEnumerable<DacFieldInfo> dacFields)
+		{
+			foreach (var dacField in dacFields)
+			{
+				SymbolEqualityComparer.Default.Equals(dacField.BqlFieldDataTypeDeclared, dacField.BqlFieldInfo?.BqlFieldDataTypeDeclared)
+											  .Should().BeTrue();
+				SymbolEqualityComparer.Default.Equals(dacField.BqlFieldDataTypeEffective, dacField.BqlFieldInfo?.BqlFieldDataTypeEffective)
+											  .Should().BeTrue();
 			}
 		}
 	}

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/CodeGeneration/BqlFieldGeneration.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/CodeGeneration/BqlFieldGeneration.cs
@@ -38,10 +38,10 @@ namespace Acuminator.Utilities.Roslyn.CodeGeneration
 			return iBqlFieldBaseType;
 		}
 
-		public static ClassDeclarationSyntax? GenerateTypedBqlField(PropertyTypeName fieldPropertyTypeName, string bqlFieldName, bool isFirstField,
+		public static ClassDeclarationSyntax? GenerateTypedBqlField(DataTypeName dataTypeName, string bqlFieldName, bool isFirstField,
 																	bool isRedeclaration, MemberDeclarationSyntax? adjacentMemberToCopyRegions)
 		{
-			var bqlFieldBaseTypeNode = BaseTypeForBqlField(fieldPropertyTypeName, bqlFieldName);
+			var bqlFieldBaseTypeNode = BaseTypeForBqlField(dataTypeName, bqlFieldName);
 
 			if (bqlFieldBaseTypeNode == null)
 				return null;
@@ -59,11 +59,11 @@ namespace Acuminator.Utilities.Roslyn.CodeGeneration
 			return bqlField;
 		}
 
-		public static SimpleBaseTypeSyntax? BaseTypeForBqlField(PropertyTypeName fieldPropertyTypeName, string bqlFieldName)
+		public static SimpleBaseTypeSyntax? BaseTypeForBqlField(DataTypeName dataTypeName, string bqlFieldName)
 		{
 			bqlFieldName.ThrowOnNullOrWhiteSpace();
 
-			var bqlFieldTypeName = PropertyTypeToBqlFieldTypeMapping.GetBqlFieldType(fieldPropertyTypeName).NullIfWhiteSpace();
+			var bqlFieldTypeName = DataTypeToBqlFieldTypeMapping.GetBqlFieldType(dataTypeName).NullIfWhiteSpace();
 
 			if (bqlFieldTypeName == null)
 				return null;

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Constants/DataTypeToBqlFieldTypeMapping.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Constants/DataTypeToBqlFieldTypeMapping.cs
@@ -1,17 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
-using Acuminator.Utilities.Common;
-
 namespace Acuminator.Utilities.Roslyn.Constants
 {
 	/// <summary>
-	/// A property type to BQL field type mapping table. 
-	/// Contains mapping between DAC field property type and BQL field type.
+	/// A mapping between data types (such as C# property type) to BQL field type (such as BqlString).
 	/// </summary>
-	public static class PropertyTypeToBqlFieldTypeMapping
+	public static class DataTypeToBqlFieldTypeMapping
 	{
-		private static readonly Dictionary<string, string> _propertyTypeToBqlFieldType = new(StringComparer.OrdinalIgnoreCase)
+		private static readonly Dictionary<string, string> _dataTypeToBqlFieldType = new(StringComparer.OrdinalIgnoreCase)
 		{
 			{ nameof(String)  , "BqlString"   },
 			{ nameof(Guid)	  , "BqlGuid"	  },
@@ -41,7 +38,7 @@ namespace Acuminator.Utilities.Roslyn.Constants
 			{ "ByteArray"		 , "BqlByteArray" }
 		};
 
-		private static readonly Dictionary<string, string> _bqlFieldTypeToPropertyType = new(StringComparer.OrdinalIgnoreCase)
+		private static readonly Dictionary<string, string> _bqlFieldTypeToDataType = new(StringComparer.OrdinalIgnoreCase)
 		{
 			{ "BqlString"	 , nameof(String) 	   },
 			{ "BqlGuid"		 , nameof(Guid) 	   },
@@ -57,20 +54,20 @@ namespace Acuminator.Utilities.Roslyn.Constants
 			{ "BqlByteArray" , $"{nameof(Byte)}[]" },
 		};
 
-		public static bool ContainsPropertyType(PropertyTypeName propertyType) =>
-			_propertyTypeToBqlFieldType.ContainsKey(propertyType.Value);
+		public static bool ContainsDataType(DataTypeName dataType) =>
+			_dataTypeToBqlFieldType.ContainsKey(dataType.Value);
 
 		public static bool ContainsBqlFieldType(BqlFieldTypeName bqlFieldType) =>
-			_bqlFieldTypeToPropertyType.ContainsKey(bqlFieldType.Value);
+			_bqlFieldTypeToDataType.ContainsKey(bqlFieldType.Value);
 
-		public static string? GetBqlFieldType(PropertyTypeName propertyType) =>
-			_propertyTypeToBqlFieldType.TryGetValue(propertyType.Value, out var bqlFieldType)
+		public static string? GetBqlFieldType(DataTypeName dataType) =>
+			_dataTypeToBqlFieldType.TryGetValue(dataType.Value, out var bqlFieldType)
 				? bqlFieldType
 				: null;
 
-		public static string? GetPropertyType(BqlFieldTypeName bqlFieldType) =>
-			_bqlFieldTypeToPropertyType.TryGetValue(bqlFieldType.Value, out var propertyType)
-				? propertyType
+		public static string? GetDataType(BqlFieldTypeName bqlFieldType) =>
+			_bqlFieldTypeToDataType.TryGetValue(bqlFieldType.Value, out var dataType)
+				? dataType
 				: null;
 	}
 }

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Constants/TypeNames.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Constants/TypeNames.cs
@@ -1,5 +1,8 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
+
+using Acuminator.Utilities.Common;
 
 namespace Acuminator.Utilities.Roslyn.Constants
 {
@@ -47,6 +50,57 @@ namespace Acuminator.Utilities.Roslyn.Constants
 			public const string IBqlField = "IBqlField";
 			public const string Field	  = "Field";
 			public const string BqlType   = "BqlType";
+		}
+
+		/// <summary>
+		/// C# predefined types.
+		/// </summary>
+		public static class CSharpPredefinedTypes
+		{
+			public const string Object 	= "object";
+			public const string Dynamic = "dynamic";
+			public const string Void 	= "void";
+			public const string Boolean = "bool";
+			public const string Char 	= "char";
+			public const string SByte 	= "sbyte";
+			public const string Byte 	= "byte";
+			public const string Int16 	= "short";
+			public const string UInt16 	= "ushort" ;
+			public const string Int32 	= "int";
+			public const string UInt32 	= "uint";
+			public const string Int64 	= "long";
+			public const string UInt64 	= "ulong";
+			public const string Decimal = "decimal";
+			public const string Single 	= "float";
+			public const string Double 	= "double";
+			public const string String 	= "string";
+			public const string NInt 	= "nint";
+			public const string NUInt 	= "nuint";
+
+			public static ReadOnlyHashSet<string> All { get; } = 
+				new ReadOnlyHashSet<string>
+				([
+					Object,
+					Dynamic,
+					Void,
+					Boolean,
+					Char,
+					SByte,
+					Byte,
+					Int16,
+					UInt16,
+					Int32,
+					UInt32,
+					Int64,
+					UInt64,
+					Decimal,
+					Single,
+					Double,
+					String,
+					NInt,
+					NUInt
+				],
+				StringComparer.OrdinalIgnoreCase);
 		}
 
 		public const string PXView = "PXView";

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/DataTypeName.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/DataTypeName.cs
@@ -5,7 +5,7 @@ using Acuminator.Utilities.Common;
 
 namespace Acuminator.Utilities.Roslyn;
 
-public readonly record struct PropertyTypeName(string Value)
+public readonly record struct DataTypeName(string Value)
 {
 	public string Value { get; } = Value.CheckIfNullOrWhiteSpace();
 

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/ISymbolGenericUtils.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/ISymbolGenericUtils.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 using Acuminator.Utilities.Common;
@@ -187,5 +188,25 @@ namespace Acuminator.Utilities.Roslyn.Semantic
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static bool IsInSourceCode(this ISymbol symbol) =>
 			!symbol.DeclaringSyntaxReferences.IsDefaultOrEmpty;
+
+		/// <summary>
+		/// A <see cref="Location"/> extension method that returns <see langword="null"/> if location's <see cref="Location.Kind"/> is <see cref="LocationKind.None"/>.
+		/// </summary>
+		/// <param name="location">The location to act on.</param>
+		/// <returns>
+		/// The location or <see langword="null"/> if location's kind is <see cref="LocationKind.None"/>.
+		/// </returns>
+		/// <remarks>
+		/// This method is a safety wrapper for locations that are obtained from <see cref="SyntaxToken.GetLocation"/> tokens.<br/>
+		/// Syntax tokens may return a special null-object location with <see cref="LocationKind.None"/> kind.<br/>
+		/// Such "null-object" location will prevent the usage of any fallback location that could have been obtained from coalesce chainings if the location was null.<br/>
+		/// This helper allows to use coalsesce chaining with fallback locations in a safe manner.<br/><br/>
+		/// Note, that locations obtained from <see cref="CSharpSyntaxNode.GetLocation"/> do not need to be checked this way.
+		/// </remarks>
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static Location? NullIfLocationKindIsNone(this Location? location) =>
+			location?.Kind == LocationKind.None
+				? null
+				: location;
 	}
 }

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/Dac/Infos/DacFieldInfo.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/Dac/Infos/DacFieldInfo.cs
@@ -76,13 +76,13 @@ namespace Acuminator.Utilities.Roslyn.Semantic.Dac
 		/// <value>
 		/// The type of the DAC field property.
 		/// </value>
-		public ITypeSymbol? FieldPropertyType { get; private set; }
+		public ITypeSymbol? PropertyType { get; private set; }
 
 		/// <value>
-		/// The effective type of the property. For reference types and non nullable value types it is the same as <see cref="PropertyType"/>. 
+		/// The non nullable type of the property. For reference types and non nullable value types it is the same as <see cref="PropertyType"/>. 
 		/// For nulable value types it is the underlying type extracted from nullable. It is <c>T</c> for <see cref="Nullable{T}"/>.
 		/// </value>
-		public ITypeSymbol? EffectivePropertyType { get; private set; }
+		public ITypeSymbol? PropertyTypeUnwrappedNullable { get; private set; }
 
 		/// <summary>
 		/// The declared BQL field data type of this DAC field.
@@ -152,11 +152,12 @@ namespace Acuminator.Utilities.Roslyn.Semantic.Dac
 				IsKey 					  = dacPropertyInfo.IsKey;
 				IsIdentity 				  = dacPropertyInfo.IsIdentity;
 				IsAutoNumbering 		  = dacPropertyInfo.IsAutoNumbering;
-				FieldPropertyType 		  = dacPropertyInfo.PropertyType;
-				EffectivePropertyType 	  = dacPropertyInfo.EffectivePropertyType;
 				DeclaredDbBoundness 	  = dacPropertyInfo.DeclaredDbBoundness;
 				EffectiveDbBoundness 	  = dacPropertyInfo.EffectiveDbBoundness;
 				HasAcumaticaAttributes 	  = dacPropertyInfo.HasAcumaticaAttributesEffective;
+
+				PropertyType 				  = dacPropertyInfo.PropertyType;
+				PropertyTypeUnwrappedNullable = dacPropertyInfo.PropertyTypeUnwrappedNullable;
 			}
 			else
 			{
@@ -165,11 +166,12 @@ namespace Acuminator.Utilities.Roslyn.Semantic.Dac
 				IsKey 					  = false;
 				IsIdentity 				  = false;
 				IsAutoNumbering 		  = false;
-				FieldPropertyType 		  = null;
-				EffectivePropertyType 	  = null;
 				DeclaredDbBoundness 	  = DbBoundnessType.NotDefined;
 				EffectiveDbBoundness 	  = DbBoundnessType.NotDefined;
 				HasAcumaticaAttributes 	  = false;
+
+				PropertyType 				  = null;
+				PropertyTypeUnwrappedNullable = null;
 			}
 		}
 
@@ -188,8 +190,8 @@ namespace Acuminator.Utilities.Roslyn.Semantic.Dac
 			IsAutoNumbering 		  = IsAutoNumbering 		  || baseInfo.IsAutoNumbering;
 			HasAcumaticaAttributes 	  = HasAcumaticaAttributes 	  || baseInfo.HasAcumaticaAttributes;
 
-			FieldPropertyType	  ??= baseInfo.FieldPropertyType;
-			EffectivePropertyType ??= baseInfo.EffectivePropertyType;
+			PropertyType				  ??= baseInfo.PropertyType;
+			PropertyTypeUnwrappedNullable ??= baseInfo.PropertyTypeUnwrappedNullable;
 
 			BqlFieldDataTypeEffective ??= baseInfo.BqlFieldDataTypeEffective;
 

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/Dac/Infos/DacFieldInfo.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/Dac/Infos/DacFieldInfo.cs
@@ -85,6 +85,17 @@ namespace Acuminator.Utilities.Roslyn.Semantic.Dac
 		public ITypeSymbol? EffectivePropertyType { get; private set; }
 
 		/// <summary>
+		/// The declared BQL field data type of this DAC field.
+		/// </summary>
+		public ITypeSymbol? BqlFieldDataTypeDeclared { get; }
+
+		/// <summary>
+		/// The effective BQL field data type of this DAC field that is obtained through the combination of <see cref="BqlFieldDataTypeDeclared"/> 
+		/// from this and base infos.
+		/// </summary>
+		public ITypeSymbol? BqlFieldDataTypeEffective {  get; private set; }
+
+		/// <summary>
 		/// The DB boundness calculated from attributes declared on this DAC property.
 		/// </summary>
 		public DbBoundnessType DeclaredDbBoundness { get; }
@@ -119,7 +130,19 @@ namespace Acuminator.Utilities.Roslyn.Semantic.Dac
 			Name 		 = PropertyInfo?.Name ?? BqlFieldInfo!.Name.ToPascalCase();
 			DacType 	 = PropertyInfo?.Symbol.ContainingType ?? BqlFieldInfo!.Symbol.ContainingType;
 
-			HasBqlFieldDeclared  = dacBqlFieldInfo != null;
+			if (dacBqlFieldInfo != null)
+			{
+				HasBqlFieldDeclared = true;
+				BqlFieldDataTypeDeclared  = dacBqlFieldInfo.BqlFieldDataTypeDeclared;
+				BqlFieldDataTypeEffective = dacBqlFieldInfo.BqlFieldDataTypeEffective;
+			}
+			else
+			{
+				HasBqlFieldDeclared = false;
+				BqlFieldDataTypeDeclared  = null;
+				BqlFieldDataTypeEffective = null;
+			}
+
 			HasBqlFieldEffective = HasBqlFieldDeclared;
 
 			if (dacPropertyInfo != null)
@@ -167,6 +190,8 @@ namespace Acuminator.Utilities.Roslyn.Semantic.Dac
 
 			FieldPropertyType	  ??= baseInfo.FieldPropertyType;
 			EffectivePropertyType ??= baseInfo.EffectivePropertyType;
+
+			BqlFieldDataTypeEffective ??= baseInfo.BqlFieldDataTypeEffective;
 
 			EffectiveDbBoundness = DeclaredDbBoundness.Combine(baseInfo.EffectiveDbBoundness);
 		}

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/Dac/Infos/DacPropertyInfo.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/Dac/Infos/DacPropertyInfo.cs
@@ -66,7 +66,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic.Dac
 		/// The effective type of the property. For reference types and non nullable value types it is the same as <see cref="PropertyType"/>. 
 		/// For nulable value types it is the underlying type extracted from nullable. It is <c>T</c> for <see cref="Nullable{T}"/>.
 		/// </value>
-		public ITypeSymbol EffectivePropertyType { get; }
+		public ITypeSymbol PropertyTypeUnwrappedNullable { get; }
 
 		/// <summary>
 		/// The DB boundness calculated from attributes declared on this DAC property.
@@ -88,16 +88,16 @@ namespace Acuminator.Utilities.Roslyn.Semantic.Dac
 
 		public bool IsAutoNumbering { get; }
 
-		protected DacPropertyInfo(PropertyDeclarationSyntax? node, IPropertySymbol symbol, ITypeSymbol effectivePropertyType,
+		protected DacPropertyInfo(PropertyDeclarationSyntax? node, IPropertySymbol symbol, ITypeSymbol propertyTypeUnwrappedNullable,
 								  int declarationOrder, bool hasBqlField, IEnumerable<DacFieldAttributeInfo> attributeInfos, 
 								  DacPropertyInfo baseInfo) :
-							 this(node, symbol, effectivePropertyType, declarationOrder, hasBqlField, attributeInfos)
+							 this(node, symbol, propertyTypeUnwrappedNullable, declarationOrder, hasBqlField, attributeInfos)
 		{
 			_baseInfo = baseInfo.CheckIfNull();
 			CombineWithBaseInfo(baseInfo);
 		}
 
-		protected DacPropertyInfo(PropertyDeclarationSyntax? node, IPropertySymbol symbol, ITypeSymbol effectivePropertyType,
+		protected DacPropertyInfo(PropertyDeclarationSyntax? node, IPropertySymbol symbol, ITypeSymbol propertyTypeUnwrappedNullable,
 								  int declarationOrder, bool hasBqlField, IEnumerable<DacFieldAttributeInfo> attributeInfos) :
 							 base(node, symbol, declarationOrder)
 		{
@@ -121,10 +121,10 @@ namespace Acuminator.Utilities.Roslyn.Semantic.Dac
 				hasAcumaticaAttributes = hasAcumaticaAttributes || attributeInfo.IsAcumaticaAttribute;
 			}
 	
-			EffectivePropertyType = effectivePropertyType;
-			IsIdentity 			  = isIdentity;
-			IsKey 				  = isPrimaryKey;
-			IsAutoNumbering 	  = isAutoNumbering;
+			PropertyTypeUnwrappedNullable = propertyTypeUnwrappedNullable;
+			IsIdentity 			  		  = isIdentity;
+			IsKey 				  		  = isPrimaryKey;
+			IsAutoNumbering 	  		  = isAutoNumbering;
 
 			HasAcumaticaAttributesDeclared  = hasAcumaticaAttributes;
 			HasAcumaticaAttributesEffective = hasAcumaticaAttributes;
@@ -144,11 +144,11 @@ namespace Acuminator.Utilities.Roslyn.Semantic.Dac
 		{
 			bool hasBqlField = dacFields.ContainsKey(property.Name);
 			var attributeInfos = GetAttributeInfos(property, dbBoundnessCalculator);
-			var effectivePropertyType = property.Type.GetUnderlyingTypeFromNullable(context) ?? property.Type;
+			var propertyTypeUnwrappedNullable = property.Type.GetUnderlyingTypeFromNullable(context) ?? property.Type;
 
 			return baseInfo != null
-				? new DacPropertyInfo(node, property, effectivePropertyType, declarationOrder, hasBqlField, attributeInfos, baseInfo)
-				: new DacPropertyInfo(node, property, effectivePropertyType, declarationOrder, hasBqlField, attributeInfos);
+				? new DacPropertyInfo(node, property, propertyTypeUnwrappedNullable, declarationOrder, hasBqlField, attributeInfos, baseInfo)
+				: new DacPropertyInfo(node, property, propertyTypeUnwrappedNullable, declarationOrder, hasBqlField, attributeInfos);
 		}
 
 		private static IEnumerable<DacFieldAttributeInfo> GetAttributeInfos(IPropertySymbol property, DbBoundnessCalculator dbBoundnessCalculator)

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/Dac/Utils/DacFieldsCollector.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/Dac/Utils/DacFieldsCollector.cs
@@ -28,10 +28,8 @@ namespace Acuminator.Utilities.Roslyn.Semantic.Dac
 			var propertiesByTypes = RegroupInfosByType<DacPropertyInfo, IPropertySymbol>(propertiesByNames.Values);
 
 			var typeHierarchy = dacType == DacType.Dac
-				? dacOrDacExtension.GetDacWithBaseTypesThatMayStoreDacProperties(pxContext)
+				? dacOrDacExtension.GetDacWithBaseTypesThatMayStoreDacProperties(pxContext).Reverse()
 				: dacOrDacExtension.GetDacExtensionWithBaseExtensions(pxContext, SortDirection.Ascending, includeDac: true);
-
-			typeHierarchy = typeHierarchy.Reverse();
 
 			foreach (var type in typeHierarchy)
 			{

--- a/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/Nodes/Dac/DacMembers/DacFieldGroupingNodeViewModel.cs
+++ b/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/Nodes/Dac/DacMembers/DacFieldGroupingNodeViewModel.cs
@@ -66,9 +66,9 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 
 		private IEnumerable<ExtraInfoViewModel> GetExtraInfos()
 		{
-			if (FieldInfo.EffectivePropertyType != null)
+			if (FieldInfo.PropertyTypeUnwrappedNullable != null)
 			{
-				yield return new TextViewModel(this, FieldInfo.EffectivePropertyType.GetSimplifiedName(),
+				yield return new TextViewModel(this, FieldInfo.PropertyTypeUnwrappedNullable.GetSimplifiedName(),
 												darkThemeForeground: Color.FromRgb(86, 156, 214),
 												lightThemeForeground: Color.FromRgb(0, 0, 255));
 			}

--- a/src/Samples/PX.Objects.HackathonDemo/PX.Objects.HackathonDemo/DAC/DAC with inconsistent Property and BQL field types/DerivedDacWithInconsistentTypes.cs
+++ b/src/Samples/PX.Objects.HackathonDemo/PX.Objects.HackathonDemo/DAC/DAC with inconsistent Property and BQL field types/DerivedDacWithInconsistentTypes.cs
@@ -1,0 +1,46 @@
+﻿using System;
+
+using PX.Data;
+using PX.Data.BQL;
+
+namespace PX.Analyzers.Test.Sources
+{
+	[PXHidden]
+	public class DerivedDac : Dac
+	{
+		#region LineNbr
+		[PXUIField]
+		public byte[] LineNbr { get; set; }
+
+		public abstract class lineNbr : Data.BQL.BqlInt.Field<lineNbr> { }
+		#endregion
+
+		#region OrderType
+		public abstract class orderType : BqlLong.Field<orderType> { }
+
+		[PXUIField]
+		public string OrderType { get; set; }
+		#endregion
+
+		// Acuminator disable once PX1067 MissingBqlFieldRedeclarationInDerivedDac [Justification]
+		[PXUIField]
+		public string NoteID { get; set; }
+
+		public new abstract class Tstamp : BqlByte.Field<Tstamp> { }
+	}
+
+	[PXHidden]
+	public class Dac : IBqlTable
+	{
+		#region NoteID
+		public abstract class noteID : PX.Data.BQL.BqlGuid.Field<noteID> { }
+		#endregion
+
+		#region tstamp
+		public abstract class Tstamp : IBqlField { }
+
+		[PXUIField]
+		public virtual byte[] tstamp { get; set; }
+		#endregion
+	}
+}

--- a/src/Samples/PX.Objects.HackathonDemo/PX.Objects.HackathonDemo/PX.Objects.HackathonDemo.csproj
+++ b/src/Samples/PX.Objects.HackathonDemo/PX.Objects.HackathonDemo/PX.Objects.HackathonDemo.csproj
@@ -69,6 +69,7 @@
     <Compile Include="Attributes\PXDBBaseCuryAttribute.cs" />
     <Compile Include="Attributes\FinPeriodIDAttribute.cs" />
     <Compile Include="Attributes\PXDBCurrencyAttribute.cs" />
+    <Compile Include="DAC\DAC with inconsistent Property and BQL field types\DerivedDacWithInconsistentTypes.cs" />
     <Compile Include="DAC\Documentation in DAC\ProjectionDAC_MappingWithInheritance_NoInheritdoc_AddInheritdoc.cs" />
     <Compile Include="DAC\Multiple field attributes, invalid aggregators and DAC field must be abstract\FeatureSet.cs" />
     <Compile Include="DAC\Property and attribute types mismatch and nullable types\SOOrder.cs" />


### PR DESCRIPTION
Implemented PX1068 diagnostic that checks DAC fields for mismatch between property and BQL field types.

 **Changes Overview**

**PX1068 Diagnostic**
- implemented PX1068 diagnostic
- implemented PX1068 code fix that will change BQL field type into a type consistent with a property type
- implemented PX1068 code fix that will change property type into a type consistent with a BQL field type
- added unit tests for PX1068 diagnostic and code fixes
- added documentation for PX1068

**DAC Semantic Model**
- enhanced unit tests for DAC semantic model collection from DACs and DAC extensions with checks for consistency between BQL field info and DAC field info
- extended DAC field info with information about BQL field data type
- renamed `EffectivePropertyType` into `PropertyTypeUnwrappedNullable` in DAC field info and BQL field info to avoid confusion with the semantic of Declared/Effective in overridable infos
- fixed bug in DAC fields collection from DAC extensions

**Common Utilities**
- updated and renamed mapping helper between property type and BQL field type
- added `NullIfLocationKindIsNone` extension method that will correctly handle possible "null-object" locations obtained from `SyntaxToken` tokens. Integrated changes. 
- minor refactorings