### PR TITLE
Feature/atr 602 dev add navigation into metadata and write it to journal

### DIFF
--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/Dac/Infos/DacOrDacExt/DacExtensionInfo.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/Dac/Infos/DacOrDacExt/DacExtensionInfo.cs
@@ -47,7 +47,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic.Dac
 			{
 				cancellation.ThrowIfCancellationRequested();
 
-				var baseDacExtNode = dacExtension.GetSyntax(cancellation) as ClassDeclarationSyntax;
+				var baseDacExtNode = baseExtensionType.GetSyntax(cancellation) as ClassDeclarationSyntax;
 
 				aggregatedBaseDacInfo = prevDacInfo != null
 					? new DacExtensionInfo(baseDacExtNode, baseExtensionType, dacInfo, declarationOrder: 1, prevDacInfo)

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/Dac/Infos/DacOrDacExt/DacInfo.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/Dac/Infos/DacOrDacExt/DacInfo.cs
@@ -42,7 +42,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic.Dac
 				cancellation.ThrowIfCancellationRequested();
 
 				var baseDacNode = isInSource
-					? dac.GetSyntax(cancellation) as ClassDeclarationSyntax
+					? baseType.GetSyntax(cancellation) as ClassDeclarationSyntax
 					: null;
 
 				isInSource = baseDacNode != null;

--- a/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/Base/TreeNodeViewModel.cs
+++ b/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/Base/TreeNodeViewModel.cs
@@ -175,8 +175,10 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 
 		public virtual Task NavigateToItemAsync() => Task.CompletedTask;
 
-		protected bool TryNavigateToItemWithVisualStudioWorkspace(ISymbol symbol, CancellationToken cancellation)
+		protected bool TryNavigateToItemWithVisualStudioWorkspace(ISymbol symbol)
 		{
+			CancellationToken cancellation = Tree.CodeMapViewModel.CancellationToken ?? AcuminatorVSPackage.Instance.DisposalToken;
+
 			if (Tree.CodeMapViewModel.Workspace is VisualStudioWorkspace workspace && Tree.CodeMapViewModel.Document?.Project is { } project)
 				return workspace.TryGoToDefinition(symbol, project, cancellation);
 

--- a/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/Base/TreeNodeViewModel.cs
+++ b/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/Base/TreeNodeViewModel.cs
@@ -6,12 +6,15 @@ using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Acuminator.Utilities.Common;
 using Acuminator.Vsix.ToolWindows.CodeMap.Filter;
 using Acuminator.Vsix.Utilities;
 
+using Microsoft.CodeAnalysis;
+using Microsoft.VisualStudio.LanguageServices;
 using Microsoft.VisualStudio.PlatformUI;
 
 namespace Acuminator.Vsix.ToolWindows.CodeMap
@@ -171,6 +174,14 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 		}
 
 		public virtual Task NavigateToItemAsync() => Task.CompletedTask;
+
+		protected bool TryNavigateToItemWithVisualStudioWorkspace(ISymbol symbol, CancellationToken cancellation)
+		{
+			if (Tree.CodeMapViewModel.Workspace is VisualStudioWorkspace workspace && Tree.CodeMapViewModel.Document?.Project is { } project)
+				return workspace.TryGoToDefinition(symbol, project, cancellation);
+
+			return false;
+		}
 
 		/// <summary>
 		/// Check if node is visible in filter going from the node to its descendants.

--- a/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/Nodes/Dac/Dac/Base/DacNodeViewModelBase.cs
+++ b/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/Nodes/Dac/Dac/Base/DacNodeViewModelBase.cs
@@ -3,20 +3,28 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using System.Windows.Media;
 
 using Acuminator.Utilities.Common;
+using Acuminator.Utilities.Roslyn.Semantic;
 using Acuminator.Utilities.Roslyn.Semantic.Attribute;
 using Acuminator.Utilities.Roslyn.Semantic.Dac;
 using Acuminator.Vsix.ToolWindows.CodeMap.Dac;
 using Acuminator.Vsix.ToolWindows.CodeMap.Filter;
 using Acuminator.Vsix.ToolWindows.Common;
+using Acuminator.Vsix.Utilities.Navigation;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Acuminator.Vsix.ToolWindows.CodeMap
 {
 	public abstract class DacNodeViewModelBase : TreeNodeViewModel, IElementWithTooltip
 	{
 		public override TreeNodeFilterBehavior FilterBehavior => TreeNodeFilterBehavior.DisplayedIfNodeOrChildrenMeetFilter;
+
+		public abstract DacOrDacExtInfoBase DacOrDacExtInfo { get; }
 
 		public DacNodeViewModelBase(TreeViewModel tree, TreeNodeViewModel? parent, bool isExpanded) : 
 							   base(tree, parent, isExpanded)
@@ -66,6 +74,40 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 			return dacAttributesGroupNode is IElementWithTooltip elementWithTooltip
 				? elementWithTooltip.CalculateTooltip()
 				: null;
+		}
+
+		public override Task NavigateToItemAsync()
+		{
+			if (TryNavigateToItemWithVisualStudioWorkspace(DacOrDacExtInfo.Symbol))
+				return Task.CompletedTask;
+
+			// Fallback to the old VS navigation
+			var references = DacOrDacExtInfo.Symbol.DeclaringSyntaxReferences;
+
+			if (references.IsDefaultOrEmpty)
+			{
+				Location? location = GetLocationForNavigation(DacOrDacExtInfo.Node);
+
+				return location?.NavigateToAsync() ?? Task.CompletedTask;
+			}
+			else
+				return DacOrDacExtInfo.Symbol.NavigateToAsync();
+		}
+
+		protected Location? GetLocationForNavigation(ClassDeclarationSyntax? dacNode)
+		{
+			if (dacNode != null)
+				return dacNode.Identifier.GetLocation().NullIfLocationKindIsNone() ?? dacNode.GetLocation();
+
+			if (Parent is not DacBaseTypesCategoryNodeViewModel baseTypesCategoryNodeViewModel ||
+				baseTypesCategoryNodeViewModel.Parent is not DacNodeViewModel dacNodeViewModel ||
+				dacNodeViewModel.DacModel.Node?.BaseList?.Types.Count is null or 0)
+			{
+				return null;
+			}
+
+			var baseType = dacNodeViewModel.DacModel.Node.BaseList.Types[0];
+			return baseType.GetLocation().NullIfLocationKindIsNone();
 		}
 	}
 }

--- a/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/Nodes/Dac/Dac/BaseDacPlaceholderNodeViewModel.cs
+++ b/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/Nodes/Dac/Dac/BaseDacPlaceholderNodeViewModel.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
 
 using Acuminator.Utilities.Common;
 using Acuminator.Utilities.Roslyn.Semantic;
@@ -11,7 +10,6 @@ using Acuminator.Utilities.Roslyn.Semantic.Dac;
 using Acuminator.Vsix.ToolWindows.CodeMap.Dac;
 using Acuminator.Vsix.ToolWindows.Common;
 using Acuminator.Vsix.Utilities;
-using Acuminator.Vsix.Utilities.Navigation;
 
 namespace Acuminator.Vsix.ToolWindows.CodeMap
 {
@@ -31,7 +29,7 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 			? Icon.Dac
 			: Icon.DacExtension;
 
-		public DacOrDacExtInfoBase DacOrDacExtInfo { get; }
+		public override DacOrDacExtInfoBase DacOrDacExtInfo { get; }
 
 		public bool IsDac => DacOrDacExtInfo is DacInfo;
 
@@ -52,23 +50,6 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 		{
 			var dacTypeInfo = CreateDacTypeInfo(IsDac);
 			return [dacTypeInfo];
-		}
-
-		public override Task NavigateToItemAsync()
-		{
-			var references = DacOrDacExtInfo.Symbol.DeclaringSyntaxReferences;
-
-			if (references.IsDefaultOrEmpty)
-			{
-				if (DacOrDacExtInfo.IsInMetadata)
-					return Task.CompletedTask;
-
-				var location = DacOrDacExtInfo.Node.Identifier.GetLocation().NullIfLocationKindIsNone() ??
-							   DacOrDacExtInfo.Node.GetLocation();
-				return location.NavigateToAsync();
-			}
-			else
-				return DacOrDacExtInfo.Symbol.NavigateToAsync();
 		}
 
 		public override TResult AcceptVisitor<TInput, TResult>(CodeMapTreeVisitor<TInput, TResult> treeVisitor, TInput input) =>

--- a/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/Nodes/Dac/Dac/DacNodeViewModel.cs
+++ b/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/Nodes/Dac/Dac/DacNodeViewModel.cs
@@ -3,14 +3,12 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
 
 using Acuminator.Utilities.Common;
 using Acuminator.Utilities.Roslyn.Semantic.Dac;
 using Acuminator.Vsix.ToolWindows.CodeMap.Dac;
 using Acuminator.Vsix.ToolWindows.Common;
 using Acuminator.Vsix.Utilities;
-using Acuminator.Vsix.Utilities.Navigation;
 
 namespace Acuminator.Vsix.ToolWindows.CodeMap
 {
@@ -32,14 +30,14 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 
 		public override ExtendedObservableCollection<ExtraInfoViewModel> ExtraInfos { get; }
 
+		public override DacOrDacExtInfoBase DacOrDacExtInfo => DacModel.DacOrDacExtInfo;
+
 		public DacNodeViewModel(DacSemanticModelForCodeMap dacModel, TreeViewModel tree, TreeNodeViewModel? parent, bool isExpanded) : 
 						   base(tree, parent, isExpanded)
 		{
 			DacModelForCodeMap = dacModel.CheckIfNull();
 			ExtraInfos		   = new ExtendedObservableCollection<ExtraInfoViewModel>(GetDacExtraInfos(DacModelForCodeMap));
 		}
-
-		public override Task NavigateToItemAsync() => DacModelForCodeMap.Symbol.NavigateToAsync();
 
 		public override TResult AcceptVisitor<TInput, TResult>(CodeMapTreeVisitor<TInput, TResult> treeVisitor, TInput input) => 
 			treeVisitor.VisitNode(this, input);

--- a/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/Nodes/Dac/DacMembers/Base/DacMemberNodeViewModel.cs
+++ b/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/Nodes/Dac/DacMembers/Base/DacMemberNodeViewModel.cs
@@ -43,6 +43,9 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 			MemberCategory = dacMemberCategoryVM!;
 		}
 
-		public override Task NavigateToItemAsync() => MemberSymbol.NavigateToAsync();
+		public override Task NavigateToItemAsync() =>
+			TryNavigateToItemWithVisualStudioWorkspace(MemberSymbol)
+				? Task.CompletedTask
+				: MemberSymbol.NavigateToAsync();
 	}
 }

--- a/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/Nodes/Graph/GraphMemberInfos/GraphMemberInfoNodeViewModel.cs
+++ b/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/Nodes/Graph/GraphMemberInfos/GraphMemberInfoNodeViewModel.cs
@@ -48,7 +48,10 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 			GraphMemberInfoType = graphMemberInfoType;
 		}
 
-		public override Task NavigateToItemAsync() => GraphMemberInfoSymbol.NavigateToAsync();
+		public override Task NavigateToItemAsync() =>
+			TryNavigateToItemWithVisualStudioWorkspace(GraphMemberInfoSymbol)
+				? Task.CompletedTask
+				: GraphMemberInfoSymbol.NavigateToAsync();
 
 		private static Icon GetIconType(GraphMemberInfoType graphMemberInfoType) =>
 			graphMemberInfoType switch

--- a/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/Nodes/Graph/GraphMembers/Base/GraphMemberNodeViewModel.cs
+++ b/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/Nodes/Graph/GraphMembers/Base/GraphMemberNodeViewModel.cs
@@ -42,6 +42,9 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 			MemberCategory = graphMemberCategoryVM!;
 		}
 
-		public override Task NavigateToItemAsync() => MemberSymbol.NavigateToAsync();
+		public override Task NavigateToItemAsync() =>
+			TryNavigateToItemWithVisualStudioWorkspace(MemberSymbol)
+				? Task.CompletedTask
+				: MemberSymbol.NavigateToAsync();
 	}
 }

--- a/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/Nodes/Graph/GraphNodeViewModel.cs
+++ b/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/Nodes/Graph/GraphNodeViewModel.cs
@@ -63,7 +63,7 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 
 		public override Task NavigateToItemAsync()
 		{
-			if (GraphSemanticModel.IsInMetadata)
+			if (TryNavigateToItemWithVisualStudioWorkspace(GraphSemanticModel.Symbol) || GraphSemanticModel.IsInMetadata)
 				return Task.CompletedTask;
 
 			var syntaxReferences = GraphSemanticModel.Symbol.DeclaringSyntaxReferences;


### PR DESCRIPTION
Implemented navigation into metadata / decompiled sources and integration with VS navigation journal for Code Map and "Go To Action/View Handler/Delegate" command.

**Changes Overview**

**Code Map**
- Integrated navigation through VS workspace to drill down in metadata / decompiled sources and add entries into the VS navigation journal

**Go To Action/View Handler/Delegate**
- Integrated navigation through VS workspace to drill down in metadata / decompiled sources and add entries into the VS navigation journal

**Semantic Model**
- Fixed copy paste bug in the DAC / DAC extension info collection that caused incorrect collection of nodes for base infos