### PR TITLE
Bugfix/atr 833 dev support bql attributes in px1068

### DIFF
--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/LegacyBqlConstant/LegacyBqlConstantAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/LegacyBqlConstant/LegacyBqlConstantAnalyzer.cs
@@ -73,14 +73,19 @@ namespace Acuminator.Analyzers.StaticAnalysis.LegacyBqlConstant
 				.FirstOrDefault(t => t.IsGenericType && t.InheritsFromOrEqualsGeneric(pxContext.BqlConstantType!))?
 				.TypeArguments[0];
 
-			if (constantUnderlyingType == null || constantUnderlyingType.Name.IsNullOrWhiteSpace())
+			if (constantUnderlyingType == null)
 				return false;
 
-			var constantDataTypeName = new DataTypeName(constantUnderlyingType.Name);
+			var constantUnderlyingTypeSimpleName = constantUnderlyingType.GetSimplifiedName();
+
+			if (constantUnderlyingTypeSimpleName.IsNullOrWhiteSpace())
+				return false;
+
+			var constantDataTypeName = new DataTypeName(constantUnderlyingTypeSimpleName);
 
 			if (DataTypeToBqlFieldTypeMapping.ContainsDataType(constantDataTypeName))
 			{
-				constantType = constantUnderlyingType.Name;
+				constantType = constantDataTypeName.Value;
 				return true;
 			}
 

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/LegacyBqlConstant/LegacyBqlConstantAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/LegacyBqlConstant/LegacyBqlConstantAnalyzer.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Immutable;
+﻿using System;
+using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
@@ -73,17 +74,13 @@ namespace Acuminator.Analyzers.StaticAnalysis.LegacyBqlConstant
 				.FirstOrDefault(t => t.IsGenericType && t.InheritsFromOrEqualsGeneric(pxContext.BqlConstantType!))?
 				.TypeArguments[0];
 
-			if (constantUnderlyingType == null)
+			if (constantUnderlyingType == null || constantUnderlyingType is IArrayTypeSymbol || constantUnderlyingType.Name.IsNullOrWhiteSpace())
 				return false;
 
-			var constantUnderlyingTypeSimpleName = constantUnderlyingType.GetSimplifiedName();
+			var constantDataTypeName = new DataTypeName(constantUnderlyingType.Name);
+			var constantBqlFieldType = DataTypeToBqlFieldTypeMapping.GetBqlFieldType(constantDataTypeName);
 
-			if (constantUnderlyingTypeSimpleName.IsNullOrWhiteSpace())
-				return false;
-
-			var constantDataTypeName = new DataTypeName(constantUnderlyingTypeSimpleName);
-
-			if (DataTypeToBqlFieldTypeMapping.ContainsDataType(constantDataTypeName))
+			if (constantBqlFieldType != null)
 			{
 				constantType = constantDataTypeName.Value;
 				return true;

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/LegacyBqlField/LegacyBqlFieldAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/LegacyBqlField/LegacyBqlFieldAnalyzer.cs
@@ -17,8 +17,6 @@ namespace Acuminator.Analyzers.StaticAnalysis.LegacyBqlField
 {
 	public class LegacyBqlFieldAnalyzer : DacAggregatedAnalyzerBase
 	{
-		private const string StringArray = "string[]";
-
 		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Descriptors.PX1060_LegacyBqlField);
 
 		public override bool ShouldAnalyze(PXContext pxContext, DacSemanticModel dac) =>
@@ -49,7 +47,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.LegacyBqlField
 					continue;
 
 				// Is field type is string array, then show diagnostic warning only for the Attributes field
-				if (propertyDataTypeName.Value.Equals(StringArray, StringComparison.OrdinalIgnoreCase) &&
+				if (propertyDataTypeName.Value.Equals(TypeNames.StringArray, StringComparison.OrdinalIgnoreCase) &&
 					!property.Name.Equals(DacFieldNames.System.Attributes, StringComparison.OrdinalIgnoreCase))
 				{
 					continue;

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/LegacyBqlField/LegacyBqlFieldAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/LegacyBqlField/LegacyBqlFieldAnalyzer.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 
@@ -16,6 +17,8 @@ namespace Acuminator.Analyzers.StaticAnalysis.LegacyBqlField
 {
 	public class LegacyBqlFieldAnalyzer : DacAggregatedAnalyzerBase
 	{
+		private const string StringArray = "string[]";
+
 		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Descriptors.PX1060_LegacyBqlField);
 
 		public override bool ShouldAnalyze(PXContext pxContext, DacSemanticModel dac) =>
@@ -44,6 +47,13 @@ namespace Acuminator.Analyzers.StaticAnalysis.LegacyBqlField
 
 				if (!DataTypeToBqlFieldTypeMapping.ContainsDataType(propertyDataTypeName))
 					continue;
+
+				// Is field type is string array, then show diagnostic warning only for the Attributes field
+				if (propertyDataTypeName.Value.Equals(StringArray, StringComparison.OrdinalIgnoreCase) &&
+					!property.Name.Equals(DacFieldNames.System.Attributes, StringComparison.OrdinalIgnoreCase))
+				{
+					continue;
+				}
 
 				var args = ImmutableDictionary.CreateBuilder<string, string?>();
 				args.Add(DiagnosticProperty.PropertyType, propertyTypeName);

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PropertyAndBqlFieldTypesMismatch/PropertyAndBqlFieldTypesMismatchFix.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PropertyAndBqlFieldTypesMismatch/PropertyAndBqlFieldTypesMismatchFix.cs
@@ -201,7 +201,9 @@ namespace Acuminator.Analyzers.StaticAnalysis.PropertyAndBqlFieldTypesMismatch
 															 string newBqlFieldTypeName, string bqlFieldName,
 															 CancellationToken cancellation)
 		{
-			if (nodeWithDiagnostic is not IdentifierNameSyntax bqlFieldTypeNode || !IsBqlFieldTypeNode(bqlFieldTypeNode))
+			bool isAttributesField = bqlFieldName.Equals(DacFieldNames.System.Attributes, StringComparison.OrdinalIgnoreCase);
+
+			if (nodeWithDiagnostic is not IdentifierNameSyntax bqlFieldTypeNode || !IsBqlFieldTypeNode(bqlFieldTypeNode) || isAttributesField)
 			{
 				return ChangeEntireBqlFieldTypeAsync(document, root, nodeWithDiagnostic, newBqlFieldTypeName,
 													 bqlFieldName, cancellation);

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PropertyAndBqlFieldTypesMismatch/PropertyAndBqlFieldTypesMismatchFix.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PropertyAndBqlFieldTypesMismatch/PropertyAndBqlFieldTypesMismatchFix.cs
@@ -116,6 +116,10 @@ namespace Acuminator.Analyzers.StaticAnalysis.PropertyAndBqlFieldTypesMismatch
 			cancellation.ThrowIfCancellationRequested();
 
 			var newPropertyType = CreateDataTypeNode(newPropertyDataTypeName, makePropertyTypeNullable);
+
+			if (newPropertyType == null)
+				return Task.FromResult(document);
+
 			var newPropertyNode = propertyNode.WithType(newPropertyType);
 			var newRoot			= root.ReplaceNode(propertyNode, newPropertyNode);
 
@@ -125,13 +129,17 @@ namespace Acuminator.Analyzers.StaticAnalysis.PropertyAndBqlFieldTypesMismatch
 			return Task.FromResult(newDocument);
 		}
 
-		private TypeSyntax CreateDataTypeNode(string dataTypeName, bool makePropertyTypeNullable)
-		{			
-			int indexOfOpeningSquareBracket = dataTypeName.LastIndexOf('[');
-			bool isArrayType = indexOfOpeningSquareBracket >= 0;
-
+		private TypeSyntax? CreateDataTypeNode(string dataTypeName, bool makePropertyTypeNullable)
+		{
+			bool isArrayType = dataTypeName[^1] == ']';
+			
 			if (isArrayType)
 			{
+				int indexOfOpeningSquareBracket = dataTypeName.LastIndexOf('[');
+
+				if (indexOfOpeningSquareBracket < 0)
+					return null;
+
 				var elementTypeName	   = dataTypeName[..indexOfOpeningSquareBracket].Trim();
 				var predefinedTypeKind = GetPredefinedTypeKind(elementTypeName);
 

--- a/src/Acuminator/Acuminator.Tests/Acuminator.Tests.csproj
+++ b/src/Acuminator/Acuminator.Tests/Acuminator.Tests.csproj
@@ -673,6 +673,7 @@
     <EmbeddedResource Include="Tests\Utilities\SemanticModels\Dac\Sources\DacWithBaseTypeNonDac.cs" />
     <EmbeddedResource Include="Tests\Utilities\SemanticModels\Dac\Sources\DacExtensionWithBaseTypeNonDac.cs" />
     <EmbeddedResource Include="Tests\Utilities\SemanticModels\Dac\Sources\DacChainedExtensionWithBaseTypeNonDac.cs" />
+    <Compile Include="Tests\Utilities\DataTypeToBqlFieldTypeMapping\DataTypeNameTests.cs" />
     <Compile Include="Tests\Utilities\SemanticModels\RoslynTestContext.cs" />
     <Compile Include="Tests\Utilities\SemanticModels\SemanticModelTestsBase.cs" />
     <Compile Include="Tests\Utilities\SemanticModels\Dac\DacSemanticModelTests.cs" />

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/LegacyBqlField/LegacyBqlFieldTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/LegacyBqlField/LegacyBqlFieldTests.cs
@@ -37,7 +37,8 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.LegacyBqlField
 				Descriptors.PX1060_LegacyBqlField.CreateFor(44, 25, "legacyStringField"),
 				Descriptors.PX1060_LegacyBqlField.CreateFor(48, 25, "legacyDateField"),
 				Descriptors.PX1060_LegacyBqlField.CreateFor(52, 25, "legacyGuidField"),
-				Descriptors.PX1060_LegacyBqlField.CreateFor(56, 25, "legacyBinaryField"));
+				Descriptors.PX1060_LegacyBqlField.CreateFor(56, 25, "legacyBinaryField"),
+				Descriptors.PX1060_LegacyBqlField.CreateFor(60, 25, "attributes"));
 
 		[Theory]
 		[EmbeddedFileData("LegacyBqlFieldBad.cs", "LegacyBqlFieldBad_Expected.cs")]

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/LegacyBqlField/Sources/LegacyBqlFieldBad.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/LegacyBqlField/Sources/LegacyBqlFieldBad.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using PX.Data;
+using PX.Objects.CR;
 
 namespace PX.Analyzers.Test.Sources
 {
@@ -56,5 +56,9 @@ namespace PX.Analyzers.Test.Sources
 		public abstract class legacyBinaryField : IBqlField { }
 		[PXDBBinary]
 		public byte[] LegacyBinaryField { get; set; }
+
+		public abstract class attributes : IBqlField { }
+		[CRAttributesField(typeof(CRQuote.opportunityClassID))]
+		public virtual string[] Attributes { get; set; }
 	}
 }

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/LegacyBqlField/Sources/LegacyBqlFieldBad_Expected.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/LegacyBqlField/Sources/LegacyBqlFieldBad_Expected.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using PX.Data;
+using PX.Objects.CR;
 
 namespace PX.Analyzers.Test.Sources
 {
@@ -56,5 +56,9 @@ namespace PX.Analyzers.Test.Sources
 		public abstract class legacyBinaryField : PX.Data.BQL.BqlByteArray.Field<legacyBinaryField> { }
 		[PXDBBinary]
 		public byte[] LegacyBinaryField { get; set; }
+
+		public abstract class attributes : PX.Objects.CR.BqlAttributes.Field<attributes> { }
+		[CRAttributesField(typeof(CRQuote.opportunityClassID))]
+		public virtual string[] Attributes { get; set; }
 	}
 }

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/LegacyBqlField/Sources/LegacyBqlFieldGood.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/LegacyBqlField/Sources/LegacyBqlFieldGood.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using PX.Data;
+using PX.Objects.CR;
 
 namespace PX.Analyzers.Test.Sources
 {
@@ -57,8 +58,13 @@ namespace PX.Analyzers.Test.Sources
 		[PXDBBinary]
 		public byte[] ModernBinaryField { get; set; }
 
+		public abstract class attributes : BqlAttributes.Field<attributes> { }
+
+		[CRAttributesField(typeof(CRQuote.opportunityClassID))]
+		public virtual string[] Attributes { get; set; }
+
 		public abstract class unsupportedField1 : IBqlField { }
-		public uint UnsupportedField1 { get; set; }
+		public uint? UnsupportedField1 { get; set; }
 
 		public abstract class unsupportedField2 : IBqlField { }
 		public uint[] UnsupportedField2 { get; set; }

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/NoBqlFieldForDacFieldProperty/NoBqlFieldForDacFieldPropertyTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/NoBqlFieldForDacFieldProperty/NoBqlFieldForDacFieldPropertyTests.cs
@@ -41,7 +41,8 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.NoBqlFieldForDacFieldProperty
 			Descriptors.PX1065_NoBqlFieldForDacFieldProperty.CreateFor(70, 20, "DateField"),
 			Descriptors.PX1065_NoBqlFieldForDacFieldProperty.CreateFor(74, 16, "GuidField"),
 			Descriptors.PX1065_NoBqlFieldForDacFieldProperty.CreateFor(77, 17, "BinaryField"),
-			Descriptors.PX1065_NoBqlFieldForDacFieldProperty.CreateFor(81, 17, "BinaryField2"));
+			Descriptors.PX1065_NoBqlFieldForDacFieldProperty.CreateFor(81, 17, "BinaryField2"),
+			Descriptors.PX1065_NoBqlFieldForDacFieldProperty.CreateFor(88, 27, "Attributes"));
 
 		[Theory]
 		[EmbeddedFileData(@"MissingBqlField\DacWithBqlFieldMissingInBaseDac.cs")]

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/NoBqlFieldForDacFieldProperty/Sources/MissingBqlField/DacWithoutBqlFields.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/NoBqlFieldForDacFieldProperty/Sources/MissingBqlField/DacWithoutBqlFields.cs
@@ -83,5 +83,8 @@ namespace PX.Analyzers.Test.Sources
 
 		[System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
 		public bool HasGuidField => GuidField != null;
+
+		[PXUIField]
+		public virtual string[] Attributes { get; set; }
 	}
 }

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/NoBqlFieldForDacFieldProperty/Sources/MissingBqlField/DacWithoutBqlFields_Expected.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/NoBqlFieldForDacFieldProperty/Sources/MissingBqlField/DacWithoutBqlFields_Expected.cs
@@ -121,5 +121,10 @@ namespace PX.Analyzers.Test.Sources
 
 		[System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
 		public bool HasGuidField => GuidField != null;
+
+		public abstract class attributes : PX.Objects.CR.BqlAttributes.Field<attributes> { }
+
+		[PXUIField]
+		public virtual string[] Attributes { get; set; }
 	}
 }

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PropertyAndBqlFieldTypesMismatch/PropertyAndBqlFieldTypesMismatchTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PropertyAndBqlFieldTypesMismatch/PropertyAndBqlFieldTypesMismatchTests.cs
@@ -33,7 +33,8 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.PropertyAndBqlFieldTypesMismatch
 				Descriptors.PX1068_PropertyAndBqlFieldTypesMismatch.CreateFor(12, 46),
 				Descriptors.PX1068_PropertyAndBqlFieldTypesMismatch.CreateFor(15, 10),
 				Descriptors.PX1068_PropertyAndBqlFieldTypesMismatch.CreateFor(19, 34),
-				Descriptors.PX1068_PropertyAndBqlFieldTypesMismatch.CreateFor(22, 18));
+				Descriptors.PX1068_PropertyAndBqlFieldTypesMismatch.CreateFor(22, 18),
+				Descriptors.PX1068_PropertyAndBqlFieldTypesMismatch.CreateFor(33, 38));
 
 		[Theory]
 		[EmbeddedFileData("DacWithInconsistentTypes_BqlFieldFirst.cs", "DacWithInconsistentTypes_BqlFieldFirst_Expected.cs")]
@@ -56,7 +57,8 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.PropertyAndBqlFieldTypesMismatch
 				Descriptors.PX1068_PropertyAndBqlFieldTypesMismatch.CreateFor(20, 18),
 				Descriptors.PX1068_PropertyAndBqlFieldTypesMismatch.CreateFor(22, 34),
 				Descriptors.PX1068_PropertyAndBqlFieldTypesMismatch.CreateFor(27, 18),
-				Descriptors.PX1068_PropertyAndBqlFieldTypesMismatch.CreateFor(29, 46));
+				Descriptors.PX1068_PropertyAndBqlFieldTypesMismatch.CreateFor(29, 46),
+				Descriptors.PX1068_PropertyAndBqlFieldTypesMismatch.CreateFor(41, 18));
 
 		[Theory]
 		[EmbeddedFileData("DacWithInconsistentTypes_PropertyFirst.cs", "DacWithInconsistentTypes_PropertyFirst_Expected.cs")]

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PropertyAndBqlFieldTypesMismatch/Sources/DacWithInconsistentTypes_BqlFieldFirst.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PropertyAndBqlFieldTypesMismatch/Sources/DacWithInconsistentTypes_BqlFieldFirst.cs
@@ -29,6 +29,13 @@ namespace PX.Analyzers.Test.Sources
 		public virtual int? ShipmentNbr { get; set; }
 		#endregion
 
+		#region Attributes
+		public abstract class attributes : BqlByteArray.Field<attributes> { }
+
+		[PXUIField]
+		public virtual string[] Attributes { get; set; }
+		#endregion
+
 		[System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
 		public bool HasNoteID => NoteID != null;
 	}

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PropertyAndBqlFieldTypesMismatch/Sources/DacWithInconsistentTypes_BqlFieldFirst_Expected.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PropertyAndBqlFieldTypesMismatch/Sources/DacWithInconsistentTypes_BqlFieldFirst_Expected.cs
@@ -29,6 +29,13 @@ namespace PX.Analyzers.Test.Sources
 		public virtual int? ShipmentNbr { get; set; }
 		#endregion
 
+		#region Attributes
+		public abstract class attributes : PX.Objects.CR.BqlAttributes.Field<attributes> { }
+
+		[PXUIField]
+		public virtual string[] Attributes { get; set; }
+		#endregion
+
 		[System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
 		public bool HasNoteID => NoteID != null;
 	}

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PropertyAndBqlFieldTypesMismatch/Sources/DacWithInconsistentTypes_PropertyFirst.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PropertyAndBqlFieldTypesMismatch/Sources/DacWithInconsistentTypes_PropertyFirst.cs
@@ -36,6 +36,13 @@ namespace PX.Analyzers.Test.Sources
 		public virtual int? ShipmentNbr { get; set; }
 		#endregion
 
+		#region Attributes
+		[PXUIField]
+		public virtual byte[] Attributes { get; set; }
+
+		public abstract class attributes : PX.Objects.CR.BqlAttributes.Field<attributes> { }
+		#endregion
+
 		[System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
 		public bool HasNoteID => NoteID != null;
 	}

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PropertyAndBqlFieldTypesMismatch/Sources/DacWithInconsistentTypes_PropertyFirst_Expected.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PropertyAndBqlFieldTypesMismatch/Sources/DacWithInconsistentTypes_PropertyFirst_Expected.cs
@@ -36,6 +36,13 @@ namespace PX.Analyzers.Test.Sources
 		public virtual int? ShipmentNbr { get; set; }
 		#endregion
 
+		#region Attributes
+		[PXUIField]
+		public virtual string[] Attributes { get; set; }
+
+		public abstract class attributes : PX.Objects.CR.BqlAttributes.Field<attributes> { }
+		#endregion
+
 		[System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
 		public bool HasNoteID => NoteID != null;
 	}

--- a/src/Acuminator/Acuminator.Tests/Tests/Utilities/DataTypeToBqlFieldTypeMapping/DataTypeNameTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/Utilities/DataTypeToBqlFieldTypeMapping/DataTypeNameTests.cs
@@ -1,0 +1,28 @@
+﻿#nullable enable
+
+using System;
+
+using Acuminator.Utilities.Roslyn;
+
+using Xunit;
+
+using FluentAssertions;
+
+namespace Acuminator.Tests.Tests.Utilities.DataTypeToBqlFieldTypeMapping
+{
+	public class DataTypeNameTests 
+	{
+		[Theory]
+		[InlineData("string", "string")]
+		[InlineData("Byte", "Byte")]
+		[InlineData("string[]", "string[]")]
+		[InlineData("string   []", "string[]")]
+		[InlineData("int[   ]", "int[]")]
+		[InlineData("byte   [         ]", "byte[]")]
+		public void DataTypeNamesCreation(string inputDataType, string expectedDataType)
+		{
+			var dataTypeName = new DataTypeName(inputDataType);
+			dataTypeName.Value.Should().Be(expectedDataType);
+		}
+	}
+}

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/CodeGeneration/BqlFieldGeneration.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/CodeGeneration/BqlFieldGeneration.cs
@@ -90,16 +90,34 @@ namespace Acuminator.Utilities.Roslyn.CodeGeneration
 						.WithGreaterThanToken(
 							Token(leading: TriviaList(), SyntaxKind.GreaterThanToken, TriviaList(Space))));
 
+			bool isAttributesBqlField = bqlFieldName.Equals(DacFieldNames.System.Attributes, StringComparison.OrdinalIgnoreCase); 
+			QualifiedNameSyntax bqlFieldNamespaceName;
+
+			if (isAttributesBqlField)
+			{
+				bqlFieldNamespaceName =
+					QualifiedName(
+						QualifiedName(
+							IdentifierName("PX"),
+							IdentifierName("Objects")),
+							IdentifierName("CR"));
+			}
+			else
+			{
+				bqlFieldNamespaceName =
+					QualifiedName(
+						QualifiedName(
+							IdentifierName("PX"),
+							IdentifierName("Data")),
+							IdentifierName("BQL"));
+			}
+
 			var newBaseType =
 				SimpleBaseType(
 					QualifiedName(
 						QualifiedName(
-							QualifiedName(
-								QualifiedName(
-									IdentifierName("PX"),
-									IdentifierName("Data")),
-									IdentifierName("BQL")),
-									IdentifierName(bqlFieldTypeName)),
+							bqlFieldNamespaceName,
+							IdentifierName(bqlFieldTypeName)),
 						fieldTypeNode));
 
 			return newBaseType;

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/CodeGeneration/BqlFieldGeneration.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/CodeGeneration/BqlFieldGeneration.cs
@@ -90,7 +90,8 @@ namespace Acuminator.Utilities.Roslyn.CodeGeneration
 						.WithGreaterThanToken(
 							Token(leading: TriviaList(), SyntaxKind.GreaterThanToken, TriviaList(Space))));
 
-			bool isAttributesBqlField = bqlFieldName.Equals(DacFieldNames.System.Attributes, StringComparison.OrdinalIgnoreCase); 
+			bool isAttributesBqlField = bqlFieldName.Equals(DacFieldNames.System.Attributes, StringComparison.OrdinalIgnoreCase) &&
+										bqlFieldTypeName.Equals(TypeNames.BqlField.BqlAttributes, StringComparison.OrdinalIgnoreCase); 
 			QualifiedNameSyntax bqlFieldNamespaceName;
 
 			if (isAttributesBqlField)

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Constants/DataTypeToBqlFieldTypeMapping.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Constants/DataTypeToBqlFieldTypeMapping.cs
@@ -34,24 +34,28 @@ namespace Acuminator.Utilities.Roslyn.Constants
 			{ nameof(Double) , "BqlDouble" },
 			{ nameof(Decimal), "BqlDecimal" },
 
-			{ $"{nameof(Byte)}[]", "BqlByteArray" },
-			{ "ByteArray"		 , "BqlByteArray" }
+			{ "byte[]"   , "BqlByteArray" },
+			{ "ByteArray", "BqlByteArray" },
+
+			{ "string[]"   , "BqlAttributes" },
+			{ "StringArray", "BqlAttributes" }
 		};
 
 		private static readonly Dictionary<string, string> _bqlFieldTypeToDataType = new(StringComparer.OrdinalIgnoreCase)
 		{
-			{ "BqlString"	 , nameof(String) 	   },
-			{ "BqlGuid"		 , nameof(Guid) 	   },
-			{ "BqlDateTime"	 , nameof(DateTime)	   },
-			{ "BqlBool"		 , nameof(Boolean) 	   },
-			{ "BqlByte" 	 , nameof(Byte) 	   },
-			{ "BqlShort"	 , nameof(Int16)	   },
-			{ "BqlInt"		 , nameof(Int32) 	   },
-			{ "BqlLong"		 , nameof(Int64) 	   },
-			{ "BqlFloat"	 , nameof(Single) 	   },
-			{ "BqlDouble" 	 , nameof(Double)	   },
-			{ "BqlDecimal" 	 , nameof(Decimal) 	   },
-			{ "BqlByteArray" , $"{nameof(Byte)}[]" },
+			{ "BqlString"	 , nameof(String)  },
+			{ "BqlGuid" 	 , nameof(Guid)    },
+			{ "BqlDateTime"	 , nameof(DateTime)},
+			{ "BqlBool"		 , nameof(Boolean) },
+			{ "BqlByte"		 , nameof(Byte)    },
+			{ "BqlShort"	 , nameof(Int16)   },
+			{ "BqlInt"		 , nameof(Int32)   },
+			{ "BqlLong"		 , nameof(Int64)   },
+			{ "BqlFloat"	 , nameof(Single)  },
+			{ "BqlDouble"	 , nameof(Double)  },
+			{ "BqlDecimal"	 , nameof(Decimal) },
+			{ "BqlByteArray" , $"byte[]" 	   },
+			{ "BqlAttributes", $"string[]" 	   }
 		};
 
 		public static bool ContainsDataType(DataTypeName dataType) =>

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Constants/DataTypeToBqlFieldTypeMapping.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Constants/DataTypeToBqlFieldTypeMapping.cs
@@ -37,8 +37,8 @@ namespace Acuminator.Utilities.Roslyn.Constants
 			{ "byte[]"   , "BqlByteArray" },
 			{ "ByteArray", "BqlByteArray" },
 
-			{ "string[]"   , "BqlAttributes" },
-			{ "StringArray", "BqlAttributes" }
+			{ "string[]"   , TypeNames.BqlField.BqlAttributes },
+			{ "StringArray", TypeNames.BqlField.BqlAttributes }
 		};
 
 		private static readonly Dictionary<string, string> _bqlFieldTypeToDataType = new(StringComparer.OrdinalIgnoreCase)
@@ -55,7 +55,8 @@ namespace Acuminator.Utilities.Roslyn.Constants
 			{ "BqlDouble"	 , nameof(Double)  },
 			{ "BqlDecimal"	 , nameof(Decimal) },
 			{ "BqlByteArray" , $"byte[]" 	   },
-			{ "BqlAttributes", $"string[]" 	   }
+
+			{ TypeNames.BqlField.BqlAttributes, $"string[]" }
 		};
 
 		public static bool ContainsDataType(DataTypeName dataType) =>

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Constants/TypeFullNames.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Constants/TypeFullNames.cs
@@ -111,6 +111,7 @@
 		internal const string IBqlDoubleType = "PX.Data.BQL.IBqlDouble";
 		internal const string IBqlDecimalType = "PX.Data.BQL.IBqlDecimal";
 		internal const string IBqlByteArrayType = "PX.Data.BQL.IBqlByteArray";
+		internal const string IBqlAttributes = "PX.Objects.CR.IBqlAttributes";
 
 		internal const string CustomPredicate = "PX.Data.CustomPredicate";
 		internal const string AreSame2 = "PX.Data.AreSame`2";

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Constants/TypeNames.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Constants/TypeNames.cs
@@ -105,6 +105,8 @@ namespace Acuminator.Utilities.Roslyn.Constants
 				StringComparer.OrdinalIgnoreCase);
 		}
 
+		public const string StringArray = "string[]";
+
 		public const string PXView = "PXView";
 
 		public const string PXAdapter = "PXAdapter";

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Constants/TypeNames.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Constants/TypeNames.cs
@@ -50,6 +50,8 @@ namespace Acuminator.Utilities.Roslyn.Constants
 			public const string IBqlField = "IBqlField";
 			public const string Field	  = "Field";
 			public const string BqlType   = "BqlType";
+
+			public const string BqlAttributes = "BqlAttributes";
 		}
 
 		/// <summary>

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/DataTypeName.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/DataTypeName.cs
@@ -1,13 +1,38 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+
 using Acuminator.Utilities.Common;
 
 namespace Acuminator.Utilities.Roslyn;
 
 public readonly record struct DataTypeName(string Value)
 {
-	public string Value { get; } = Value.CheckIfNullOrWhiteSpace();
+	public string Value { get; } = RemoveEmptySpacesInArrayTypeNames(Value);
 
 	public override string ToString() => Value;
+
+	private static string RemoveEmptySpacesInArrayTypeNames(string dataTypeName)
+	{
+		dataTypeName.ThrowOnNullOrWhiteSpace();
+
+		bool isArrayTypeName = dataTypeName[^1] == ']';
+
+		if (!isArrayTypeName)
+			return dataTypeName;
+		else if (dataTypeName.Length <= 2)
+			throw new ArgumentException($"Invalid data type name \"{dataTypeName}\"", nameof(dataTypeName));
+
+		// if there is no empty spaces in array, return the original string
+		if (dataTypeName[^2] == '[' && !char.IsWhiteSpace(dataTypeName[^3]))
+			return dataTypeName;
+
+		int indexOfOpeningSquareBracket = dataTypeName.LastIndexOf('[');
+
+		if (indexOfOpeningSquareBracket < 0)
+			throw new ArgumentException($"Invalid data type name \"{dataTypeName}\"", nameof(dataTypeName));
+
+		var elementTypeName = dataTypeName[..indexOfOpeningSquareBracket].Trim();
+		return $"{elementTypeName}[]";
+	}
 }

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/DataTypeName.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/DataTypeName.cs
@@ -1,38 +1,12 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 
-using Acuminator.Utilities.Common;
+using Acuminator.Utilities.Roslyn.Semantic;
 
 namespace Acuminator.Utilities.Roslyn;
 
 public readonly record struct DataTypeName(string Value)
 {
-	public string Value { get; } = RemoveEmptySpacesInArrayTypeNames(Value);
+	public string Value { get; } = Value.RemoveEmptySpacesInArrayTypeNames();
 
 	public override string ToString() => Value;
-
-	private static string RemoveEmptySpacesInArrayTypeNames(string dataTypeName)
-	{
-		dataTypeName.ThrowOnNullOrWhiteSpace();
-
-		bool isArrayTypeName = dataTypeName[^1] == ']';
-
-		if (!isArrayTypeName)
-			return dataTypeName;
-		else if (dataTypeName.Length <= 2)
-			throw new ArgumentException($"Invalid data type name \"{dataTypeName}\"", nameof(dataTypeName));
-
-		// if there is no empty spaces in array, return the original string
-		if (dataTypeName[^2] == '[' && !char.IsWhiteSpace(dataTypeName[^3]))
-			return dataTypeName;
-
-		int indexOfOpeningSquareBracket = dataTypeName.LastIndexOf('[');
-
-		if (indexOfOpeningSquareBracket < 0)
-			throw new ArgumentException($"Invalid data type name \"{dataTypeName}\"", nameof(dataTypeName));
-
-		var elementTypeName = dataTypeName[..indexOfOpeningSquareBracket].Trim();
-		return $"{elementTypeName}[]";
-	}
 }

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/ITypeSymbolExtensions.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/ITypeSymbolExtensions.cs
@@ -416,7 +416,39 @@ namespace Acuminator.Utilities.Roslyn.Semantic
 		}
 
 		/// <summary>
-		/// An INamedTypeSymbol extension method that gets CLR-style full type name from type.
+		/// A <see cref="String"/> extension method that removes the empty spaces in array type names described by dataTypeName.
+		/// </summary>
+		/// <exception cref="ArgumentException">Thrown when one or more arguments have unsupported or illegal values.</exception>
+		/// <param name="dataTypeName">The dataTypeName to act on.</param>
+		/// <returns>
+		/// A string.
+		/// </returns>
+		public static string RemoveEmptySpacesInArrayTypeNames(this string dataTypeName)
+		{
+			dataTypeName.ThrowOnNullOrWhiteSpace();
+
+			bool isArrayTypeName = dataTypeName[^1] == ']';
+
+			if (!isArrayTypeName)
+				return dataTypeName;
+			else if (dataTypeName.Length <= 2)
+				throw new ArgumentException($"Invalid data type name \"{dataTypeName}\"", nameof(dataTypeName));
+
+			// if there is no empty spaces in array, return the original string
+			if (dataTypeName[^2] == '[' && !char.IsWhiteSpace(dataTypeName[^3]))
+				return dataTypeName;
+
+			int indexOfOpeningSquareBracket = dataTypeName.LastIndexOf('[');
+
+			if (indexOfOpeningSquareBracket < 0)
+				throw new ArgumentException($"Invalid data type name \"{dataTypeName}\"", nameof(dataTypeName));
+
+			var elementTypeName = dataTypeName[..indexOfOpeningSquareBracket].Trim();
+			return $"{elementTypeName}[]";
+		}
+
+		/// <summary>
+		/// An <see cref="INamedTypeSymbol"/> extension method that gets CLR-style full type name from type.
 		/// </summary>
 		/// <param name="typeSymbol">The typeSymbol to act on.</param>
 		/// <returns/>

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/ITypeSymbolExtensions.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/ITypeSymbolExtensions.cs
@@ -665,5 +665,16 @@ namespace Acuminator.Utilities.Roslyn.Semantic
 			typeSymbol.CheckIfNull(nameof(typeSymbol))
 					  .GetContainingTypesAndThis()
 					  .All(type => type.DeclaredAccessibility == Accessibility.Public);
+
+		/// <summary>
+		/// Check if <paramref name="typeSymbol"/> type is one dimensional string array.
+		/// </summary>
+		/// <param name="typeSymbol">The type to act on.</param>
+		/// <returns>
+		/// True if one dimensional string array, false if not.
+		/// </returns>
+		public static bool IsOneDimensionalStringArray(this ITypeSymbol? typeSymbol) =>
+			typeSymbol is IArrayTypeSymbol arrayType && arrayType.Rank == 1 && 
+			arrayType.ElementType.SpecialType == SpecialType.System_String;
 	}
 }

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/Symbols/BqlDataTypeSymbols.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/Symbols/BqlDataTypeSymbols.cs
@@ -34,5 +34,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic.Symbols
 		public INamedTypeSymbol IBqlDecimal => Compilation.GetTypeByMetadataName(TypeFullNames.IBqlDecimalType)!;
 
 		public INamedTypeSymbol IBqlByteArray => Compilation.GetTypeByMetadataName(TypeFullNames.IBqlByteArrayType)!;
+
+		public INamedTypeSymbol? IBqlAttributes => Compilation.GetTypeByMetadataName(TypeFullNames.IBqlAttributes);
 	}
 }


### PR DESCRIPTION
**Changes Overview:**

**`Attributes` Support**
- Added string constant and symbol for `BqlAttributes` type 
- Added mapping between `string[]` and `BqlAttributes` BQL type
- Added support of `Attributes` field to BQL field generation
- Added support of `Attributes` field to PX1060 diagnostic checking legacy BQL fields and extended unit tests for this case
- Enhanced `PX1061` diagnostic for legacy BQL constants to explicitly skip array constants
- Added support of `Attributes` field to PX1068 diagnostic checking compatibility between property and BQL filed types, added support to code fix, and extended unit tests for this case

**Other**
- Added helper that removes spaces from names of single dimension array types, added its call to the `DataTypeName`
- Added tests for `DataTypeName`
- Added new extensions methods