### PR TITLE
Bugfix/atr 854 dev px1015 stackoverflow

### DIFF
--- a/src/Acuminator/Acuminator.Tests/Acuminator.Tests.csproj
+++ b/src/Acuminator/Acuminator.Tests/Acuminator.Tests.csproj
@@ -96,6 +96,7 @@
     <Compile Include="Tests\StaticAnalysis\BannedApi\BannedApiTestsNonIsv.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\BannedApi\Sources\CallsToApisForbiddenToIsv.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\BannedApi\Sources\CallsToMathRoundAPIs.cs" />
+    <EmbeddedResource Include="Tests\StaticAnalysis\BqlParameterMismatch\Sources\BqlWithGenericDacFieldCall.cs" />
     <Compile Include="Tests\StaticAnalysis\ForbidPrivateEventHandlers\ForbidPrivateEventHandlersFixerTests.cs" />
     <Compile Include="Tests\StaticAnalysis\ForbidPrivateEventHandlers\ForbidPrivateEventHandlersTests.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\ForbidPrivateEventHandlers\Sources\PrivateModifier.cs" />

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/BqlParameterMismatch/BqlParameterMismatchTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/BqlParameterMismatch/BqlParameterMismatchTests.cs
@@ -91,5 +91,10 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.BqlParameterMismatch
 		[EmbeddedFileData("PXSelectExtensionCall.cs")]
 		public virtual async Task PXSelectExtension_Call_NoDiagnostic(string source) => 
 			await VerifyCSharpDiagnosticAsync(source);
+
+		[Theory]
+		[EmbeddedFileData("BqlWithGenericDacFieldCall.cs")]
+		public virtual async Task PXSelectCall_WithGenericDacField_NoDiagnostic(string source) =>
+			await VerifyCSharpDiagnosticAsync(source);
 	}
 }

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/BqlParameterMismatch/Sources/BqlWithGenericDacFieldCall.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/BqlParameterMismatch/Sources/BqlWithGenericDacFieldCall.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+
+using PX.Data;
+using PX.Data.BQL;
+using PX.Objects.AR;
+
+namespace PX.Objects.HackathonDemo
+{
+	public abstract class SomeGraphBaseExt<TGraph, TDac, TRefNbrField, TDocTypeVal> : PXGraphExtension<TGraph>
+	where TGraph : PXGraph
+	where TDac : class, IBqlTable, new()
+	where TRefNbrField : BqlString.Field<TRefNbrField>
+	where TDocTypeVal : BqlString.Constant<TDocTypeVal>, new()
+	{
+		public PXSelect<ARInvoice,
+					Where<ARInvoice.refNbr, Equal<Current<TRefNbrField>>,
+					  And<ARInvoice.docType, Equal<TDocTypeVal>>>,
+				  OrderBy<
+					  Asc<ARInvoice.refNbr>>>
+		   Invoices;
+
+		protected virtual ARInvoice GetInvoice()
+		{
+			ARInvoice invoice = Invoices.SelectSingle();
+			return invoice; 
+		}
+
+		protected virtual ARInvoice GetInvoice2()
+		{
+			ARInvoice invoice = PXSelect<ARInvoice,
+					Where<ARInvoice.refNbr, Equal<Current<TRefNbrField>>,
+					  And<ARInvoice.docType, Equal<TDocTypeVal>>>,
+				  OrderBy<
+					  Asc<ARInvoice.refNbr>>>
+					  .SelectSingleBound(Base, currents: new[] { Invoices.Cache.Current });
+			return invoice;
+		}
+	}
+
+	public class SomeGraph : PXGraph<SomeGraph>
+	{
+
+	}
+}


### PR DESCRIPTION
The bug is caused by stack overflow exception thrown by the PX1015 diagnostic. It is thrown in this generic extension, and the reason is this constraint:
![image](https://github.com/user-attachments/assets/6973a798-d342-4e46-b419-4ac3add3b6da)

The error was thrown during the analysis of a call to this BQL query:
![image](https://github.com/user-attachments/assets/c6b6f1b7-b0c6-4776-8877-6ec873eae938)

For BQL graph views the PX1015 analyzer performs recursive visit of all symbols composing the BQL query. It also analyzes constraints of generic type parameters. So, basically this happened:
- The analyzer sees `TRefNbrField` in the query and tried to understand, what is this - a BQL field, constant, some kind of sub query, or something else.
- Analysis sees that it is a type parameter and attempts to classify it by checking its constraints.
- In constraints it sees a complex type `BqlString.Field<TField>` and tries to analyze it. It attempts to analyze its generic type arguments and there it sees again `TRefNbrField` type parameter. So, the analysis starts analyzing it again. And we end up with an infinite loop

**Changes overview:**
- fixed bug
- added unit test for this scenario