### PR TITLE
Resolved an issue where RowChangesInEventHandlersAnalyzer would incorrectly error for variables created from e.Row using a recursive pattern.

### DIFF
--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/RowChangesInEventHandlers/VariablesWalker.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/RowChangesInEventHandlers/VariablesWalker.cs
@@ -55,7 +55,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.RowChangesInEventHandlers
 							.ToImmutableHashSet<ILocalSymbol>(SymbolEqualityComparer.Default);
 					}
 				}
-				
+
 			}
 
 			public override void VisitAssignmentExpression(AssignmentExpressionSyntax assignment)
@@ -84,9 +84,16 @@ namespace Acuminator.Analyzers.StaticAnalysis.RowChangesInEventHandlers
 			{
 				_cancellationToken.ThrowIfCancellationRequested();
 
-				if (isPatternExpression.Pattern is DeclarationPatternSyntax declarationPattern && declarationPattern.Designation != null)
+				VariableDesignationSyntax? designation = isPatternExpression.Pattern switch
 				{
-					var variableSymbol = _semanticModel.GetDeclaredSymbol(declarationPattern.Designation, _cancellationToken) as ILocalSymbol;
+					DeclarationPatternSyntax declarationPattern => declarationPattern.Designation,
+					RecursivePatternSyntax recursivePattern => recursivePattern.Designation,
+					_ => null
+				};
+
+				if (designation != null)
+				{
+					var variableSymbol = _semanticModel.GetDeclaredSymbol(designation, _cancellationToken) as ILocalSymbol;
 					ValidateThatVariableIsSetToDacFromEvent(variableSymbol, isPatternExpression.Expression);
 				}
 			}

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/RowChangesInEventHandlers/RowChangesInEventHandlersTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/RowChangesInEventHandlers/RowChangesInEventHandlersTests.cs
@@ -21,7 +21,7 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.RowChangesInEventHandlers
 		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer() =>
 			new EventHandlerAnalyzer(CodeAnalysisSettings.Default
 					.WithRecursiveAnalysisEnabled()
-					.WithIsvSpecificAnalyzersEnabled(), 
+					.WithIsvSpecificAnalyzersEnabled(),
 				new RowChangesInEventHandlersAnalyzer());
 
 		[Theory]
@@ -29,7 +29,10 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.RowChangesInEventHandlers
 		public Task IsPatternAssignment(string actual) => VerifyCSharpDiagnosticAsync(actual,
 			Descriptors.PX1047_RowChangesInEventHandlersForbiddenForArgs.CreateFor(17, 4, EventType.RowSelected),
 			Descriptors.PX1047_RowChangesInEventHandlersForbiddenForArgs.CreateFor(25, 4, EventType.FieldDefaulting),
-			Descriptors.PX1047_RowChangesInEventHandlersForbiddenForArgs.CreateFor(33, 4, EventType.FieldVerifying));
+			Descriptors.PX1047_RowChangesInEventHandlersForbiddenForArgs.CreateFor(33, 4, EventType.FieldVerifying),
+			Descriptors.PX1047_RowChangesInEventHandlersForbiddenForArgs.CreateFor(41, 4, EventType.RowSelected),
+			Descriptors.PX1047_RowChangesInEventHandlersForbiddenForArgs.CreateFor(49, 4, EventType.FieldDefaulting),
+			Descriptors.PX1047_RowChangesInEventHandlersForbiddenForArgs.CreateFor(57, 4, EventType.FieldVerifying));
 
 		[Theory]
 		[EmbeddedFileData("DirectAssignment.cs")]
@@ -81,14 +84,13 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.RowChangesInEventHandlers
 		[EmbeddedFileData("NonRowAssignment.cs")]
 		public Task NonRowAssignment_ShouldNotShowDiagnostic(string actual) => VerifyCSharpDiagnosticAsync(actual);
 
-
 		[Theory]
 		[EmbeddedFileData(@"Reversed\IsPatternAssignment.cs")]
 		public Task Reversed_IsPatternAssignment_ShouldNotShowDiagnostic(string actual) => VerifyCSharpDiagnosticAsync(actual);
 
 		[Theory]
 		[EmbeddedFileData(@"Reversed\DirectAssignment.cs")]
-		public Task Reversed_DirectAssignment(string actual) => VerifyCSharpDiagnosticAsync(actual, 
+		public Task Reversed_DirectAssignment(string actual) => VerifyCSharpDiagnosticAsync(actual,
 			Descriptors.PX1048_RowChangesInEventHandlersAllowedForArgsOnly.CreateFor(17, 4, EventType.RowInserting),
 			Descriptors.PX1048_RowChangesInEventHandlersAllowedForArgsOnly.CreateFor(23, 4, EventType.RowSelecting));
 

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/RowChangesInEventHandlers/Sources/IsPatternAssignment.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/RowChangesInEventHandlers/Sources/IsPatternAssignment.cs
@@ -32,6 +32,30 @@ namespace PX.Objects
 
 			invoice.RefNbr = "<NEW>";
 		}
+
+		protected virtual void _(Events.RowSelected<SOLine> e)
+		{
+			if (!(e.Row is { } row))
+				return;
+
+			row.RefNbr = "<NEW>";
+		}
+
+		protected virtual void _(Events.FieldDefaulting<SOLine, SOLine.refNbr> e)
+		{
+			if (!(e.Row is { } row))
+				return;
+
+			row.RefNbr = "<NEW>";
+		}
+
+		protected virtual void _(Events.FieldVerifying<SOLine, SOLine.refNbr> e)
+		{
+			if (!(e.Row is { } row))
+				return;
+
+			row.RefNbr = "<NEW>";
+		}
 	}
 
 	public class SOInvoice : IBqlTable
@@ -40,6 +64,15 @@ namespace PX.Objects
 		[PXDBString(8, IsKey = true, InputMask = "")]
 		public string RefNbr { get; set; }
 		public abstract class refNbr : IBqlField { }
-		#endregion	
+		#endregion
+	}
+
+	public class SOLine : IBqlTable
+	{
+		#region RefNbr
+		[PXDBString(8, IsKey = true, InputMask = "")]
+		public string RefNbr { get; set; }
+		public abstract class refNbr : IBqlField { }
+		#endregion
 	}
 }

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/RowChangesInEventHandlers/Sources/Reversed/IsPatternAssignment.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/RowChangesInEventHandlers/Sources/Reversed/IsPatternAssignment.cs
@@ -26,6 +26,22 @@ namespace PX.Objects
 
 			invoice.RefNbr = "<NEW>"; // should be OK
 		}
+
+		protected virtual void _(Events.RowInserting<SOLine> e)
+		{
+			if (!(e.Row is { } row))
+				return;
+
+			row.RefNbr = "<NEW>"; // should be OK
+		}
+
+		protected virtual void _(Events.RowSelecting<SOLine> e)
+		{
+			if (!(e.Row is { RefNbr: { } } row))
+				return;
+
+			row.RefNbr = "<NEW>" // should be OK
+		}
 	}
 
 	public class SOInvoice : IBqlTable
@@ -34,6 +50,15 @@ namespace PX.Objects
 		[PXDBString(8, IsKey = true, InputMask = "")]
 		public string RefNbr { get; set; }
 		public abstract class refNbr : IBqlField { }
-		#endregion	
+		#endregion
+	}
+
+	public class SOLine : IBqlTable
+	{
+		#region RefNbr
+		[PXDBString(8, IsKey = true, InputMask = "")]
+		public string RefNbr { get; set; }
+		public abstract class refNbr : IBqlField { }
+		#endregion
 	}
 }


### PR DESCRIPTION
Resolved an issue where RowChangesInEventHandlersAnalyzer would incorrectly error for variables created from e.Row using a recursive pattern.

For example, this analyzer supported a declaration pattern :

```cs
protected virtual void _(Events.RowInserting<SOInvoice> e)
{
	if (e.Row is SOInvoice row)
	{
	}
}
```

Whereas this is a recursive pattern :

```cs
protected virtual void _(Events.RowInserting<SOLine> e)
{
	if (e.Row is { } row)
	{
	}
}

protected virtual void _(Events.RowSelecting<SOLine> e)
{
	if (e.Row is { RefNbr: { } refNbr } row)
	{
	}
}
```