### PR TITLE
Updated how Acumatica version is determined to be more durable in order to resolve an issue where PX1042 was improperly reported in Acumatica 2023 R1 and up.  This was caused by Acuminator determining whether or not the Acumatica version was above a certain range by checking for the existence of Types/Members, one being PXCache.RowSelectingWhileReading which was internal, which was not returned by Roslyn because it is marked as internal.

### DIFF
--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/ChangesInPXCache/ChangesInPXCacheDuringPXGraphInitializationTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/ChangesInPXCache/ChangesInPXCacheDuringPXGraphInitializationTests.cs
@@ -9,52 +9,52 @@ using Xunit;
 
 namespace Acuminator.Tests.Tests.StaticAnalysis.ChangesInPXCache
 {
-    public class ChangesInPXCacheDuringPXGraphInitializationTests : DiagnosticVerifier
-    {
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer() =>
-            new PXGraphAnalyzer(
-                CodeAnalysisSettings.Default
-                .WithRecursiveAnalysisEnabled(),
-                new ChangesInPXCacheDuringPXGraphInitializationAnalyzer());
+	public class ChangesInPXCacheDuringPXGraphInitializationTests : DiagnosticVerifier
+	{
+		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer() =>
+			new PXGraphAnalyzer(
+				CodeAnalysisSettings.Default
+				.WithRecursiveAnalysisEnabled(),
+				new ChangesInPXCacheDuringPXGraphInitializationAnalyzer());
 
-        [Theory]
-        [EmbeddedFileData(@"PXGraph\PXGraphChangesPXCacheInInstanceConstructor.cs")]
-        public void GraphInstanceConstructor_ReportsDiagnostic(string source)
-        {
-            VerifyCSharpDiagnostic(source,
-                Descriptors.PX1059_ChangesInPXCacheDuringPXGraphInitialization.CreateFor(16, 17),
-                Descriptors.PX1059_ChangesInPXCacheDuringPXGraphInitialization.CreateFor(17, 17),
-                Descriptors.PX1059_ChangesInPXCacheDuringPXGraphInitialization.CreateFor(18, 17),
-                Descriptors.PX1059_ChangesInPXCacheDuringPXGraphInitialization.CreateFor(20, 17),
-                Descriptors.PX1059_ChangesInPXCacheDuringPXGraphInitialization.CreateFor(21, 17),
-                Descriptors.PX1059_ChangesInPXCacheDuringPXGraphInitialization.CreateFor(22, 17));
-        }
+		[Theory]
+		[EmbeddedFileData(@"PXGraph\PXGraphChangesPXCacheInInstanceConstructor.cs")]
+		public void GraphInstanceConstructor_ReportsDiagnostic(string source)
+		{
+			VerifyCSharpDiagnostic(source,
+				Descriptors.PX1059_ChangesInPXCacheDuringPXGraphInitialization.CreateFor(16, 17),
+				Descriptors.PX1059_ChangesInPXCacheDuringPXGraphInitialization.CreateFor(17, 17),
+				Descriptors.PX1059_ChangesInPXCacheDuringPXGraphInitialization.CreateFor(18, 17),
+				Descriptors.PX1059_ChangesInPXCacheDuringPXGraphInitialization.CreateFor(20, 17),
+				Descriptors.PX1059_ChangesInPXCacheDuringPXGraphInitialization.CreateFor(21, 17),
+				Descriptors.PX1059_ChangesInPXCacheDuringPXGraphInitialization.CreateFor(22, 17));
+		}
 
-        [Theory]
-        [EmbeddedFileData(@"PXGraph\PXGraphChangesPXCacheInInstanceConstructorViaMethod.cs")]
-        public void GraphInstanceConstructorViaMethod_ReportsDiagnostic(string source)
-        {
-            VerifyCSharpDiagnostic(source, Descriptors.PX1059_ChangesInPXCacheDuringPXGraphInitialization.CreateFor(16, 17));
-        }
+		[Theory]
+		[EmbeddedFileData(@"PXGraph\PXGraphChangesPXCacheInInstanceConstructorViaMethod.cs")]
+		public void GraphInstanceConstructorViaMethod_ReportsDiagnostic(string source)
+		{
+			VerifyCSharpDiagnostic(source, Descriptors.PX1059_ChangesInPXCacheDuringPXGraphInitialization.CreateFor(16, 17));
+		}
 
-        [Theory]
-        [EmbeddedFileData(@"PXGraph\PXGraphExtensionChangesPXCacheInInitializationMethod.cs")]
-        public void GraphExtensionInitializationMethod_ReportsDiagnostic(string source)
-        {
-            VerifyCSharpDiagnostic(source,
-                Descriptors.PX1059_ChangesInPXCacheDuringPXGraphInitialization.CreateFor(14, 17),
-                Descriptors.PX1059_ChangesInPXCacheDuringPXGraphInitialization.CreateFor(15, 17),
-                Descriptors.PX1059_ChangesInPXCacheDuringPXGraphInitialization.CreateFor(16, 17),
-                Descriptors.PX1059_ChangesInPXCacheDuringPXGraphInitialization.CreateFor(18, 17),
-                Descriptors.PX1059_ChangesInPXCacheDuringPXGraphInitialization.CreateFor(19, 17),
-                Descriptors.PX1059_ChangesInPXCacheDuringPXGraphInitialization.CreateFor(20, 17));
-        }
+		[Theory]
+		[EmbeddedFileData(@"PXGraph\PXGraphExtensionChangesPXCacheInInitializationMethod.cs")]
+		public void GraphExtensionInitializationMethod_ReportsDiagnostic(string source)
+		{
+			VerifyCSharpDiagnostic(source,
+				Descriptors.PX1059_ChangesInPXCacheDuringPXGraphInitialization.CreateFor(21, 5),
+				Descriptors.PX1059_ChangesInPXCacheDuringPXGraphInitialization.CreateFor(22, 5),
+				Descriptors.PX1059_ChangesInPXCacheDuringPXGraphInitialization.CreateFor(23, 5),
+				Descriptors.PX1059_ChangesInPXCacheDuringPXGraphInitialization.CreateFor(25, 5),
+				Descriptors.PX1059_ChangesInPXCacheDuringPXGraphInitialization.CreateFor(26, 5),
+				Descriptors.PX1059_ChangesInPXCacheDuringPXGraphInitialization.CreateFor(27, 5));
+		}
 
-        [Theory]
-        [EmbeddedFileData(@"PXGraph\PXGraphDoesntChangePXCacheInInstanceConstructor.cs")]
-        public void GraphInstanceConstructor_DoesntReportsDiagnostic(string source)
-        {
-            VerifyCSharpDiagnostic(source);
-        }
-    }
+		[Theory]
+		[EmbeddedFileData(@"PXGraph\PXGraphDoesntChangePXCacheInInstanceConstructor.cs")]
+		public void GraphInstanceConstructor_DoesntReportsDiagnostic(string source)
+		{
+			VerifyCSharpDiagnostic(source);
+		}
+	}
 }

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/ChangesInPXCache/Sources/PXGraph/PXGraphExtensionChangesPXCacheInInitializationMethod.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/ChangesInPXCache/Sources/PXGraph/PXGraphExtensionChangesPXCacheInInitializationMethod.cs
@@ -1,31 +1,31 @@
 ﻿using PX.Data;
-using PX.SM;
+using PX.Objects.AP;
 
 namespace Acuminator.Tests.Tests.StaticAnalysis.PXGraphLongOperationDuringInitialization.Sources
 {
-    public class SMAccessExtDerived : SMAccessExtBase
-	{
-        public override void Initialize()
-        {
-            int count = Base.Identities.Select().Count;
-
-            if (count > 0)
-            {
-                Base.Identities.Cache.Insert(Base.Identities.Current);
-                Base.Identities.Cache.Update(Base.Identities.Current);
-                Base.Identities.Cache.Delete(Base.Identities.Current);
-
-                Base.Identities.Insert(Base.Identities.Current);
-                Base.Identities.Update(Base.Identities.Current);
-                Base.Identities.Delete(Base.Identities.Current);
-            }
-        }
-    }
-
-	public class SMAccessExtBase : PXGraphExtension<SMAccessPersonalMaint>
+	public class APInvoiceEntryExt : PXGraphExtension<APInvoiceEntry>
 	{
 		public override void Initialize()
 		{
+		}
+	}
+
+	public class APInvoiceEntryExtDerived : APInvoiceEntryExt
+	{
+		public override void Initialize()
+		{
+			int count = Base.Document.Select().Count;
+
+			if (count > 0)
+			{
+				Base.Document.Cache.Insert(Base.Document.Current);
+				Base.Document.Cache.Update(Base.Document.Current);
+				Base.Document.Cache.Delete(Base.Document.Current);
+
+				Base.Document.Insert(Base.Document.Current);
+				Base.Document.Update(Base.Document.Current);
+				Base.Document.Delete(Base.Document.Current);
+			}
 		}
 	}
 }

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/PXContext.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/PXContext.cs
@@ -18,18 +18,20 @@ namespace Acuminator.Utilities.Roslyn.Semantic
 		public bool IsAcumatica2018R2_OrGreater { get; }
 		public bool IsAcumatica2019R1_OrGreater { get; }
 
-		public bool IsAcumatica2023R1_OrGreater => PXCache.RowSelectingWhileReading != null;
+		public bool IsAcumatica2023R1_OrGreater { get; }
 
-		public bool IsAcumatica2024R1_OrGreater => PXBqlTable != null;
+		public bool IsAcumatica2024R1_OrGreater { get; }
 
 		public CodeAnalysisSettings CodeAnalysisSettings { get; }
+
+		public Compilation Compilation { get; }
 
 		/// <summary>
 		/// Is platform referenced in the current solution. If not then diagnostic can't run on the solution.
 		/// </summary>
 		public bool IsPlatformReferenced { get; }
 
-		public Compilation Compilation { get; }
+		public AcumaticaVersion AcumaticaVersion { get; }
 
 		private readonly Lazy<BQLSymbols> _bql;
 		public BQLSymbols BQL => _bql.Value;
@@ -51,23 +53,23 @@ namespace Acuminator.Utilities.Roslyn.Semantic
 		private readonly Lazy<AttributeSymbols> _attributes;
 		public AttributeSymbols AttributeTypes => _attributes.Value;
 
-        private readonly Lazy<LocalizationSymbols> _localizationMethods;
-        public LocalizationSymbols Localization => _localizationMethods.Value;
+		private readonly Lazy<LocalizationSymbols> _localizationMethods;
+		public LocalizationSymbols Localization => _localizationMethods.Value;
 
-        private readonly Lazy<PXGraphSymbols> _pxGraph;
-        public PXGraphSymbols PXGraph => _pxGraph.Value;
+		private readonly Lazy<PXGraphSymbols> _pxGraph;
+		public PXGraphSymbols PXGraph => _pxGraph.Value;
 
-        private readonly Lazy<PXCacheSymbols> _pxCache;
-        public PXCacheSymbols PXCache => _pxCache.Value;
+		private readonly Lazy<PXCacheSymbols> _pxCache;
+		public PXCacheSymbols PXCache => _pxCache.Value;
 
 		private readonly Lazy<PXActionSymbols> _pxAction;
 		public PXActionSymbols PXAction => _pxAction.Value;
 
-        private readonly Lazy<PXSelectBaseGenericSymbols> _pxSelectBaseGeneric;
-        public PXSelectBaseGenericSymbols PXSelectBaseGeneric => _pxSelectBaseGeneric.Value;
+		private readonly Lazy<PXSelectBaseGenericSymbols> _pxSelectBaseGeneric;
+		public PXSelectBaseGenericSymbols PXSelectBaseGeneric => _pxSelectBaseGeneric.Value;
 
-        private readonly Lazy<PXSelectBaseSymbols> _pxSelectBase;
-        public PXSelectBaseSymbols PXSelectBase => _pxSelectBase.Value;
+		private readonly Lazy<PXSelectBaseSymbols> _pxSelectBase;
+		public PXSelectBaseSymbols PXSelectBase => _pxSelectBase.Value;
 
 		private readonly Lazy<PXSelectExtensionSymbols> _pxSelectExtensionSymbols;
 
@@ -86,7 +88,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic
 		public SerializationSymbols Serialization => _serialization.Value;
 
 		private readonly Lazy<PXProcessingBaseSymbols> _pxProcessingBase;
-        public PXProcessingBaseSymbols PXProcessingBase => _pxProcessingBase.Value;
+		public PXProcessingBaseSymbols PXProcessingBase => _pxProcessingBase.Value;
 
 		private readonly Lazy<PXReferentialIntegritySymbols> _referentialIntegritySymbols;
 		public PXReferentialIntegritySymbols ReferentialIntegritySymbols => _referentialIntegritySymbols.Value;
@@ -122,10 +124,10 @@ namespace Acuminator.Utilities.Roslyn.Semantic
 		public INamedTypeSymbol PXFieldState => Compilation.GetTypeByMetadataName(TypeFullNames.PXFieldState)!;
 		public INamedTypeSymbol PXAttributeFamily => Compilation.GetTypeByMetadataName(TypeFullNames.PXAttributeFamilyAttribute)!;
 
-        public INamedTypeSymbol IPXLocalizableList => Compilation.GetTypeByMetadataName(TypeFullNames.IPXLocalizableList)!;
+		public INamedTypeSymbol IPXLocalizableList => Compilation.GetTypeByMetadataName(TypeFullNames.IPXLocalizableList)!;
 		public INamedTypeSymbol PXConnectionScope => Compilation.GetTypeByMetadataName(TypeFullNames.PXConnectionScope)!;
 
-        public ImmutableArray<IMethodSymbol> StartOperation => PXLongOperation.GetMethods(DelegateNames.StartOperation).ToImmutableArray();
+		public ImmutableArray<IMethodSymbol> StartOperation => PXLongOperation.GetMethods(DelegateNames.StartOperation).ToImmutableArray();
 
 		public INamedTypeSymbol IImplementType => Compilation.GetTypeByMetadataName(TypeFullNames.IImplementType)!;
 
@@ -135,9 +137,12 @@ namespace Acuminator.Utilities.Roslyn.Semantic
 		{
 			compilation.ThrowOnNull();
 
+			INamedTypeSymbol? pxGraphSymbol = compilation.GetTypeByMetadataName(TypeFullNames.PXGraph);
+
 			CodeAnalysisSettings = codeAnalysisSettings ?? CodeAnalysisSettings.Default;
 			Compilation = compilation;
-			IsPlatformReferenced = compilation.GetTypeByMetadataName(TypeFullNames.PXGraph) != null;
+			IsPlatformReferenced = pxGraphSymbol != null;
+			AcumaticaVersion = new(pxGraphSymbol?.ContainingAssembly);
 
 			_bql 						 = new Lazy<BQLSymbols>(() => new BQLSymbols(Compilation));
 			_bqlTypes 					 = new Lazy<BqlDataTypeSymbols>(() => new BqlDataTypeSymbols(Compilation));
@@ -165,8 +170,13 @@ namespace Acuminator.Utilities.Roslyn.Semantic
 
 			_uiPresentationLogicMethods = new Lazy<ImmutableHashSet<IMethodSymbol>>(GetUiPresentationLogicMethods);
 
-			IsAcumatica2018R2_OrGreater = PXSelectBase2018R2NewType != null;
-			IsAcumatica2019R1_OrGreater = IImplementType != null;
+			// Acumatica 2018 R2 Preview started in the 18.19X range.
+			IsAcumatica2018R2_OrGreater = AcumaticaVersion.Major == 18
+				? AcumaticaVersion.Minor >= 191
+				: AcumaticaVersion.Major > 18;
+			IsAcumatica2019R1_OrGreater = AcumaticaVersion.Major >= 19;
+			IsAcumatica2023R1_OrGreater = AcumaticaVersion.Major >= 23;
+			IsAcumatica2024R1_OrGreater = AcumaticaVersion.Major >= 24;
 		}
 
 		private ImmutableHashSet<IMethodSymbol> GetUiPresentationLogicMethods()

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/Symbols/AcumaticaVersion.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/Symbols/AcumaticaVersion.cs
@@ -1,0 +1,34 @@
+﻿#nullable enable
+
+using System.Linq;
+
+using Microsoft.CodeAnalysis;
+
+namespace Acuminator.Utilities.Roslyn.Semantic.Symbols;
+
+public sealed class AcumaticaVersion
+{
+	public readonly int Major;
+	public readonly int Minor;
+	public readonly int Build;
+
+	public AcumaticaVersion(IAssemblySymbol? assemblySymbol)
+	{
+		if
+		(
+			assemblySymbol == null
+			|| assemblySymbol.GetAttributes().FirstOrDefault(x => x?.AttributeClass?.Name == "AssemblyFileVersionAttribute") is not { } attributeData
+			|| attributeData.ConstructorArguments is not { Length: > 0 } constructorArguments
+			|| constructorArguments[0].Value is not string { } acumaticaVersion
+			|| acumaticaVersion.Split('.') is not { Length: > 2 } versionParts
+			|| !int.TryParse(versionParts[0], out int major)
+			|| !int.TryParse(versionParts[1], out int minor)
+			|| !int.TryParse(versionParts[2], out int build)
+		)
+			return;
+
+		Major = major;
+		Minor = minor;
+		Build = build;
+	}
+}

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/Symbols/PXCacheSymbols.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/Symbols/PXCacheSymbols.cs
@@ -1,8 +1,6 @@
 ﻿#nullable enable
 
-using System;
 using System.Collections.Immutable;
-using System.Linq;
 
 using Acuminator.Utilities.Common;
 using Acuminator.Utilities.Roslyn.Constants;
@@ -21,8 +19,6 @@ namespace Acuminator.Utilities.Roslyn.Semantic.Symbols
 
 		public INamedTypeSymbol GenericType { get; }
 		
-		public IEventSymbol? RowSelectingWhileReading { get; }
-
 		internal PXCacheSymbols(Compilation compilation) : base(compilation, TypeFullNames.PXCache)
 		{
 			Type.ThrowOnNull();
@@ -34,9 +30,6 @@ namespace Acuminator.Utilities.Roslyn.Semantic.Symbols
 			Delete = Type.GetMethods(DelegateNames.Delete).ToImmutableArray();
 
 			RaiseExceptionHandling   = Type.GetMethods(DelegateNames.RaiseExceptionHandling).ToImmutableArray();
-			RowSelectingWhileReading = Type.GetMembers(EventsNames.PXCache.RowSelectingWhileReading)
-										   .OfType<IEventSymbol>()
-										   .FirstOrDefault();
 		}
 	}
 }


### PR DESCRIPTION
Updated how Acumatica version is determined to be more durable in order to resolve an issue where PX1042 was improperly reported in Acumatica 2023 R1 and up.  This was caused by Acuminator determining whether or not the Acumatica version was above a certain range by checking for the existence of Types/Members, one being PXCache.RowSelectingWhileReading which was internal, which was not returned by Roslyn because it is marked as internal.

Also fixed a test which was not passing due to a "compilation" error that was not reported by the test runner, but was accessible while debugging.