### PR TITLE
ATR-862: fixed check for Acumatica 2023r1

### DIFF
--- a/docs/dev/CodingGuidelines/CodingGuidelines.md
+++ b/docs/dev/CodingGuidelines/CodingGuidelines.md
@@ -26,8 +26,9 @@
     * [Parametrized Diagnostic Messages](#parametrized-diagnostic-messages)
     * [Test Methods](#test-methods)
     * [Async Anonymous Delegates](#async-anonymous-delegates)
-    * [Value Tuples](#value-tuples)
+    * [Value Tuples (Obsolete)](#value-tuples-obsolete)
     * [Debugging Hints](#debugging-hints)
+    * [Checking Acumatica DLL Version](#checking-acumatica-dll-version)
 
 ## Code Style
 
@@ -443,7 +444,7 @@ https://docs.microsoft.com/ru-ru/dotnet/framework/configure-apps/file-schema/run
 
 Overall, the passing of asynchronous methods to `analyzer.RegisterXXX `is an unwanted scenario that should be avoided at all costs.
 
-### Value Tuples
+### Value Tuples (Obsolete)
 
 There is an issue with value tuples in Visual Studio 2017. There is a dependency conflict between some packages depending on different versions of `System.ValueTuple` which proved to be impossible to fix.
 The issue appear as a `MissingMethod` exception being thrown on attempt to call public API method with signature containing value tuples if the caller and callee are declared in different assemblies.
@@ -464,3 +465,12 @@ You need to do one of the following:
 * Perform a multiprocess debugging by attaching your debugger to a second process with loaded Roslyn analyzers. The name of the process should look like the following: *ServiceHub.RoslynCodeAnalysisService.exe*.
 
 The first option is much simpler but you have to check that your diagnostic works correctly when the out of process analysis is enabled for Visual Studio.
+
+### Checking Acumatica DLL Version
+
+You can find flags indicating the version of analyzed Acumatica DLLs in the `Acuminator.Utilities.Roslyn.Semantic.PXContext` type.
+
+If you need to add a new flag indicating the version of Acumatica DLLs, you should add it to the `PXContext` class. The check for Acumatica version has to be based on the presense of some new API
+added in the specific version of Acumatica DLLs. We can't rely on standard .Net assembly version attributes because Acumatica assemblies don't have them or they are not updated properly.
+
+*Remember! Only public API can be used to check the version of Acumatica DLLs because Roslyn does not load private and internal metadata of the external dependencies of the analyzed code.*

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/PXContext.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/PXContext.cs
@@ -18,7 +18,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic
 		public bool IsAcumatica2018R2_OrGreater { get; }
 		public bool IsAcumatica2019R1_OrGreater { get; }
 
-		public bool IsAcumatica2023R1_OrGreater => PXCache.RowSelectingWhileReading != null;
+		public bool IsAcumatica2023R1_OrGreater { get; }
 
 		public bool IsAcumatica2024R1_OrGreater => PXBqlTable != null;
 
@@ -167,6 +167,9 @@ namespace Acuminator.Utilities.Roslyn.Semantic
 
 			IsAcumatica2018R2_OrGreater = PXSelectBase2018R2NewType != null;
 			IsAcumatica2019R1_OrGreater = IImplementType != null;
+
+			const string archiveProcessGraphName = "PX.Data.Archiving.ArchiveProcess";
+			IsAcumatica2023R1_OrGreater = compilation.GetTypeByMetadataName(archiveProcessGraphName) != null;
 		}
 
 		private ImmutableHashSet<IMethodSymbol> GetUiPresentationLogicMethods()


### PR DESCRIPTION
Fix check that Acumatica DLLs version is 2023r1 or greater.

The previous check worked incorrect because Roslyn actually does not load private and internal metadata from external dependencies such as referenced DLLs. This is a quick fix that uses the public API `PX.Data.Archiving.ArchiveProcess` to check

More details about the issue with PX1042 diagnostic and Roslyn not loading internal metadata can be found here: 
https://github.com/Acumatica/Acuminator/issues/572

Initially, I thought that the fix must make Roslyn load internal and private metadata (this is a separate ticket ATR-860). However, several things make this extremely difficult at the moment. 

The mode in which Roslyn loads metadata is set by the property `CompilationOptions.MetadataImportOptions`. The default value is `MetadataImportOptions.Public`. To load all metadata it should be `MetadataImportOptions.All`. The problem is that the compilation object can't be changed in Roslyn analyzers, it is immutable. There is no API to configure compilation options for an analyzer currently. 

I found a request for such API on GitHub: https://github.com/dotnet/roslyn/issues/30723
The discussion with the Roslyn team ended up with putting the request for compilation options configuration into a backlog. 

Roslyn team sees private and internal members of external dlls as an implementation details which should not be relied upon. The code consuming the dependency should treat its private and internal members as a black box, otherwise it is a design problem.

I don't think that Acumatica framework can be viewed as such a black box. Although, it follows C# visibility rules in most cases, there are things like private graph event handlers in the application code. There also could be some other special private members that I'm not aware of. 

Still, when I tried to find a place to set compilation options to `MetadataImportOptions.All`, I found no possibility to do so.
My first approach was to use reflection to set options on an immutable `Compilation` object. However, this approach failed. 
Setting just a compilation option with reflection didn't fix the loading of private metadata. 

I have even considered the usage of the Harmony project for IL weaving and patching the code: https://github.com/pardeike/Harmony. However, there is no obvious place to patch in Roslyn sources. Moreover, there is a high change to break something by setting metadata import mode to all for every C# compilation.

There is still one approach that may work but it is too risky and too difficult to implement currently. During the initialization of each analyzer we can create a different `Compilation` object. No reflection is needed, it can be created via the regular Roslyn `WithOptions` API usage. This new compilation can be passed to `PXContext` and other analyzers. 

The main problem here is that the compilation in `PXContext` and the compilation provided by Roslyn are different. This means that type symbols provided by them are different too from the Roslyn POV, even if they represent the same type. 
In theory, we can try to replace every symbol comparison in Acuminator with a string comparison of symbol's string representations. However, this has too many cons:

- There is no guarantee that it is always possible to compare strings instead of symbols
- This goes against Roslyn best practices
- Roslyn own APIs and helpers most likely use symbol comparison. There is a very high risk that they won't work correctly.
- This will take significantly more resources. We already received complaints about Acuminator performance, this will make it worse. Loading private and internal metadata will hit Acuminator and VS performance. Plus, there will be a need for expensive creation of a new compilation object.

Therefore, I decided that it is better to just fix PX1042 diagnostic. 