### PR TITLE
ATR-863: fixed processing icon tooltip for graph extensions that add …

### DIFF
--- a/src/Acuminator/Acuminator.Vsix/Resources/VSIXResource.Designer.cs
+++ b/src/Acuminator/Acuminator.Vsix/Resources/VSIXResource.Designer.cs
@@ -682,7 +682,7 @@ namespace Acuminator.Vsix {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to A path to the file with allowed APIs that will not be reported by Acuminator even if their containing namespaces or types are contained in the &quot;Banned API File&quot; as banned.
+        ///   Looks up a localized string similar to A path to the file with allowed APIs that will not be reported by Acuminator even if their containing namespaces or types are listed in the &quot;Banned API File&quot; as banned.
         ///This option should be used together with the &quot;Banned API File&quot; setting..
         /// </summary>
         public static string Setting_BannedAPI_AllowedApiFilePath_Description {

--- a/src/Acuminator/Acuminator.Vsix/Resources/VSIXResource.Designer.cs
+++ b/src/Acuminator/Acuminator.Vsix/Resources/VSIXResource.Designer.cs
@@ -394,6 +394,15 @@ namespace Acuminator.Vsix {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to This graph extension adds a processing view.
+        /// </summary>
+        public static string CodeMap_ExtraInfo_ProcessingGraphExtensionIconTooltip {
+            get {
+                return ResourceManager.GetString("CodeMap_ExtraInfo_ProcessingGraphExtensionIconTooltip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to This is a processing graph.
         /// </summary>
         public static string CodeMap_ExtraInfo_ProcessingGraphIconTooltip {

--- a/src/Acuminator/Acuminator.Vsix/Resources/VSIXResource.resx
+++ b/src/Acuminator/Acuminator.Vsix/Resources/VSIXResource.resx
@@ -240,6 +240,9 @@
   <data name="CodeMap_ExtraInfo_PXSetupViewIconTooltip" xml:space="preserve">
     <value>This view is PXSetup or derived from it</value>
   </data>
+  <data name="CodeMap_ExtraInfo_ProcessingGraphExtensionIconTooltip" xml:space="preserve">
+    <value>This graph extension adds a processing view</value>
+  </data>
   <data name="CodeMap_ExtraInfo_ProcessingGraphIconTooltip" xml:space="preserve">
     <value>This is a processing graph</value>
   </data>
@@ -321,6 +324,13 @@
   <data name="PackageLoad_WaitMessage" xml:space="preserve">
     <value>Loading the Acuminator package</value>
   </data>
+  <data name="Setting_BannedAPI_AllowedApiFilePath_Description" xml:space="preserve">
+    <value>A path to the file with allowed APIs that will not be reported by Acuminator even if their containing namespaces or types are contained in the "Banned API File" as banned.
+This option should be used together with the "Banned API File" setting.</value>
+  </data>
+  <data name="Setting_BannedAPI_AllowedApiFilePath_Title" xml:space="preserve">
+    <value>Allowed APIs File</value>
+  </data>
   <data name="Setting_BannedAPI_BannedApiAnalysisEnabled_Description" xml:space="preserve">
     <value>Enable Acuminator PX1099 diagnostic which reports calls to API that should not be used with Acumatica Framework. </value>
   </data>
@@ -332,13 +342,6 @@
   </data>
   <data name="Setting_BannedAPI_BannedApiFilePath_Title" xml:space="preserve">
     <value>Banned APIs File</value>
-  </data>
-  <data name="Setting_BannedAPI_AllowedApiFilePath_Description" xml:space="preserve">
-    <value>A path to the file with allowed APIs that will not be reported by Acuminator even if their containing namespaces or types are contained in the "Banned API File" as banned.
-This option should be used together with the "Banned API File" setting.</value>
-  </data>
-  <data name="Setting_BannedAPI_AllowedApiFilePath_Title" xml:space="preserve">
-    <value>Allowed APIs File</value>
   </data>
   <data name="Setting_CodeAnalysis_IsvSpecificAnalyzersEnabled_Description" xml:space="preserve">
     <value>Display the diagnostics that are necessary only for ISV Solution Certification. For non-ISV solutions, these diagnostics are informational.</value>

--- a/src/Acuminator/Acuminator.Vsix/Resources/VSIXResource.resx
+++ b/src/Acuminator/Acuminator.Vsix/Resources/VSIXResource.resx
@@ -325,7 +325,7 @@
     <value>Loading the Acuminator package</value>
   </data>
   <data name="Setting_BannedAPI_AllowedApiFilePath_Description" xml:space="preserve">
-    <value>A path to the file with allowed APIs that will not be reported by Acuminator even if their containing namespaces or types are contained in the "Banned API File" as banned.
+    <value>A path to the file with allowed APIs that will not be reported by Acuminator even if their containing namespaces or types are listed in the "Banned API File" as banned.
 This option should be used together with the "Banned API File" setting.</value>
   </data>
   <data name="Setting_BannedAPI_AllowedApiFilePath_Title" xml:space="preserve">

--- a/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/Tooltips/TreeIconTooltipConverter.cs
+++ b/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/Tooltips/TreeIconTooltipConverter.cs
@@ -24,8 +24,11 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 				Icon.DacKeyField 								=> VSIXResource.CodeMap_ExtraInfo_DacKeyIconTooltip,
 				Icon.Settings 									=> VSIXResource.CodeMap_ExtraInfo_PXSetupViewIconTooltip,
 				Icon.Filter 									=> VSIXResource.CodeMap_ExtraInfo_PXFilterViewIconTooltip,
-				Icon.Processing when node is ViewNodeViewModel 	=> VSIXResource.CodeMap_ExtraInfo_ProcessingViewIconTooltip,
-				Icon.Processing when node is GraphNodeViewModel => VSIXResource.CodeMap_ExtraInfo_ProcessingGraphIconTooltip,
+				Icon.Processing when node is ViewNodeViewModel	=> VSIXResource.CodeMap_ExtraInfo_ProcessingViewIconTooltip,
+				Icon.Processing 
+				when node is GraphNodeViewModel graphVM			=> graphVM.IsGraph 
+																	? VSIXResource.CodeMap_ExtraInfo_ProcessingGraphIconTooltip
+																	: VSIXResource.CodeMap_ExtraInfo_ProcessingGraphExtensionIconTooltip,
 				Icon.ProjectionDac 								=> VSIXResource.CodeMap_ExtraInfo_ProjectionDacIndicatorTooltip,
 				Icon.ProjectionAttribute 						=> VSIXResource.CodeMap_Icon_ProjectionAttributeTooltip,
 				_ 												=> null


### PR DESCRIPTION
There is no bug with FBQL processing views. The FBQL processing views are recognized correctly, I just looked at a wrong code map tree node. 
Still, there is a small issue with a tooltip for processing icon indicator for graph extensions. Currently, it is "This is a processing graph" which is wrong for a graph extension. I changed it in scope of this item.