### PR TITLE
Bugfix/atr 878 dev support is not variable declaration in px1047 and px1048

### DIFF
--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/RowChangesInEventHandlers/EventArgsRowWalker.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/RowChangesInEventHandlers/EventArgsRowWalker.cs
@@ -16,7 +16,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.RowChangesInEventHandlers
 		/// </summary>
 		private class EventArgsRowWalker : CSharpSyntaxWalker
 		{
-			private static readonly string RowPropertyName = "Row";
+			private const string RowPropertyName = "Row";
 
 			private readonly SemanticModel _semanticModel;
 			private readonly PXContext _pxContext;

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/RowChangesInEventHandlers/EventArgsRowWalker.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/RowChangesInEventHandlers/EventArgsRowWalker.cs
@@ -1,4 +1,5 @@
-﻿
+﻿using System.Diagnostics.CodeAnalysis;
+
 using Acuminator.Utilities.Common;
 using Acuminator.Utilities.Roslyn;
 using Acuminator.Utilities.Roslyn.Semantic;
@@ -21,7 +22,10 @@ namespace Acuminator.Analyzers.StaticAnalysis.RowChangesInEventHandlers
 			private readonly SemanticModel _semanticModel;
 			private readonly PXContext _pxContext;
 
-			public bool Success { get; private set; }
+			[MemberNotNullWhen(returnValue: true, nameof(FoundRowProperty))]
+			public bool Success => FoundRowProperty != null;
+
+			public IPropertySymbol? FoundRowProperty { get; private set; }
 
 			public EventArgsRowWalker(SemanticModel semanticModel, PXContext pxContext)
 			{
@@ -31,7 +35,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.RowChangesInEventHandlers
 
 			public void Reset()
 			{
-				Success = false;
+				FoundRowProperty = null;
 			}
 
 			public override void Visit(SyntaxNode? node)
@@ -49,7 +53,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.RowChangesInEventHandlers
 
 					if (containingType != null && _pxContext.Events.EventArgTypeToEventTypeMap.ContainsKey(containingType))
 					{
-						Success = true;
+						FoundRowProperty = propertySymbol;
 					}
 				}
 			}

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/RowChangesInEventHandlers/RowChangesInEventHandlersAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/RowChangesInEventHandlers/RowChangesInEventHandlersAnalyzer.cs
@@ -57,7 +57,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.RowChangesInEventHandlers
 					methodSyntax.Accept(variablesWalker);
 
 					// Perform analysis
-					var diagnosticWalker = new DiagnosticWalker(context, semanticModel, pxContext, variablesWalker.Result,
+					var diagnosticWalker = new DiagnosticWalker(context, semanticModel, pxContext, variablesWalker.FoundRowVariables,
 						analysisMode, eventHandlerInfo.Type);
 					methodSyntax.Accept(diagnosticWalker);
 				}

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/RowChangesInEventHandlers/VariablesWalker.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/RowChangesInEventHandlers/VariablesWalker.cs
@@ -26,9 +26,9 @@ namespace Acuminator.Analyzers.StaticAnalysis.RowChangesInEventHandlers
 			private readonly HashSet<ILocalSymbol>? _variables;
 			private readonly EventArgsRowWalker _eventArgsRowWalker;
 
-			private readonly HashSet<ILocalSymbol> _result = new(SymbolEqualityComparer.Default);
+			private readonly HashSet<ILocalSymbol> _foundRowVariables = new(SymbolEqualityComparer.Default);
 
-			public ImmutableArray<ILocalSymbol> Result => _result.ToImmutableArray();
+			public ImmutableArray<ILocalSymbol> FoundRowVariables => _foundRowVariables.ToImmutableArray();
 
 			public VariablesWalker(MethodDeclarationSyntax methodSyntax, SemanticModel semanticModel, PXContext pxContext,
 				CancellationToken cancellationToken)
@@ -106,7 +106,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.RowChangesInEventHandlers
 				variableInitializerExpression.Accept(_eventArgsRowWalker);
 
 				if (_eventArgsRowWalker.Success)
-					_result.Add(variableSymbol);
+					_foundRowVariables.Add(variableSymbol);
 			}
 		}
 	}

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/RowChangesInEventHandlers/VariablesWalker.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/RowChangesInEventHandlers/VariablesWalker.cs
@@ -1,11 +1,11 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 
 using Acuminator.Utilities.Common;
-using Acuminator.Utilities.Roslyn;
 using Acuminator.Utilities.Roslyn.Semantic;
+using Acuminator.Utilities.Roslyn.Syntax;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -83,17 +83,31 @@ namespace Acuminator.Analyzers.StaticAnalysis.RowChangesInEventHandlers
 			{
 				_cancellationToken.ThrowIfCancellationRequested();
 
-				VariableDesignationSyntax? designation = isPatternExpression.Pattern switch
-				{
-					DeclarationPatternSyntax declarationPattern => declarationPattern.Designation,
-					RecursivePatternSyntax recursivePattern => recursivePattern.Designation,
-					_ => null
-				};
+				if (_variables == null)
+					return;
 
-				if (designation != null)
+				_eventArgsRowWalker.Reset();
+				isPatternExpression.Expression.Accept(_eventArgsRowWalker);
+
+				if (_eventArgsRowWalker.FoundRowProperty == null)
+					return;
+
+				IPropertySymbol rowProperty = _eventArgsRowWalker.FoundRowProperty;
+				var variableDesignations	= isPatternExpression.Pattern.GetAllVariableDesignations();
+
+				foreach (SingleVariableDesignationSyntax variableDesignation in variableDesignations)
 				{
-					var variableSymbol = _semanticModel.GetDeclaredSymbol(designation, _cancellationToken) as ILocalSymbol;
-					ValidateThatVariableIsSetToDacFromEvent(variableSymbol, isPatternExpression.Expression);
+					_cancellationToken.ThrowIfCancellationRequested();
+
+					var variableSymbol = _semanticModel.GetDeclaredSymbol(variableDesignation, _cancellationToken) as ILocalSymbol;
+
+					if (variableSymbol?.Type == null || !_variables.Contains(variableSymbol) ||
+						!variableSymbol.Type.Equals(rowProperty.Type, SymbolEqualityComparer.Default))  // Filter out variables with types different from the found property type
+					{
+						continue;
+					}
+
+					_foundRowVariables.Add(variableSymbol);
 				}
 			}
 

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/RowChangesInEventHandlers/VariablesWalker.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/RowChangesInEventHandlers/VariablesWalker.cs
@@ -1,4 +1,3 @@
-﻿
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -24,10 +23,11 @@ namespace Acuminator.Analyzers.StaticAnalysis.RowChangesInEventHandlers
 			private readonly SemanticModel _semanticModel;
 			private readonly PXContext _pxContext;
 			private CancellationToken _cancellationToken;
-			private readonly ImmutableHashSet<ILocalSymbol>? _variables;
+			private readonly HashSet<ILocalSymbol>? _variables;
 			private readonly EventArgsRowWalker _eventArgsRowWalker;
 
-			private readonly ISet<ILocalSymbol> _result = new HashSet<ILocalSymbol>(SymbolEqualityComparer.Default);
+			private readonly HashSet<ILocalSymbol> _result = new(SymbolEqualityComparer.Default);
+
 			public ImmutableArray<ILocalSymbol> Result => _result.ToImmutableArray();
 
 			public VariablesWalker(MethodDeclarationSyntax methodSyntax, SemanticModel semanticModel, PXContext pxContext,
@@ -52,10 +52,9 @@ namespace Acuminator.Analyzers.StaticAnalysis.RowChangesInEventHandlers
 						_variables = dataFlow.WrittenInside
 							.Intersect(dataFlow.VariablesDeclared, SymbolEqualityComparer.Default)
 							.OfType<ILocalSymbol>()
-							.ToImmutableHashSet<ILocalSymbol>(SymbolEqualityComparer.Default);
+							.ToHashSet<ILocalSymbol>(SymbolEqualityComparer.Default);
 					}
 				}
-
 			}
 
 			public override void VisitAssignmentExpression(AssignmentExpressionSyntax assignment)
@@ -100,7 +99,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.RowChangesInEventHandlers
 
 			private void ValidateThatVariableIsSetToDacFromEvent(ILocalSymbol? variableSymbol, ExpressionSyntax variableInitializerExpression)
 			{
-				if (variableSymbol == null || !_variables?.Contains(variableSymbol) == true)
+				if (variableSymbol == null || _variables == null || !_variables.Contains(variableSymbol))
 					return;
 
 				_eventArgsRowWalker.Reset();

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/RowChangesInEventHandlers/VariablesWalker.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/RowChangesInEventHandlers/VariablesWalker.cs
@@ -50,9 +50,8 @@ namespace Acuminator.Analyzers.StaticAnalysis.RowChangesInEventHandlers
 					if (dataFlow?.Succeeded == true)
 					{
 						_variables = dataFlow.WrittenInside
-							.Intersect(dataFlow.VariablesDeclared, SymbolEqualityComparer.Default)
-							.OfType<ILocalSymbol>()
-							.ToHashSet<ILocalSymbol>(SymbolEqualityComparer.Default);
+											 .OfType<ILocalSymbol>()
+											 .ToHashSet<ILocalSymbol>(SymbolEqualityComparer.Default);
 					}
 				}
 			}

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/RowChangesInEventHandlers/RowChangesInEventHandlersTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/RowChangesInEventHandlers/RowChangesInEventHandlersTests.cs
@@ -28,12 +28,20 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.RowChangesInEventHandlers
 		[Theory]
 		[EmbeddedFileData("IsPatternAssignment.cs")]
 		public Task IsPatternAssignment(string actual) => VerifyCSharpDiagnosticAsync(actual,
-			Descriptors.PX1047_RowChangesInEventHandlersForbiddenForArgs.CreateFor(17, 4, EventType.RowSelected),
-			Descriptors.PX1047_RowChangesInEventHandlersForbiddenForArgs.CreateFor(25, 4, EventType.FieldDefaulting),
-			Descriptors.PX1047_RowChangesInEventHandlersForbiddenForArgs.CreateFor(33, 4, EventType.FieldVerifying),
-			Descriptors.PX1047_RowChangesInEventHandlersForbiddenForArgs.CreateFor(41, 4, EventType.RowSelected),
-			Descriptors.PX1047_RowChangesInEventHandlersForbiddenForArgs.CreateFor(49, 4, EventType.FieldDefaulting),
-			Descriptors.PX1047_RowChangesInEventHandlersForbiddenForArgs.CreateFor(57, 4, EventType.FieldVerifying));
+			Descriptors.PX1047_RowChangesInEventHandlersForbiddenForArgs.CreateFor(18, 4, EventType.RowSelected),
+			Descriptors.PX1047_RowChangesInEventHandlersForbiddenForArgs.CreateFor(24, 4, EventType.RowSelected),
+			Descriptors.PX1047_RowChangesInEventHandlersForbiddenForArgs.CreateFor(30, 4, EventType.RowSelected),
+			Descriptors.PX1047_RowChangesInEventHandlersForbiddenForArgs.CreateFor(36, 4, EventType.RowSelected),
+			Descriptors.PX1047_RowChangesInEventHandlersForbiddenForArgs.CreateFor(42, 4, EventType.RowSelected),
+			Descriptors.PX1047_RowChangesInEventHandlersForbiddenForArgs.CreateFor(50, 4, EventType.RowSelected),
+			Descriptors.PX1047_RowChangesInEventHandlersForbiddenForArgs.CreateFor(56, 4, EventType.RowSelected),
+			Descriptors.PX1047_RowChangesInEventHandlersForbiddenForArgs.CreateFor(61, 5, EventType.RowSelected),
+
+			Descriptors.PX1047_RowChangesInEventHandlersForbiddenForArgs.CreateFor(71, 4, EventType.FieldDefaulting),
+			Descriptors.PX1047_RowChangesInEventHandlersForbiddenForArgs.CreateFor(79, 4, EventType.FieldVerifying),
+			Descriptors.PX1047_RowChangesInEventHandlersForbiddenForArgs.CreateFor(87, 4, EventType.RowSelected),
+			Descriptors.PX1047_RowChangesInEventHandlersForbiddenForArgs.CreateFor(95, 4, EventType.FieldDefaulting),
+			Descriptors.PX1047_RowChangesInEventHandlersForbiddenForArgs.CreateFor(103, 4, EventType.FieldVerifying));
 
 		[Theory]
 		[EmbeddedFileData("DirectAssignment.cs")]

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/RowChangesInEventHandlers/Sources/IsPatternAssignment.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/RowChangesInEventHandlers/Sources/IsPatternAssignment.cs
@@ -11,10 +11,56 @@ namespace PX.Objects
 	{
 		protected virtual void _(Events.RowSelected<SOInvoice> e)
 		{
+			// Simple "is not" pattern
 			if (e.Row is not SOInvoice invoice)
 				return;
 
-			invoice.RefNbr = "<NEW>";
+			invoice.RefNbr = "<NEW>"; // should be reported
+
+			// Recursive "is not" pattern
+			if (e.Row is not { RefNbr: { Length: 2 } } invoice2)
+				return;
+
+			invoice2.RefNbr = "<NEW>"; // should be reported
+
+			// "var" pattern
+			if (e.Row is var invoice3)
+				return;
+
+			invoice3.RefNbr = "<NEW>"; // should be reported
+
+			// "is not var" pattern, although never true, should produce a warning
+			if (e.Row is not var invoice4)
+				return;
+
+			invoice4.RefNbr = "<NEW>"; // should be reported
+
+			// parenthesized "var" pattern
+			if ((e.Row, true) is var (invoice5, flag))
+				return;
+
+			invoice5.RefNbr = "<NEW>"; // should be reported
+
+			// positional pattern
+			bool flag2 = true;
+
+			if ((e.Row, flag2) is ({ } invoice6, true) { Row.RefNbr: { } })
+				return;
+
+			invoice6.RefNbr = "<NEW>"; // should be reported
+
+			// binary and relation patterns
+			if (e.Row is not ({ RefNbr.Length: > 2 } and { RefNbr.Length: < 5 } invoice7))
+				return;
+
+			invoice7.RefNbr = "<NEW>"; // should be reported
+
+			// Parenthesized pattern
+			if (e.Row is (SOInvoice invoice8))
+			{
+				invoice8.RefNbr = "<NEW>"; // should be reported
+				return;
+			}
 		}
 
 		protected virtual void _(Events.FieldDefaulting<SOInvoice, SOInvoice.refNbr> e)

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/RowChangesInEventHandlers/Sources/IsPatternAssignment.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/RowChangesInEventHandlers/Sources/IsPatternAssignment.cs
@@ -11,7 +11,7 @@ namespace PX.Objects
 	{
 		protected virtual void _(Events.RowSelected<SOInvoice> e)
 		{
-			if (!(e.Row is SOInvoice invoice))
+			if (e.Row is not SOInvoice invoice)
 				return;
 
 			invoice.RefNbr = "<NEW>";

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/RowChangesInEventHandlers/Sources/Reversed/IsPatternAssignment.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/RowChangesInEventHandlers/Sources/Reversed/IsPatternAssignment.cs
@@ -13,7 +13,7 @@ namespace PX.Objects
 
 		protected virtual void _(Events.RowInserting<SOInvoice> e)
 		{
-			if (!(e.Row is SOInvoice invoice))
+			if (e.Row is not SOInvoice invoice)
 				return;
 
 			invoice.RefNbr = "<NEW>"; // should be OK

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/RowChangesInEventHandlers/Sources/Reversed/IsPatternAssignment.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/RowChangesInEventHandlers/Sources/Reversed/IsPatternAssignment.cs
@@ -13,10 +13,56 @@ namespace PX.Objects
 
 		protected virtual void _(Events.RowInserting<SOInvoice> e)
 		{
+			// Simple "is not" pattern
 			if (e.Row is not SOInvoice invoice)
 				return;
 
 			invoice.RefNbr = "<NEW>"; // should be OK
+
+			// Recursive "is not" pattern
+			if (e.Row is not { RefNbr: { Length: 2 } } invoice2)
+				return;
+
+			invoice2.RefNbr = "<NEW>"; // should be OK
+
+			// "var" pattern
+			if (e.Row is var invoice3)
+				return;
+
+			invoice3.RefNbr = "<NEW>"; // should be OK
+
+			// "is not var" pattern, although never true, should not produce a warning
+			if (e.Row is not var invoice4)
+				return;
+
+			invoice4.RefNbr = "<NEW>"; // should be OK
+
+			// parenthesized "var" pattern
+			if ((e.Row, true) is var (invoice5, flag))
+				return;
+
+			invoice5.RefNbr = "<NEW>"; // should be OK
+
+			// positional pattern
+			bool flag2 = true;
+
+			if ((e.Row, flag2) is ({ } invoice6 , true ) { Row.RefNbr: { } })
+				return;
+
+			invoice6.RefNbr = "<NEW>"; // should be OK
+
+			// binary and relation patterns
+			if (e.Row is not ({RefNbr.Length: > 2 } and { RefNbr.Length: < 5 } invoice7))
+				return;
+
+			invoice7.RefNbr = "<NEW>"; // should be OK
+
+			// Parenthesized pattern
+			if (e.Row is (SOInvoice invoice8))
+			{
+				invoice8.RefNbr = "<NEW>"; // should be OK
+				return;
+			}
 		}
 
 		protected virtual void _(Events.RowSelecting<SOInvoice> e)
@@ -40,7 +86,7 @@ namespace PX.Objects
 			if (!(e.Row is { RefNbr: { } } row))
 				return;
 
-			row.RefNbr = "<NEW>" // should be OK
+			row.RefNbr = "<NEW>"; // should be OK
 		}
 	}
 

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Syntax/RoslynSyntaxUtils.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Syntax/RoslynSyntaxUtils.cs
@@ -118,15 +118,10 @@ namespace Acuminator.Utilities.Roslyn.Syntax
 		/// </returns>
 		public static Task<SyntaxNode?> GetSyntaxAsync(this ISymbol? symbol, CancellationToken cancellationToken = default)
 		{
-			if (symbol == null)
+			if (symbol == null || !symbol.IsInSourceCode())
 				return Task.FromResult<SyntaxNode?>(null);
 
-			var declarations = symbol.DeclaringSyntaxReferences;
-
-			if (declarations.Length == 0)
-				return Task.FromResult<SyntaxNode?>(null);
-
-			return declarations[0].GetSyntaxAsync(cancellationToken)!;
+			return symbol.DeclaringSyntaxReferences[0].GetSyntaxAsync(cancellationToken)!;
 		}
 
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -357,6 +352,120 @@ namespace Acuminator.Utilities.Roslyn.Syntax
 			}
 
 			return regionTrivias;
+		}
+
+		public static IEnumerable<SingleVariableDesignationSyntax> GetAllVariableDesignations(this PatternSyntax? pattern)
+		{
+			switch (pattern)
+			{
+				case DeclarationPatternSyntax declarationPattern:
+					return declarationPattern.Designation.GetSingleVariableDesignations();
+
+				case UnaryPatternSyntax unaryPattern:
+					return unaryPattern.Pattern.GetAllVariableDesignations();
+
+				case VarPatternSyntax varPattern:
+					return varPattern.Designation.GetSingleVariableDesignations();
+
+				case ParenthesizedPatternSyntax parenthesizedPattern:
+					return parenthesizedPattern.Pattern.GetAllVariableDesignations();
+
+				case RecursivePatternSyntax recursivePattern:
+					IEnumerable<SingleVariableDesignationSyntax>? allSingleVariableDesignations = null;
+
+					if (recursivePattern.PositionalPatternClause?.Subpatterns.Count > 0)
+					{
+						var positionalPatternDesignations =
+							recursivePattern.PositionalPatternClause.Subpatterns
+																	.SelectMany(subpattern => subpattern.Pattern.GetAllVariableDesignations());
+						allSingleVariableDesignations = positionalPatternDesignations;
+					}
+
+					if (recursivePattern.PropertyPatternClause?.Subpatterns.Count > 0)
+					{
+						var propertyPatternDesignations =
+							recursivePattern.PropertyPatternClause.Subpatterns
+																  .SelectMany(subpattern => subpattern.Pattern.GetAllVariableDesignations());
+						allSingleVariableDesignations = allSingleVariableDesignations?.Concat(propertyPatternDesignations) ?? propertyPatternDesignations;
+					}
+					
+					var ownRecursivePatternDesignations = recursivePattern.Designation.GetSingleVariableDesignations();
+					allSingleVariableDesignations = allSingleVariableDesignations?.Concat(ownRecursivePatternDesignations) ?? ownRecursivePatternDesignations;
+					return allSingleVariableDesignations;
+
+				case BinaryPatternSyntax binaryPattern:
+					var designationsFromLeftPattern = binaryPattern.Left.GetAllVariableDesignations();
+					var designationsFromRightPattern = binaryPattern.Right.GetAllVariableDesignations();
+
+					return designationsFromLeftPattern.Concat(designationsFromRightPattern);
+
+				case ConstantPatternSyntax constantPattern:
+				case DiscardPatternSyntax discardPattern:
+				case RelationalPatternSyntax relationalPattern:
+				case TypePatternSyntax typePattern:
+					return [];
+
+				// List patterns are not supported by this version of Roslyn. After upgrade to a new Roslyn version we will need to support them.
+				//case Microsoft.CodeAnalysis.CSharp.Syntax.ListPatternSyntax:
+				//case Microsoft.CodeAnalysis.CSharp.Syntax.SlicePatternSyntax:
+				default:
+					return [];
+			}			
+		}
+
+		public static IEnumerable<SingleVariableDesignationSyntax> GetSingleVariableDesignations(this VariableDesignationSyntax? variableDesignation)
+		{
+			switch (variableDesignation)
+			{
+				case SingleVariableDesignationSyntax singleVariableDesignation:
+					return [singleVariableDesignation];
+				
+				case ParenthesizedVariableDesignationSyntax multipleVariablesDesignation:
+					return multipleVariablesDesignation.Variables.Count switch
+					{
+						0 => [],
+						1 => GetSingleVariableDesignations(multipleVariablesDesignation.Variables[0]),
+						_ => GetSingleVariablesFromMultipleVariablesDesignation(multipleVariablesDesignation, recursionLevel: 0)
+					};
+
+				case DiscardDesignationSyntax:
+				default:
+					return [];
+			}
+
+			//----------------------------------------------------Local Function---------------------------------------------------------------
+			static IEnumerable<SingleVariableDesignationSyntax> GetSingleVariablesFromMultipleVariablesDesignation(
+																			ParenthesizedVariableDesignationSyntax multipleVariablesDesignation,
+																			int recursionLevel)
+			{
+				const int maxRecursionLevel = 100;
+				var variables = multipleVariablesDesignation.Variables;
+
+				for (int i = 0; i < variables.Count; i++)
+				{
+					var variable = variables[i];
+
+					switch (variable)
+					{
+						case SingleVariableDesignationSyntax singleVariable:
+							yield return singleVariable;
+							continue;
+
+						case ParenthesizedVariableDesignationSyntax nestedMultipleVariablesDesignation
+						when recursionLevel <= maxRecursionLevel:
+							var singleVariables = GetSingleVariablesFromMultipleVariablesDesignation(nestedMultipleVariablesDesignation, recursionLevel + 1);
+
+							foreach (SingleVariableDesignationSyntax nestedSingleVariable in singleVariables)
+								yield return nestedSingleVariable;
+
+							continue;
+
+						case DiscardDesignationSyntax:
+						default:
+							continue;
+					}
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
Changes Overview:
- added recursive extension method that retrieves all variables declared by the C# pattern
- added support for different C# patterns to PX1047 and PX1048
- added unit tests for different C# patterns with assignments
- minor refactoring