### PR TITLE
Bugfix/atr 874 dev extend px1073 with field updating

### DIFF
--- a/docs/Summary.md
+++ b/docs/Summary.md
@@ -79,7 +79,7 @@ Acuminator does not perform static analysis of projects whose names contain `Tes
 | [PX1070](diagnostics/PX1070.md) | The state of fields and actions can be configured only in `RowSelected` event handlers. | Error | Unavailable |
 | [PX1071](diagnostics/PX1071.md) | Actions cannot be executed within event handlers. | Error | Unavailable |
 | [PX1072](diagnostics/PX1072.md) | BQL queries must be executed within the context of an existing `PXGraph` instance. | Warning (ISV Level 1: Significant) | Available |
-| [PX1073](diagnostics/PX1073.md) | Exceptions cannot be thrown in `RowPersisted` and `FieldUpdating` event handlers. | Error | Unavailable |
+| [PX1073](diagnostics/PX1073.md) | Exceptions cannot be thrown in the `RowPersisted` and `FieldUpdating` event handlers. | Error | Unavailable |
 | [PX1074](diagnostics/PX1074.md) | `PXSetupNotEnteredException` cannot be thrown in any event handlers except for the `RowSelected` event handlers. | Warning (ISV Level 1: Significant) | Unavailable |
 | [PX1075](diagnostics/PX1075.md) | `PXCache.RaiseExceptionHandling` cannot be invoked from the `FieldDefaulting`, `FieldSelecting`, `RowSelecting`, and `RowPersisted` event handlers. | Error | Unavailable |
 | [PX1076](diagnostics/PX1076.md) | This code calls Acumatica internal API marked with PXInternalUseOnlyAttribute which is not intended for public use | Warning | Unavailable |

--- a/docs/Summary.md
+++ b/docs/Summary.md
@@ -79,7 +79,7 @@ Acuminator does not perform static analysis of projects whose names contain `Tes
 | [PX1070](diagnostics/PX1070.md) | The state of fields and actions can be configured only in `RowSelected` event handlers. | Error | Unavailable |
 | [PX1071](diagnostics/PX1071.md) | Actions cannot be executed within event handlers. | Error | Unavailable |
 | [PX1072](diagnostics/PX1072.md) | BQL queries must be executed within the context of an existing `PXGraph` instance. | Warning (ISV Level 1: Significant) | Available |
-| [PX1073](diagnostics/PX1073.md) | Exceptions cannot be thrown in the `RowPersisted` event handlers. | Error | Unavailable |
+| [PX1073](diagnostics/PX1073.md) | Exceptions cannot be thrown in `RowPersisted` and `FieldUpdating` event handlers. | Error | Unavailable |
 | [PX1074](diagnostics/PX1074.md) | `PXSetupNotEnteredException` cannot be thrown in any event handlers except for the `RowSelected` event handlers. | Warning (ISV Level 1: Significant) | Unavailable |
 | [PX1075](diagnostics/PX1075.md) | `PXCache.RaiseExceptionHandling` cannot be invoked from the `FieldDefaulting`, `FieldSelecting`, `RowSelecting`, and `RowPersisted` event handlers. | Error | Unavailable |
 | [PX1076](diagnostics/PX1076.md) | This code calls Acumatica internal API marked with PXInternalUseOnlyAttribute which is not intended for public use | Warning | Unavailable |

--- a/docs/diagnostics/PX1073.md
+++ b/docs/diagnostics/PX1073.md
@@ -5,7 +5,7 @@ This document describes the PX1073 diagnostic.
 
 | Code   | Short Description                                                                      | Type  | Code Fix    | 
 | ------ | --------------------------------------------------------------------------------- | ----- | ----------- | 
-| PX1073 | Exceptions cannot be thrown in `RowPersisted` and `FieldUpdating` event handlers. | Error | Unavailable |
+| PX1073 | Exceptions cannot be thrown in the `RowPersisted` and `FieldUpdating` event handlers. | Error | Unavailable |
 
 ## Diagnostic Description
 No exceptions of any type can be thrown in the `RowPersisted` and `FieldUpdating` event handlers. 
@@ -30,20 +30,20 @@ The diagnostic does not show an error for the exception thrown in the `RowPersis
      - .NET exceptions from the System namespace: `NotImplementedException`, `NotSupportedException`, `ArgumentException` (including its descendants `ArgumentNullException` and `ArgumentOutOfRangeException`)
  
 ## FieldUpdating
-The `FieldUpdating` event handler can be used to tranform the external representation of a value obtained from the UI or Web API into an internal representation stored in a DAC field. The hadnler is used when:
+The `FieldUpdating` event handler can be used to transform the external representation of a value obtained from the UI or Web API into an internal representation stored in a DAC field. The handler is used in the following cases:
 - The external presentation of a DAC field (the value displayed in the UI) differs from the value stored in the DAC.
-- The storage of values is spread among multiple DAC fields (database columns).
+- The storage of values is spread across multiple DAC fields (database columns).
 
-Field updating event is usually raised for external updates of DAC field's value such as updates from the UI and Web API. This means that this event won't be raised for some scenarios in which other Acumatica field events will be fired.
-Here are some of such scenarios:
+A field updating event is usually raised for external updates of a DAC field value, for example, updates from the UI and Web API. This means that this event is not raised for some scenarios in which other Acumatica field events are fired.
+Scenarios that do not fire the field updating event include the following:
 - Calls from the application code to the `PXCache.Update(object row)` method
 - Calls from the application code to the `PXCache.Delete(object row)` method
  
-Exceptions throwing in a field updating event handler is usually related to the validation logic declared in the event handler. Placing validation logic into a field updating event handler is risky 
-because the validation won't be performed in all possible scenarios. Skipping the validation may leave the modified DAC field in an inconsistent state. You should move your logic to the `FieldVerifying` event handler which is a proper
-place for a validation of DAC field values.
+Exceptions that are thrown in a field updating event handler are usually related to the validation logic declared in the event handler. Placing validation logic into a field updating event handler is risky 
+because the validation will not be performed in all possible scenarios. Skipping the validation may leave the modified DAC field in an inconsistent state. You should move your logic to the `FieldVerifying` event handler which is a proper
+the proper place for validation of DAC field values.
 
-The PX1073 diagnostic does not report an exception thrown in the `FieldUpdating` event handler if its type belongs to one of the following types, or derived from them:
+The PX1073 diagnostic does not report an exception thrown in the `FieldUpdating` event handler if the exception type belongs to one of the following types or is derived from them:
 - .NET exceptions from the System namespace: `NotImplementedException`, `NotSupportedException`, `ArgumentException` (including its descendants `ArgumentNullException` and `ArgumentOutOfRangeException`)
 
 ## Example of Incorrect Code

--- a/docs/diagnostics/PX1073.md
+++ b/docs/diagnostics/PX1073.md
@@ -3,13 +3,14 @@ This document describes the PX1073 diagnostic.
 
 ## Summary
 
-| Code   | Short Description                                                 | Type  | Code Fix    | 
-| ------ | ----------------------------------------------------------------- | ----- | ----------- | 
-| PX1073 | Exceptions cannot be thrown in the `RowPersisted` event handlers. | Error | Unavailable |
+| Code   | Short Description                                                                      | Type  | Code Fix    | 
+| ------ | --------------------------------------------------------------------------------- | ----- | ----------- | 
+| PX1073 | Exceptions cannot be thrown in `RowPersisted` and `FieldUpdating` event handlers. | Error | Unavailable |
 
 ## Diagnostic Description
-No exceptions of any type can be thrown in the `RowPersisted` event handlers. 
+No exceptions of any type can be thrown in the `RowPersisted` and `FieldUpdating` event handlers. 
 
+## RowPersisted
 The `RowPersisted` event handlers can be used for the following purposes:
 
  - Retrieval of the data from the database
@@ -28,6 +29,23 @@ The diagnostic does not show an error for the exception thrown in the `RowPersis
      - `PX.Data.PXLockViolationException`
      - .NET exceptions from the System namespace: `NotImplementedException`, `NotSupportedException`, `ArgumentException` (including its descendants `ArgumentNullException` and `ArgumentOutOfRangeException`)
  
+## FieldUpdating
+The `FieldUpdating` event handler can be used to tranform the external representation of a value obtained from the UI or Web API into an internal representation stored in a DAC field. The hadnler is used when:
+- The external presentation of a DAC field (the value displayed in the UI) differs from the value stored in the DAC.
+- The storage of values is spread among multiple DAC fields (database columns).
+
+Field updating event is usually raised for external updates of DAC field's value such as updates from the UI and Web API. This means that this event won't be raised for some scenarios in which other Acumatica field events will be fired.
+Here are some of such scenarios:
+- Calls from the application code to the `PXCache.Update(object row)` method
+- Calls from the application code to the `PXCache.Delete(object row)` method
+ 
+Exceptions throwing in a field updating event handler is usually related to the validation logic declared in the event handler. Placing validation logic into a field updating event handler is risky 
+because the validation won't be performed in all possible scenarios. Skipping the validation may leave the modified DAC field in an inconsistent state. You should move your logic to the `FieldVerifying` event handler which is a proper
+place for a validation of DAC field values.
+
+The PX1073 diagnostic does not report an exception thrown in the `FieldUpdating` event handler if its type belongs to one of the following types, or derived from them:
+- .NET exceptions from the System namespace: `NotImplementedException`, `NotSupportedException`, `ArgumentException` (including its descendants `ArgumentNullException` and `ArgumentOutOfRangeException`)
+
 ## Example of Incorrect Code
 
 ```C#
@@ -52,6 +70,7 @@ protected virtual void SOOrderLine_RowPersisted(PXCache sender, PXRowPersistedEv
 
 ## Related Articles
 
- - [RowPersisted](https://help.acumatica.com/Help?ScreenId=ShowWiki&pageid=ac686a56-ea6d-5ece-1063-a2842fb9aaa0)
- - [RowPersisting](https://help.acumatica.com/Help?ScreenId=ShowWiki&pageid=d302caf7-87a4-d7e4-65b3-c463f4d62ee3)
+ - [RowPersisted](https://help.acumatica.com/Help?ScreenId=ShowWiki&pageid=ad836991-2430-630a-3a9b-557a11e78b54)
+ - [RowPersisting](https://help.acumatica.com/Help?ScreenId=ShowWiki&pageid=ad836991-2430-630a-3a9b-557a11e78b54)
+ - [FieldUpdating](https://help.acumatica.com/Help?ScreenId=ShowWiki&pageid=3c049ef0-60f1-c3cd-85c5-21650654c5aa)
  - [Data Manipulation Scenarios](https://help.acumatica.com/Help?ScreenId=ShowWiki&pageid=d9cf6274-f5c8-43e7-9d13-9b423113d67e)

--- a/src/Acuminator/Acuminator.Analyzers/DiagnosticsShortName.Designer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/DiagnosticsShortName.Designer.cs
@@ -763,11 +763,20 @@ namespace Acuminator.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to ExceptionsInFieldUpdating.
+        /// </summary>
+        public static string PX1073FieldUpdating {
+            get {
+                return ResourceManager.GetString("PX1073FieldUpdating", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to ExceptionsInRowPersisted.
         /// </summary>
-        public static string PX1073 {
+        public static string PX1073RowPersisted {
             get {
-                return ResourceManager.GetString("PX1073", resourceCulture);
+                return ResourceManager.GetString("PX1073RowPersisted", resourceCulture);
             }
         }
         

--- a/src/Acuminator/Acuminator.Analyzers/DiagnosticsShortName.resx
+++ b/src/Acuminator/Acuminator.Analyzers/DiagnosticsShortName.resx
@@ -351,7 +351,10 @@
   <data name="PX1072" xml:space="preserve">
     <value>PXGraphCreationForBqlQueries</value>
   </data>
-  <data name="PX1073" xml:space="preserve">
+  <data name="PX1073FieldUpdating" xml:space="preserve">
+    <value>ExceptionsInFieldUpdating</value>
+  </data>
+  <data name="PX1073RowPersisted" xml:space="preserve">
     <value>ExceptionsInRowPersisted</value>
   </data>
   <data name="PX1074" xml:space="preserve">
@@ -365,6 +368,12 @@
   </data>
   <data name="PX1077" xml:space="preserve">
     <value>EventHandlersShouldBeProtectedVirtual</value>
+  </data>
+  <data name="PX1078_DifferentType" xml:space="preserve">
+    <value>TypesOfDacFieldAndReferencedFieldMismatch</value>
+  </data>
+  <data name="PX1078_DifferentTypeSize" xml:space="preserve">
+    <value>TypesOfDacFieldAndReferencedFieldHaveDifferentSize</value>
   </data>
   <data name="PX1080" xml:space="preserve">
     <value>LongRunOperationInDataViewDelegate</value>
@@ -422,11 +431,5 @@
   </data>
   <data name="PX1099" xml:space="preserve">
     <value>UsageOfForbiddenApi</value>
-  </data>
-  <data name="PX1078_DifferentType" xml:space="preserve">
-    <value>TypesOfDacFieldAndReferencedFieldMismatch</value>
-  </data>
-  <data name="PX1078_DifferentTypeSize" xml:space="preserve">
-    <value>TypesOfDacFieldAndReferencedFieldHaveDifferentSize</value>
   </data>
 </root>

--- a/src/Acuminator/Acuminator.Analyzers/Resources.Designer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/Resources.Designer.cs
@@ -241,7 +241,12 @@ namespace Acuminator.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Incorrect XML documentation of the projection DAC field property. The &lt;inheritdoc/&gt; tag with `cref` attribute should be used for a mapped DAC field property of the projection DAC.The `cref` attribute should reference the original DAC field property from the projection field&apos;s mapping:/// &lt;inheritdoc cref=&quot;OriginalDac.SomeDacField&quot;/&gt;[PXDBInt(BqlField = typeof(OriginalDac.someDacField))]public virtual int? SomeDacField{ get; set; }.
+        ///   Looks up a localized string similar to Incorrect XML documentation of the projection DAC field property. The &lt;inheritdoc/&gt; tag with `cref` attribute should be used for a mapped DAC field property of the projection DAC.
+        ///The `cref` attribute should reference the original DAC field property from the projection field&apos;s mapping:
+        ///
+        ////// &lt;inheritdoc cref=&quot;OriginalDac.SomeDacField&quot;/&gt;
+        ///[PXDBInt(BqlField = typeof(OriginalDac.someDacField))]
+        ///public virtual int? SomeDacField{ get; set; }.
         /// </summary>
         public static string PX1007Title_IncorrectProjectionDacFieldDescription {
             get {
@@ -871,7 +876,11 @@ namespace Acuminator.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to public class ReferencedDacFK : CompositeKey&lt;											   Field&lt;joinField1&gt;.IsRelatedTo&lt;ReferencedDAC.keyField1&gt;,											   Field&lt;joinField2&gt;.IsRelatedTo&lt;ReferencedDAC.keyField2&gt;,											  ...											  &gt;.WithTablesOf&lt;SOOrder, SOOrder&gt; {{ }}.
+        ///   Looks up a localized string similar to public class ReferencedDacFK : CompositeKey&lt;
+        ///											   Field&lt;joinField1&gt;.IsRelatedTo&lt;ReferencedDAC.keyField1&gt;,
+        ///											   Field&lt;joinField2&gt;.IsRelatedTo&lt;ReferencedDAC.keyField2&gt;,
+        ///											  ...
+        ///											  &gt;.WithTablesOf&lt;SOOrder, SOOrder&gt; {{ }}.
         /// </summary>
         public static string PX1034FixTemplateLine6 {
             get {
@@ -1654,11 +1663,20 @@ namespace Acuminator.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Exceptions cannot be thrown in the FieldUpdating event handler.
+        /// </summary>
+        public static string PX1073TitleFieldUpdating {
+            get {
+                return ResourceManager.GetString("PX1073TitleFieldUpdating", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Exceptions cannot be thrown in the RowPersisted event handler.
         /// </summary>
-        public static string PX1073Title {
+        public static string PX1073TitleRowPersisted {
             get {
-                return ResourceManager.GetString("PX1073Title", resourceCulture);
+                return ResourceManager.GetString("PX1073TitleRowPersisted", resourceCulture);
             }
         }
         
@@ -1753,17 +1771,7 @@ namespace Acuminator.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to DAC field &quot;{0}&quot; have data type attribute(s) incompatible with type &quot;{1}&quot; of referenced field &quot;{2}&quot;.
-        /// </summary>
-        public static string PX1078MessageFormat_TypeOfReferencedFieldIsIncompatibleWithDataTypeAnnotationsOfDacField {
-            get {
-                return ResourceManager.GetString("PX1078MessageFormat_TypeOfReferencedFieldIsIncompatibleWithDataTypeAnnotationsOfD" +
-                        "acField", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to DAC field &quot;{0}&quot; and referenced field &quot;{1}&quot; have different length specified in data type attribute. Expected length for DAC field is {2}..
+        ///   Looks up a localized string similar to The &quot;{0}&quot; DAC field and the &quot;{1}&quot; referenced field have different sizes specified in the data type attribute. The expected size of the DAC field is {2}..
         /// </summary>
         public static string PX1078MessageFormat_TypesOfDacFieldAndReferencedFieldHaveDifferentSize {
             get {
@@ -1772,7 +1780,7 @@ namespace Acuminator.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to DAC field &quot;{0}&quot; and referenced field &quot;{1}&quot; have different types. Expected type for the DAC field is {2}..
+        ///   Looks up a localized string similar to The &quot;{0}&quot; DAC field and the &quot;{1}&quot; referenced field have different types. The expected type for the DAC field is {2}..
         /// </summary>
         public static string PX1078MessageFormat_TypesOfDacFieldAndReferencedFieldMismatch {
             get {
@@ -1781,16 +1789,7 @@ namespace Acuminator.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to DAC field has at least one data type attribute which is incompatible with type of referenced field.
-        /// </summary>
-        public static string PX1078Title_TypeOfReferencedFieldIsIncompatibleWithDataTypeAnnotationsOfDacField {
-            get {
-                return ResourceManager.GetString("PX1078Title_TypeOfReferencedFieldIsIncompatibleWithDataTypeAnnotationsOfDacField", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to DAC field and referenced field have different size.
+        ///   Looks up a localized string similar to DAC field and referenced field have different sizes.
         /// </summary>
         public static string PX1078Title_TypesOfDacFieldAndReferencedFieldHaveDifferentSize {
             get {
@@ -2087,7 +2086,8 @@ namespace Acuminator.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The forbidden {0} &quot;{1}&quot; is used.Reason: {2}.
+        ///   Looks up a localized string similar to The forbidden {0} &quot;{1}&quot; is used.
+        ///Reason: {2}.
         /// </summary>
         public static string PX1099TitleFormatWithReason {
             get {

--- a/src/Acuminator/Acuminator.Analyzers/Resources.resx
+++ b/src/Acuminator/Acuminator.Analyzers/Resources.resx
@@ -657,8 +657,11 @@ public virtual int? SomeDacField{ get; set; }</value>
   <data name="PX1072Title_ReuseExistingGraphVariable" xml:space="preserve">
     <value>BQL queries must be executed within the context of an existing PXGraph instance</value>
   </data>
-  <data name="PX1073Title" xml:space="preserve">
+  <data name="PX1073TitleRowPersisted" xml:space="preserve">
     <value>Exceptions cannot be thrown in the RowPersisted event handler</value>
+  </data>
+  <data name="PX1073TitleFieldUpdating" xml:space="preserve">
+    <value>Exceptions cannot be thrown in the FieldUpdating event handler</value>
   </data>
   <data name="PX1074MessageFormat" xml:space="preserve">
     <value>PXSetupNotEnteredException cannot be thrown in the {0} event handler. Use the RowSelected event handler instead.</value>
@@ -689,6 +692,18 @@ public virtual int? SomeDacField{ get; set; }</value>
   </data>
   <data name="PX1077Title_ExplicitInterfaceImplementation" xml:space="preserve">
     <value>Event handlers should not be explicit interface implementations</value>
+  </data>
+  <data name="PX1078MessageFormat_TypesOfDacFieldAndReferencedFieldHaveDifferentSize" xml:space="preserve">
+    <value>The "{0}" DAC field and the "{1}" referenced field have different sizes specified in the data type attribute. The expected size of the DAC field is {2}.</value>
+  </data>
+  <data name="PX1078MessageFormat_TypesOfDacFieldAndReferencedFieldMismatch" xml:space="preserve">
+    <value>The "{0}" DAC field and the "{1}" referenced field have different types. The expected type for the DAC field is {2}.</value>
+  </data>
+  <data name="PX1078Title_TypesOfDacFieldAndReferencedFieldHaveDifferentSize" xml:space="preserve">
+    <value>DAC field and referenced field have different sizes</value>
+  </data>
+  <data name="PX1078Title_TypesOfDacFieldAndReferencedFieldMismatch" xml:space="preserve">
+    <value>DAC field and referenced field have different types</value>
   </data>
   <data name="PX1080Title" xml:space="preserve">
     <value>Data view delegates should not start long-running operations</value>
@@ -798,17 +813,5 @@ Reason: {2}</value>
   </data>
   <data name="SuppressDiagnosticWithCommentNonNestedCodeActionTitle" xml:space="preserve">
     <value>Suppress the {0} diagnostic with Acuminator in a comment</value>
-  </data>
-  <data name="PX1078MessageFormat_TypesOfDacFieldAndReferencedFieldMismatch" xml:space="preserve">
-    <value>The "{0}" DAC field and the "{1}" referenced field have different types. The expected type for the DAC field is {2}.</value>
-  </data>
-  <data name="PX1078MessageFormat_TypesOfDacFieldAndReferencedFieldHaveDifferentSize" xml:space="preserve">
-    <value>The "{0}" DAC field and the "{1}" referenced field have different sizes specified in the data type attribute. The expected size of the DAC field is {2}.</value>
-  </data>
-  <data name="PX1078Title_TypesOfDacFieldAndReferencedFieldHaveDifferentSize" xml:space="preserve">
-    <value>DAC field and referenced field have different sizes</value>
-  </data>
-  <data name="PX1078Title_TypesOfDacFieldAndReferencedFieldMismatch" xml:space="preserve">
-    <value>DAC field and referenced field have different types</value>
   </data>
 </root>

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/Descriptors.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/Descriptors.cs
@@ -395,10 +395,13 @@ namespace Acuminator.Analyzers.StaticAnalysis
 			Rule("PX1072", nameof(Resources.PX1072Title_CreateSharedGraphVariable).GetLocalized(), Category.Acuminator, DiagnosticSeverity.Warning, DiagnosticsShortName.PX1072);
 
 		public static DiagnosticDescriptor PX1073_ThrowingExceptionsInRowPersisted { get; } =
-			Rule("PX1073", nameof(Resources.PX1073Title).GetLocalized(), Category.Acuminator, DiagnosticSeverity.Error, DiagnosticsShortName.PX1073);
+			Rule("PX1073", nameof(Resources.PX1073TitleRowPersisted).GetLocalized(), Category.Acuminator, DiagnosticSeverity.Error, DiagnosticsShortName.PX1073RowPersisted);
 
 		public static DiagnosticDescriptor PX1073_ThrowingExceptionsInRowPersisted_NonISV { get; } =
-			Rule("PX1073", nameof(Resources.PX1073Title).GetLocalized(), Category.Acuminator, DiagnosticSeverity.Warning, DiagnosticsShortName.PX1073);
+			Rule("PX1073", nameof(Resources.PX1073TitleRowPersisted).GetLocalized(), Category.Acuminator, DiagnosticSeverity.Warning, DiagnosticsShortName.PX1073RowPersisted);
+
+		public static DiagnosticDescriptor PX1073_ThrowingExceptionsInFieldUpdating { get; } =
+			Rule("PX1073", nameof(Resources.PX1073TitleFieldUpdating).GetLocalized(), Category.Acuminator, DiagnosticSeverity.Warning, DiagnosticsShortName.PX1073FieldUpdating);
 
 		public static DiagnosticDescriptor PX1074_ThrowingSetupNotEnteredExceptionInEventHandlers { get; } =
 			Rule("PX1074", nameof(Resources.PX1074Title).GetLocalized(), Category.Acuminator, DiagnosticSeverity.Warning,

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/ThrowingExceptions/ThrowingExceptionsInEventHandlersAnalyzer.ThrowInEventsWalker.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/ThrowingExceptions/ThrowingExceptionsInEventHandlersAnalyzer.ThrowInEventsWalker.cs
@@ -84,6 +84,12 @@ namespace Acuminator.Analyzers.StaticAnalysis.ThrowingExceptions
 					isReported = true;
 				}
 
+				if (_eventType == EventType.FieldUpdating)
+				{
+					ReportDiagnostic(_context.ReportDiagnostic, Descriptors.PX1073_ThrowingExceptionsInFieldUpdating, throwNodeToReport);
+					isReported = true;
+				}
+
 				if (_eventType != EventType.RowSelected && IsPXSetupNotEnteredException(expressionAfterThrowkeyword))
 				{
 					ReportDiagnostic(_context.ReportDiagnostic,

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/ThrowingExceptions/ThrowingExceptionsInEventHandlersAnalyzer.ThrowInEventsWalker.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/ThrowingExceptions/ThrowingExceptionsInEventHandlersAnalyzer.ThrowInEventsWalker.cs
@@ -41,11 +41,13 @@ namespace Acuminator.Analyzers.StaticAnalysis.ThrowingExceptions
 		{
 			private readonly EventType _eventType;
 			private readonly List<ITypeSymbol> _exceptionTypesAllowedInRowPersisted;
+			private readonly List<ITypeSymbol> _exceptionTypesAllowedInFieldUpdating;
 
 			public ThrowInEventsWalker(SymbolAnalysisContext context, PXContext pxContext, EventType eventType) : base(context, pxContext)
 			{
 				_eventType = eventType;
-				_exceptionTypesAllowedInRowPersisted = GetExceptionTypesAllowdInRowPersisted(pxContext);
+				_exceptionTypesAllowedInRowPersisted = GetExceptionTypesAllowedInRowPersisted(pxContext);
+				_exceptionTypesAllowedInFieldUpdating = GetExceptionTypesAllowedInFieldUpdating(pxContext);
 			}
 
 			public override void VisitThrowExpression(ThrowExpressionSyntax throwExpression)
@@ -84,7 +86,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.ThrowingExceptions
 					isReported = true;
 				}
 
-				if (_eventType == EventType.FieldUpdating)
+				if (_eventType == EventType.FieldUpdating && !IsThrowingOfThisExceptionInFieldUpdatingAllowed(expressionAfterThrowkeyword))
 				{
 					ReportDiagnostic(_context.ReportDiagnostic, Descriptors.PX1073_ThrowingExceptionsInFieldUpdating, throwNodeToReport);
 					isReported = true;
@@ -104,20 +106,31 @@ namespace Acuminator.Analyzers.StaticAnalysis.ThrowingExceptions
 			protected virtual bool IsThrowingOfThisExceptionInRowPersistedAllowed(
 																	[NotNullWhen(returnValue: true)] ExpressionSyntax? expressionAfterThrowkeyword)
 			{
+				return IsExceptionTypeAllowed(expressionAfterThrowkeyword, _exceptionTypesAllowedInRowPersisted);
+			}
+
+			protected virtual bool IsThrowingOfThisExceptionInFieldUpdatingAllowed(
+																	[NotNullWhen(returnValue: true)] ExpressionSyntax? expressionAfterThrowkeyword)
+			{
+				return IsExceptionTypeAllowed(expressionAfterThrowkeyword, _exceptionTypesAllowedInFieldUpdating);
+			}
+
+			protected bool IsExceptionTypeAllowed([NotNullWhen(returnValue: true)] ExpressionSyntax? expressionAfterThrowkeyword,
+												  List<ITypeSymbol> allowedExceptionTypes)
+			{
 				if (expressionAfterThrowkeyword?.SyntaxTree == null)
-					return false;								 // It's better to be conservative here and report thrown exception if we can't verify its type
+					return false;                               // It's better to be conservative here and report thrown exception if we can't verify its type
 
 				SemanticModel? semanticModel = GetSemanticModel(expressionAfterThrowkeyword.SyntaxTree);
 				ITypeSymbol? exceptiontype = semanticModel?.GetTypeInfo(expressionAfterThrowkeyword).Type;
 
 				bool isAllowed = exceptiontype != null &&      // It's better to be conservative here and report thrown exception if we can't verify its type
-								 _exceptionTypesAllowedInRowPersisted.Any(allowedExceptionType => exceptiontype.InheritsFromOrEquals(allowedExceptionType));
+								 allowedExceptionTypes.Any(allowedType => exceptiontype.InheritsFromOrEquals(allowedType));
 				return isAllowed;
 			}
 
-			private List<ITypeSymbol> GetExceptionTypesAllowdInRowPersisted(PXContext pxContext) =>
-				new List<ITypeSymbol>
-				{
+			private List<ITypeSymbol> GetExceptionTypesAllowedInRowPersisted(PXContext pxContext) =>
+				[
 					// Acumatica exceptions
 					PxContext.Exceptions.PXRowPersistedException,
 					PxContext.Exceptions.PXLockViolationException,
@@ -125,8 +138,16 @@ namespace Acuminator.Analyzers.StaticAnalysis.ThrowingExceptions
 					// .Net exceptions
 					PxContext.Exceptions.ArgumentException,
 					PxContext.Exceptions.NotImplementedException,
-					PxContext.Exceptions.NotSupportedException		
-				};
+					PxContext.Exceptions.NotSupportedException
+				];
+
+			private List<ITypeSymbol> GetExceptionTypesAllowedInFieldUpdating(PXContext pxContext) =>
+				[
+				 // .Net exceptions
+				 PxContext.Exceptions.ArgumentException,
+				 PxContext.Exceptions.NotImplementedException, 
+				 PxContext.Exceptions.NotSupportedException
+				];
 		}
 	}
 }

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/ThrowingExceptions/ThrowingExceptionsInEventHandlersAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/ThrowingExceptions/ThrowingExceptionsInEventHandlersAnalyzer.cs
@@ -1,5 +1,4 @@
-﻿
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -22,13 +21,11 @@ namespace Acuminator.Analyzers.StaticAnalysis.ThrowingExceptions
 		public ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(
 			Descriptors.PX1073_ThrowingExceptionsInRowPersisted,
 			Descriptors.PX1073_ThrowingExceptionsInRowPersisted_NonISV,
+			Descriptors.PX1073_ThrowingExceptionsInFieldUpdating,
 			Descriptors.PX1074_ThrowingSetupNotEnteredExceptionInEventHandlers);
 
 		bool ILooseEventHandlerAggregatedAnalyzer.ShouldAnalyze(PXContext pxContext, EventHandlerLooseInfo eventHandlerInfo) => 
 			eventHandlerInfo.Type != EventType.None;
-
-		bool IPXGraphAnalyzer.ShouldAnalyze(PXContext pxContext, PXGraphEventSemanticModel graphOrGraphExtension) => 
-			graphOrGraphExtension?.IsInSource == true && !graphOrGraphExtension.Symbol.IsStatic;
 
 		/// <summary>
 		/// Analyze events outside graphs and graph extensions.
@@ -56,6 +53,10 @@ namespace Acuminator.Analyzers.StaticAnalysis.ThrowingExceptions
 				methodSyntax.Accept(walker);
 			}
 		}
+
+		bool IPXGraphAnalyzer.ShouldAnalyze(PXContext pxContext, PXGraphEventSemanticModel graphOrGraphExtension) =>
+			graphOrGraphExtension?.IsInSource == true && !graphOrGraphExtension.Symbol.IsStatic && 
+			graphOrGraphExtension.DeclaredEventHandlers.AllEventHandlersCount > 0;
 
 		/// <summary>
 		/// Analyzes events in graph or graph extension.

--- a/src/Acuminator/Acuminator.Tests/Acuminator.Tests.csproj
+++ b/src/Acuminator/Acuminator.Tests/Acuminator.Tests.csproj
@@ -594,7 +594,8 @@
     <EmbeddedResource Include="Tests\StaticAnalysis\ThrowingExceptions\Sources\EventHandlers\NonGraph\ExceptionInValidEventHandlers.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\ThrowingExceptions\Sources\EventHandlers\NonGraph\SetupNotEnteredExceptionInInvalidEventHandlers.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\ThrowingExceptions\Sources\EventHandlers\NonGraph\SetupNotEnteredExceptionInRowSelected.cs" />
-    <Compile Include="Tests\StaticAnalysis\ThrowingExceptions\Sources\EventHandlers\Graph\ExceptionInFieldUpdating.cs" />
+    <EmbeddedResource Include="Tests\StaticAnalysis\ThrowingExceptions\Sources\EventHandlers\Graph\ExceptionInFieldUpdating.cs" />
+    <EmbeddedResource Include="Tests\StaticAnalysis\ThrowingExceptions\Sources\EventHandlers\NonGraph\ExceptionInFieldUpdating.cs" />
     <Compile Include="Tests\StaticAnalysis\ThrowingExceptions\ThrowingExceptionsInActionHandlersTests.cs" />
     <Compile Include="Tests\StaticAnalysis\ThrowingExceptions\ThrowingExceptionsInNonGraphEventHandlersTests.cs" />
     <Compile Include="Tests\StaticAnalysis\ThrowingExceptions\ThrowingExceptionsInGraphEventHandlers_NonISVTests.cs" />

--- a/src/Acuminator/Acuminator.Tests/Acuminator.Tests.csproj
+++ b/src/Acuminator/Acuminator.Tests/Acuminator.Tests.csproj
@@ -594,6 +594,7 @@
     <EmbeddedResource Include="Tests\StaticAnalysis\ThrowingExceptions\Sources\EventHandlers\NonGraph\ExceptionInValidEventHandlers.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\ThrowingExceptions\Sources\EventHandlers\NonGraph\SetupNotEnteredExceptionInInvalidEventHandlers.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\ThrowingExceptions\Sources\EventHandlers\NonGraph\SetupNotEnteredExceptionInRowSelected.cs" />
+    <Compile Include="Tests\StaticAnalysis\ThrowingExceptions\Sources\EventHandlers\Graph\ExceptionInFieldUpdating.cs" />
     <Compile Include="Tests\StaticAnalysis\ThrowingExceptions\ThrowingExceptionsInActionHandlersTests.cs" />
     <Compile Include="Tests\StaticAnalysis\ThrowingExceptions\ThrowingExceptionsInNonGraphEventHandlersTests.cs" />
     <Compile Include="Tests\StaticAnalysis\ThrowingExceptions\ThrowingExceptionsInGraphEventHandlers_NonISVTests.cs" />

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/ThrowingExceptions/Sources/EventHandlers/Graph/ExceptionInFieldUpdating.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/ThrowingExceptions/Sources/EventHandlers/Graph/ExceptionInFieldUpdating.cs
@@ -1,0 +1,100 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using PX.Data;
+
+namespace PX.Objects
+{
+	public class SOInvoiceEntry : PXGraph<SOInvoiceEntry, SOInvoice>
+	{
+		public PXSelect<SOInvoice> Invoices;
+
+		public int Mode { get; set; }
+
+		protected virtual void _(Events.FieldUpdating<SOInvoice, SOInvoice.refNbr> e)
+		{
+			switch (Mode)
+			{
+				case 0:
+					throw new PXRowPersistedException(typeof(SOInvoice.refNbr).Name, e.Row.RefNbr, "Persist error");               //Should report diagnostic
+				case 1:
+					throw new PXLockViolationException(typeof(SOInvoice), PXDBOperation.Insert, new object[] { e.Row.RefNbr });    //Should report diagnostic
+				case 2:
+					throw new PXException("Something bad happened");        //Should report diagnostic
+				case 3:
+					throw new ArgumentOutOfRangeException(nameof(Mode));    //No diagnostic
+				case 4:
+					throw new ArgumentNullException(nameof(Mode));			//No diagnostic
+				case 5:
+					throw new ArgumentException("Something bad happened");  //No diagnostic
+				case 6:
+					throw new NotImplementedException();                    //No diagnostic
+				default:
+					throw new NotSupportedException();                      //No diagnostic
+			}	
+		}
+
+		protected virtual void _(Events.FieldUpdating<SOLine.refNbr> e)
+		{
+			switch (Mode)
+			{
+				case 0:
+					throw new PXRowPersistedException(typeof(SOInvoice.refNbr).Name, (e.Row as SOLine).RefNbr, "Persist error");               //Should report diagnostic
+				case 1:
+					throw new PXLockViolationException(typeof(SOInvoice), PXDBOperation.Insert, new object[] { (e.Row as SOLine).RefNbr });    //Should report diagnostic
+				case 2:
+					throw new PXException("Something bad happened");        //Should report diagnostic
+				case 3:
+					throw new ArgumentOutOfRangeException(nameof(Mode));    //No diagnostic
+				case 4:
+					throw new ArgumentNullException(nameof(Mode));          //No diagnostic
+				case 5:
+					throw new ArgumentException("Something bad happened");  //No diagnostic
+				case 6:
+					throw new NotImplementedException();                    //No diagnostic
+				default:
+					throw new NotSupportedException();                      //No diagnostic
+			}
+		}
+	}
+
+	public class SOInvoice : IBqlTable
+	{
+		#region RefNbr
+		[PXDBString(8, IsKey = true, InputMask = "")]
+		public string RefNbr { get; set; }
+
+		public abstract class refNbr : PX.Data.BQL.BqlString.Field<refNbr> { }
+		#endregion
+
+		#region LineCntr
+		public abstract class lineCntr : PX.Data.BQL.BqlInt.Field<lineCntr> { }
+
+		[PXDBInt]
+		[PXDefault(0)]
+		public virtual int? LineCntr
+		{
+			get;
+			set;
+		}
+		#endregion
+	}
+
+	public class SOLine : IBqlTable
+	{
+		#region RefNbr
+		[PXDBString(8, IsKey = true, InputMask = "")]
+		public string RefNbr { get; set; }
+
+		public abstract class refNbr : IBqlField { }
+		#endregion
+
+		#region LineNbr
+		[PXDBInt(IsKey = true)]
+		[PXLineNbr(typeof(SOInvoice.lineCntr))]
+		public int? LineNbr { get; set; }
+
+		public abstract class lineNbr : IBqlField { }
+		#endregion
+	}
+}

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/ThrowingExceptions/Sources/EventHandlers/NonGraph/ExceptionInFieldUpdating.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/ThrowingExceptions/Sources/EventHandlers/NonGraph/ExceptionInFieldUpdating.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using PX.Data;
+
+namespace PX.Objects
+{
+	public class SOSomeAttribute : PXEventSubscriberAttribute, IPXFieldUpdatingSubscriber
+	{
+		public int Mode { get; set; }
+
+		public virtual void FieldUpdating(PXCache sender, PXFieldUpdatingEventArgs e)
+		{
+			switch (Mode)
+			{
+				case 0:
+					throw new PXRowPersistedException(typeof(SOInvoice.refNbr).Name, e.Row.RefNbr, "Persist error");               //Should report diagnostic
+				case 1:
+					throw new PXLockViolationException(typeof(SOInvoice), PXDBOperation.Insert, new object[] { e.Row.RefNbr });    //Should report diagnostic
+				case 2:
+					throw new PXException("Something bad happened");        //Should report diagnostic
+				case 3:
+					throw new ArgumentOutOfRangeException(nameof(Mode));    //No diagnostic
+				case 4:
+					throw new ArgumentNullException(nameof(Mode));			//No diagnostic
+				case 5:
+					throw new ArgumentException("Something bad happened");  //No diagnostic
+				case 6:
+					throw new NotImplementedException();                    //No diagnostic
+				default:
+					throw new NotSupportedException();                      //No diagnostic
+			}	
+		}
+	}
+
+	public class SOInvoice : IBqlTable
+	{
+		#region RefNbr
+		[PXDBString(8, IsKey = true, InputMask = "")]
+		public string RefNbr { get; set; }
+
+		public abstract class refNbr : PX.Data.BQL.BqlString.Field<refNbr> { }
+		#endregion
+
+		#region LineCntr
+		public abstract class lineCntr : PX.Data.BQL.BqlInt.Field<lineCntr> { }
+
+		[PXDBInt]
+		[PXDefault(0)]
+		public virtual int? LineCntr
+		{
+			get;
+			set;
+		}
+		#endregion
+	}
+
+	public class SOLine : IBqlTable
+	{
+		#region RefNbr
+		[PXDBString(8, IsKey = true, InputMask = "")]
+		public string RefNbr { get; set; }
+
+		public abstract class refNbr : IBqlField { }
+		#endregion
+
+		#region LineNbr
+		[PXDBInt(IsKey = true)]
+		[PXLineNbr(typeof(SOInvoice.lineCntr))]
+		public int? LineNbr { get; set; }
+
+		public abstract class lineNbr : IBqlField { }
+		#endregion
+	}
+}

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/ThrowingExceptions/ThrowingExceptionsInGraphEventHandlersTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/ThrowingExceptions/ThrowingExceptionsInGraphEventHandlersTests.cs
@@ -33,6 +33,16 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.ThrowingExceptions
 			Descriptors.PX1073_ThrowingExceptionsInRowPersisted.CreateFor(50, 6));
 
 		[Theory]
+		[EmbeddedFileData(@"EventHandlers\Graph\ExceptionInFieldUpdating.cs")]
+		public async Task ExceptionInFieldUpdating(string actual) => await VerifyCSharpDiagnosticAsync(actual,
+			Descriptors.PX1073_ThrowingExceptionsInFieldUpdating.CreateFor(19, 6),
+			Descriptors.PX1073_ThrowingExceptionsInFieldUpdating.CreateFor(21, 6),
+			Descriptors.PX1073_ThrowingExceptionsInFieldUpdating.CreateFor(23, 6),
+			Descriptors.PX1073_ThrowingExceptionsInFieldUpdating.CreateFor(42, 6),
+			Descriptors.PX1073_ThrowingExceptionsInFieldUpdating.CreateFor(44, 6),
+			Descriptors.PX1073_ThrowingExceptionsInFieldUpdating.CreateFor(46, 6));
+
+		[Theory]
 		[EmbeddedFileData(@"EventHandlers\Graph\ExceptionInRowPersisted_ProcessingGraph.cs")]
 		public async Task ExceptionInRowPersisted_ProcessingGraph_ShouldNotReportDiagnostic(string actual) => 
 			await VerifyCSharpDiagnosticAsync(actual);

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/ThrowingExceptions/ThrowingExceptionsInGraphEventHandlersTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/ThrowingExceptions/ThrowingExceptionsInGraphEventHandlersTests.cs
@@ -71,6 +71,7 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.ThrowingExceptions
 			Descriptors.PX1074_ThrowingSetupNotEnteredExceptionInEventHandlers.CreateFor(69, 4, EventType.ExceptionHandling),
 			Descriptors.PX1074_ThrowingSetupNotEnteredExceptionInEventHandlers.CreateFor(72, 4, EventType.CommandPreparing),
 			Descriptors.PX1074_ThrowingSetupNotEnteredExceptionInEventHandlers.CreateFor(75, 4, EventType.FieldSelecting),
+			Descriptors.PX1073_ThrowingExceptionsInFieldUpdating.CreateFor(78, 4, EventType.FieldUpdating),
 			Descriptors.PX1074_ThrowingSetupNotEnteredExceptionInEventHandlers.CreateFor(78, 4, EventType.FieldUpdating),
 			Descriptors.PX1074_ThrowingSetupNotEnteredExceptionInEventHandlers.CreateFor(81, 4, EventType.FieldUpdated));
 

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/ThrowingExceptions/ThrowingExceptionsInGraphEventHandlers_NonISVTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/ThrowingExceptions/ThrowingExceptionsInGraphEventHandlers_NonISVTests.cs
@@ -81,6 +81,7 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.ThrowingExceptions
 				Descriptors.PX1074_ThrowingSetupNotEnteredExceptionInEventHandlers.CreateFor(69, 4, EventType.ExceptionHandling),
 				Descriptors.PX1074_ThrowingSetupNotEnteredExceptionInEventHandlers.CreateFor(72, 4, EventType.CommandPreparing),
 				Descriptors.PX1074_ThrowingSetupNotEnteredExceptionInEventHandlers.CreateFor(75, 4, EventType.FieldSelecting),
+				Descriptors.PX1073_ThrowingExceptionsInFieldUpdating.CreateFor(78, 4, EventType.FieldUpdating),
 				Descriptors.PX1074_ThrowingSetupNotEnteredExceptionInEventHandlers.CreateFor(78, 4, EventType.FieldUpdating),
 				Descriptors.PX1074_ThrowingSetupNotEnteredExceptionInEventHandlers.CreateFor(81, 4, EventType.FieldUpdated));
 

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/ThrowingExceptions/ThrowingExceptionsInGraphEventHandlers_NonISVTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/ThrowingExceptions/ThrowingExceptionsInGraphEventHandlers_NonISVTests.cs
@@ -30,6 +30,16 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.ThrowingExceptions
 			Descriptors.PX1073_ThrowingExceptionsInRowPersisted_NonISV.CreateFor(50, 6));
 
 		[Theory]
+		[EmbeddedFileData(@"EventHandlers\Graph\ExceptionInFieldUpdating.cs")]
+		public async Task ExceptionInFieldUpdating(string actual) => await VerifyCSharpDiagnosticAsync(actual,
+			Descriptors.PX1073_ThrowingExceptionsInFieldUpdating.CreateFor(19, 6),
+			Descriptors.PX1073_ThrowingExceptionsInFieldUpdating.CreateFor(21, 6),
+			Descriptors.PX1073_ThrowingExceptionsInFieldUpdating.CreateFor(23, 6),
+			Descriptors.PX1073_ThrowingExceptionsInFieldUpdating.CreateFor(42, 6),
+			Descriptors.PX1073_ThrowingExceptionsInFieldUpdating.CreateFor(44, 6),
+			Descriptors.PX1073_ThrowingExceptionsInFieldUpdating.CreateFor(46, 6));
+
+		[Theory]
 		[EmbeddedFileData(@"EventHandlers\Graph\ExceptionInRowPersisted_ProcessingGraph.cs")]
 		public async Task ExceptionInRowPersisted_ProcessingGraph_ShouldNotReportDiagnostic(string actual) =>
 			await VerifyCSharpDiagnosticAsync(actual);

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/ThrowingExceptions/ThrowingExceptionsInNonGraphEventHandlersTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/ThrowingExceptions/ThrowingExceptionsInNonGraphEventHandlersTests.cs
@@ -32,6 +32,13 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.ThrowingExceptions
 			Descriptors.PX1073_ThrowingExceptionsInRowPersisted.CreateFor(25, 6));
 
 		[Theory]
+		[EmbeddedFileData(@"EventHandlers\NonGraph\ExceptionInFieldUpdating.cs")]
+		public async Task ExceptionInFieldUpdating(string actual) => await VerifyCSharpDiagnosticAsync(actual,
+			Descriptors.PX1073_ThrowingExceptionsInFieldUpdating.CreateFor(17, 6),
+			Descriptors.PX1073_ThrowingExceptionsInFieldUpdating.CreateFor(19, 6),
+			Descriptors.PX1073_ThrowingExceptionsInFieldUpdating.CreateFor(21, 6));
+
+		[Theory]
 		[EmbeddedFileData(@"EventHandlers\NonGraph\ExceptionInValidEventHandlers.cs")]
 		public async Task ExceptionInValidEventHandlers_ShouldNotReportDiagnostic(string actual) =>
 			await VerifyCSharpDiagnosticAsync(actual);

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/ThrowingExceptions/ThrowingExceptionsInNonGraphEventHandlersTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/ThrowingExceptions/ThrowingExceptionsInNonGraphEventHandlersTests.cs
@@ -63,6 +63,7 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.ThrowingExceptions
 			Descriptors.PX1074_ThrowingSetupNotEnteredExceptionInEventHandlers.CreateFor(76, 4, EventType.ExceptionHandling),
 			Descriptors.PX1074_ThrowingSetupNotEnteredExceptionInEventHandlers.CreateFor(79, 4, EventType.CommandPreparing),
 			Descriptors.PX1074_ThrowingSetupNotEnteredExceptionInEventHandlers.CreateFor(82, 4, EventType.FieldSelecting),
+			Descriptors.PX1073_ThrowingExceptionsInFieldUpdating.CreateFor(85, 4, EventType.FieldUpdating),
 			Descriptors.PX1074_ThrowingSetupNotEnteredExceptionInEventHandlers.CreateFor(85, 4, EventType.FieldUpdating),
 			Descriptors.PX1074_ThrowingSetupNotEnteredExceptionInEventHandlers.CreateFor(88, 4, EventType.FieldUpdated));
 

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/ThrowingExceptions/ThrowingExceptionsInNonGraphEventHandlers_NonISVTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/ThrowingExceptions/ThrowingExceptionsInNonGraphEventHandlers_NonISVTests.cs
@@ -28,6 +28,13 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.ThrowingExceptions
 			Descriptors.PX1073_ThrowingExceptionsInRowPersisted_NonISV.CreateFor(25, 6));
 
 		[Theory]
+		[EmbeddedFileData(@"EventHandlers\NonGraph\ExceptionInFieldUpdating.cs")]
+		public async Task ExceptionInFieldUpdating(string actual) => await VerifyCSharpDiagnosticAsync(actual,
+			Descriptors.PX1073_ThrowingExceptionsInFieldUpdating.CreateFor(17, 6),
+			Descriptors.PX1073_ThrowingExceptionsInFieldUpdating.CreateFor(19, 6),
+			Descriptors.PX1073_ThrowingExceptionsInFieldUpdating.CreateFor(21, 6));
+
+		[Theory]
 		[EmbeddedFileData(@"EventHandlers\NonGraph\ExceptionInValidEventHandlers.cs")]
 		public async Task ExceptionInValidEventHandlers_ShouldNotReportDiagnostic(string actual) =>
 			await VerifyCSharpDiagnosticAsync(actual);

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/ThrowingExceptions/ThrowingExceptionsInNonGraphEventHandlers_NonISVTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/ThrowingExceptions/ThrowingExceptionsInNonGraphEventHandlers_NonISVTests.cs
@@ -60,6 +60,7 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.ThrowingExceptions
 				Descriptors.PX1074_ThrowingSetupNotEnteredExceptionInEventHandlers.CreateFor(76, 4, EventType.ExceptionHandling),
 				Descriptors.PX1074_ThrowingSetupNotEnteredExceptionInEventHandlers.CreateFor(79, 4, EventType.CommandPreparing),
 				Descriptors.PX1074_ThrowingSetupNotEnteredExceptionInEventHandlers.CreateFor(82, 4, EventType.FieldSelecting),
+				Descriptors.PX1073_ThrowingExceptionsInFieldUpdating.CreateFor(85, 4, EventType.FieldUpdating),
 				Descriptors.PX1074_ThrowingSetupNotEnteredExceptionInEventHandlers.CreateFor(85, 4, EventType.FieldUpdating),
 				Descriptors.PX1074_ThrowingSetupNotEnteredExceptionInEventHandlers.CreateFor(88, 4, EventType.FieldUpdated));
 


### PR DESCRIPTION
Changes Overview:
- extended PX1073 analysis to report exceptions thrown in field updating event handler
- added allowed exception types in field updating event handlers: 
`NotImplementedException`, `NotSupportedException`, `ArgumentException` (including its descendants `ArgumentNullException` and `ArgumentOutOfRangeException`)
- updated unit tests for PX1073 with field updating event handler scenarios
- updated documentation for PX1073