### PR TITLE
Bugfix/atr 875 dev extend px1075 with field updating

### DIFF
--- a/docs/Summary.md
+++ b/docs/Summary.md
@@ -81,7 +81,7 @@ Acuminator does not perform static analysis of projects whose names contain `Tes
 | [PX1072](diagnostics/PX1072.md) | BQL queries must be executed within the context of an existing `PXGraph` instance. | Warning (ISV Level 1: Significant) | Available |
 | [PX1073](diagnostics/PX1073.md) | Exceptions cannot be thrown in the `RowPersisted` event handlers. | Error | Unavailable |
 | [PX1074](diagnostics/PX1074.md) | `PXSetupNotEnteredException` cannot be thrown in any event handlers except for the `RowSelected` event handlers. | Warning (ISV Level 1: Significant) | Unavailable |
-| [PX1075](diagnostics/PX1075.md) | `PXCache.RaiseExceptionHandling` cannot be invoked from the `FieldDefaulting`, `FieldSelecting`, `RowSelecting`, and `RowPersisted` event handlers. | Error | Unavailable |
+| [PX1075](diagnostics/PX1075.md) | `PXCache.RaiseExceptionHandling` cannot be invoked from the `FieldDefaulting`, `FieldSelecting`, `FieldUpdating`, `RowSelecting`, and `RowPersisted` event handlers. | Error | Unavailable |
 | [PX1076](diagnostics/PX1076.md) | This code calls Acumatica internal API marked with PXInternalUseOnlyAttribute which is not intended for public use | Warning | Unavailable |
 | [PX1077](diagnostics/PX1077.md) | Event handlers in graphs and graph extensions should have the `protected` and `virtual` modifiers | Error | Available |
 | [PX1078](diagnostics/PX1078.md) | The DAC field and the referenced DAC field have different types or sizes. | Error | Unavailable |

--- a/docs/diagnostics/PX1075.md
+++ b/docs/diagnostics/PX1075.md
@@ -3,29 +3,37 @@ This document describes the PX1075 diagnostic.
 
 ## Summary
 
-| Code   | Short Description                                                                                                                                   | Type  | Code Fix    | 
-| ------ | --------------------------------------------------------------------------------------------------------------------------------------------------- | ----- | ----------- | 
-| PX1075 | `PXCache.RaiseExceptionHandling` cannot be invoked from the `FieldDefaulting`, `FieldSelecting`, `RowSelecting`, and `RowPersisted` event handlers. | Error | Unavailable |
+| Code   | Short Description                                                                                                                                                    |              Type              | Code Fix    | 
+| ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------ | ----------- | 
+| PX1075 | `PXCache.RaiseExceptionHandling` cannot be invoked from the `FieldDefaulting`, `FieldSelecting`, `FieldUpdating`, `RowSelecting`, and `RowPersisted` event handlers. | Warning(Non-ISV) / Error (ISV) | Unavailable |
 
 ## Diagnostic Description
-`RaiseExceptionHandling`, which is used to prevent the saving of a record or to display an error or warning on the form, cannot be invoked on a `PXCache` instance in the following event handlers: 
+The `PXCache.RaiseExceptionHandling` method, which is used to prevent the saving of a record or to display an error or warning on the form, cannot be invoked on a `PXCache` instance for some event handlers.
 
- - `FieldDefaulting`: This event handler works with a record that has not yet been added to `PXCache` or a record whose field is changed in the code. Neither situation involves the display of errors or warning for a record.
- - `FieldSelecting`: This event handler is used to configure a UI control of a field. The invocation of `PXCache.RaiseExceptionHandling` in this event handler has no effect.
- - `RowSelecting`: This event handler is called when the record is being read from the database. These records are not available in `PXCache` yet. Invocation of `PXCache.RaiseExceptionHandling` in this event handler has no effect.
- - `RowPersisted`: This event handler is called when the record has already been saved to the database. Therefore, it would not make sense to display any warnings for this record.
-
-`RaiseExceptionHandling` usually is invoked in the following event handlers:
-
- - `RowPersisting` to prevent saving of a record
- - `RowSelected` to display an error or warning on the form
+The `PXCache.RaiseExceptionHandling` method usually is invoked in the following event handlers:
+ - `RowPersisting` to prevent saving of a record.
+ - `RowSelected` to display an error or warning on the form.
 
 To prevent the error from occurring, you should remove the code that invokes `PXCache.RaiseExceptionHandling` and rework the related business logic.
 
-This diagnostic is displayed as a warning for the `FieldSelecting` event handler if the **Enable additional diagnostics for ISV Solution Certification** option (in **Tools > Options > Acuminator > Code Analysis**) is set to `False`.
+When **Enable additional diagnostics for ISV Solution Certification** Acuminator option (in **Tools > Options > Acuminator > Code Analysis**) is set to `True`, 
+the PX1073 diagnostic will be displayed as an Error for the following event handlers:
+ - `FieldDefaulting`: This event handler works with a record that has not yet been added to `PXCache` or a record whose field is changed in the code. Neither situation involves the display of errors or warning for a record.
+ - `FieldSelecting`: This event handler is used to configure a UI control of a field. The invocation of `PXCache.RaiseExceptionHandling` in this event handler has no effect.
+ - `FieldUpdating`: This event handler is used to transform external value representation from the UI or Web API into the internal value representation stored in a DAC field.
+The `FieldUpdating` event is not raised in some scenarios when Acumatica assumes that value is already in an internal state and does not require transformation. Therefore, the validation logic
+that calls `PXCache.RaiseExceptionHandling` won't be executed in all scenarios which can lead to an inconsistent state of the value in the DAC field. Use `FieldUpdating` or other event handlers for validation logic.
+ - `RowSelecting`: This event handler is called when the record is being read from the database. These records are not available in `PXCache` yet. Invocation of `PXCache.RaiseExceptionHandling` in this event handler has no effect.
+ - `RowPersisted`: This event handler is called when the record has already been saved to the database. Therefore, it would not make sense to display any warnings for this record.
+
+When **Enable additional diagnostics for ISV Solution Certification** Acuminator option (in **Tools > Options > Acuminator > Code Analysis**) is set to `False`, 
+the PX1073 diagnostic will be displayed as a Warning for the following event handlers:
+ - `FieldSelecting`: This event handler is used to configure a UI control of a field. The invocation of `PXCache.RaiseExceptionHandling` in this event handler has no effect.
+ - `FieldUpdating`: This event handler is used to transform external value representation from the UI or Web API into the internal value representation stored in a DAC field.
+The `FieldUpdating` event is not raised in some scenarios when Acumatica assumes that value is already in an internal state and does not require transformation. Therefore, the validation logic
+that calls `PXCache.RaiseExceptionHandling` won't be executed in all scenarios which can lead to an inconsistent state of the value in the DAC field. Use `FieldUpdating` or other event handlers for validation logic.
 
 ## Example of Incorrect Code
-
 ```C#
 protected virtual void SOOrder_Status_FieldSelecting(PXCache sender,
 PXRowSelectingEventArgs e)
@@ -44,9 +52,9 @@ PXRowSelectingEventArgs e)
 ```
 
 ## Related Articles
-
- - [FieldDefaulting](https://help.acumatica.com/Help?ScreenId=ShowWiki&pageid=6db70fe7-3fc3-4e05-d3a6-5ecb93bea6a9)
- - [FieldSelecting](https://help.acumatica.com/Help?ScreenId=ShowWiki&pageid=7afeed34-d321-02e8-bc8a-853d66732de3)
- - [RowSelecting](https://help.acumatica.com/Help?ScreenId=ShowWiki&pageid=3914d39a-0394-c506-92b5-3bbe3b044cbb)
- - [RowPersisted](https://help.acumatica.com/Help?ScreenId=ShowWiki&pageid=ac686a56-ea6d-5ece-1063-a2842fb9aaa0)
+ - [FieldDefaulting](https://help.acumatica.com/Help?ScreenId=ShowWiki&pageid=dedd464a-3e57-dda1-fb2e-4e7fe8d62dd7)
+ - [FieldSelecting](https://help.acumatica.com/Help?ScreenId=ShowWiki&pageid=e43e5162-c4b5-6bf8-8ff1-5c705ba73a05)
+ - [FieldUpdating](https://help.acumatica.com/Help?ScreenId=ShowWiki&pageid=3c049ef0-60f1-c3cd-85c5-21650654c5aa)
+ - [RowSelecting](https://help.acumatica.com/Help?ScreenId=ShowWiki&pageid=251735da-091e-3bc5-f805-0f570e923864)
+ - [RowPersisted](https://help.acumatica.com/Help?ScreenId=ShowWiki&pageid=f151b2b4-989e-072b-63a8-2b2b472b5e0d)
  - [Data Manipulation Scenarios](https://help.acumatica.com/Help?ScreenId=ShowWiki&pageid=d9cf6274-f5c8-43e7-9d13-9b423113d67e)

--- a/docs/diagnostics/PX1075.md
+++ b/docs/diagnostics/PX1075.md
@@ -5,24 +5,24 @@ This document describes the PX1075 diagnostic.
 
 | Code   | Short Description                                                                                                                                                    |              Type              | Code Fix    | 
 | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------ | ----------- | 
-| PX1075 | `PXCache.RaiseExceptionHandling` cannot be invoked from the `FieldDefaulting`, `FieldSelecting`, `FieldUpdating`, `RowSelecting`, and `RowPersisted` event handlers. | Warning(Non-ISV) / Error (ISV) | Unavailable |
+| PX1075 | `PXCache.RaiseExceptionHandling` cannot be invoked from the `FieldDefaulting`, `FieldSelecting`, `FieldUpdating`, `RowSelecting`, and `RowPersisted` event handlers. | Warning (Non-ISV) / Error (ISV) | Unavailable |
 
 ## Diagnostic Description
 The `PXCache.RaiseExceptionHandling` method, which is used to prevent the saving of a record or to display an error or warning on the form, cannot be invoked on a `PXCache` instance for some event handlers.
 
 The `PXCache.RaiseExceptionHandling` method usually is invoked in the following event handlers:
  - `RowPersisting` to prevent saving of a record.
- - `RowSelected` to display an error or warning on the form.
+ - `RowSelected` to display an error or a warning on the form.
 
-To prevent the error from occurring, you should remove the code that invokes `PXCache.RaiseExceptionHandling` and rework the related business logic.
+To prevent the diagnostic from showing an error, you should remove the code that invokes `PXCache.RaiseExceptionHandling` and rework the related business logic.
 
 When **Enable additional diagnostics for ISV Solution Certification** Acuminator option (in **Tools > Options > Acuminator > Code Analysis**) is set to `True`, 
-the PX1073 diagnostic will be displayed as an Error for the following event handlers:
+the PX1073 diagnostic will be displayed as an error for the following event handlers:
  - `FieldDefaulting`: This event handler works with a record that has not yet been added to `PXCache` or a record whose field is changed in the code. Neither situation involves the display of errors or warning for a record.
  - `FieldSelecting`: This event handler is used to configure a UI control of a field. The invocation of `PXCache.RaiseExceptionHandling` in this event handler has no effect.
  - `FieldUpdating`: This event handler is used to transform external value representation from the UI or Web API into the internal value representation stored in a DAC field.
 The `FieldUpdating` event is not raised in some scenarios when Acumatica assumes that value is already in an internal state and does not require transformation. Therefore, the validation logic
-that calls `PXCache.RaiseExceptionHandling` won't be executed in all scenarios which can lead to an inconsistent state of the value in the DAC field. Use `FieldUpdating` or other event handlers for validation logic.
+that calls `PXCache.RaiseExceptionHandling` won't be executed in all scenarios which can lead to an inconsistent state of the value in the DAC field. You should use `FieldUpdating` or other event handlers for validation logic.
  - `RowSelecting`: This event handler is called when the record is being read from the database. These records are not available in `PXCache` yet. Invocation of `PXCache.RaiseExceptionHandling` in this event handler has no effect.
  - `RowPersisted`: This event handler is called when the record has already been saved to the database. Therefore, it would not make sense to display any warnings for this record.
 

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/RaiseExceptionHandling/RaiseExceptionHandlingInEventHandlersAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/RaiseExceptionHandling/RaiseExceptionHandlingInEventHandlersAnalyzer.cs
@@ -18,13 +18,13 @@ namespace Acuminator.Analyzers.StaticAnalysis.RaiseExceptionHandling
 {
 	public class RaiseExceptionHandlingInEventHandlersAnalyzer : LooseEventHandlerAggregatedAnalyzerBase
 	{
-		private static readonly ISet<EventType> AnalyzedEventTypes = new HashSet<EventType>()
-		{
+		private static readonly List<EventType> _analyzedEventTypes =
+		[
 			EventType.FieldDefaulting,
 			EventType.FieldSelecting,
 			EventType.RowSelecting,
 			EventType.RowPersisted
-		};
+		];
 
 		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
 			ImmutableArray.Create(
@@ -33,17 +33,20 @@ namespace Acuminator.Analyzers.StaticAnalysis.RaiseExceptionHandling
 			);
 
 		public override bool ShouldAnalyze(PXContext pxContext, EventHandlerLooseInfo eventHandlerInfo) =>
-			base.ShouldAnalyze(pxContext, eventHandlerInfo) && AnalyzedEventTypes.Contains(eventHandlerInfo.Type);
+			base.ShouldAnalyze(pxContext, eventHandlerInfo) && _analyzedEventTypes.Contains(eventHandlerInfo.Type);
 
 		public override void Analyze(SymbolAnalysisContext context, PXContext pxContext, EventHandlerLooseInfo eventHandlerInfo)
 		{
 			context.CancellationToken.ThrowIfCancellationRequested();
 
-			var methodSymbol = (IMethodSymbol) context.Symbol;
-			var methodSyntax = methodSymbol.GetSyntax(context.CancellationToken) as CSharpSyntaxNode;
-			var walker = new Walker(context, pxContext, eventHandlerInfo.Type);
+			if (context.Symbol is not IMethodSymbol methodSymbol ||
+				methodSymbol.GetSyntax(context.CancellationToken) is not CSharpSyntaxNode methodSyntax)
+			{
+				return;
+			}
 
-			methodSyntax?.Accept(walker);
+			var walker = new Walker(context, pxContext, eventHandlerInfo.Type);
+			methodSyntax.Accept(walker);
 		}
 
 
@@ -66,24 +69,21 @@ namespace Acuminator.Analyzers.StaticAnalysis.RaiseExceptionHandling
 				var methodSymbol = GetSymbol<IMethodSymbol>(node);
 				methodSymbol = methodSymbol?.OriginalDefinition?.OverriddenMethod ?? methodSymbol?.OriginalDefinition;
 
-				if (methodSymbol != null && PxContext.PXCache.RaiseExceptionHandling.Contains(methodSymbol, SymbolEqualityComparer.Default))
+				if (methodSymbol == null || !PxContext.PXCache.RaiseExceptionHandling.Contains(methodSymbol, SymbolEqualityComparer.Default))
 				{
-					if (!Settings.IsvSpecificAnalyzersEnabled && _eventType == EventType.FieldSelecting)
-					{
-						ReportDiagnostic(_context.ReportDiagnostic,
-							Descriptors.PX1075_RaiseExceptionHandlingInEventHandlers_NonISV,
-							node, _eventType);
-					}
-					else
-					{
-						ReportDiagnostic(_context.ReportDiagnostic,
-							Descriptors.PX1075_RaiseExceptionHandlingInEventHandlers,
-							node, _eventType);
-					}
+					base.VisitInvocationExpression(node);
+					return;
+				}
+
+				if (!Settings.IsvSpecificAnalyzersEnabled && _eventType == EventType.FieldSelecting)
+				{
+					ReportDiagnostic(_context.ReportDiagnostic, Descriptors.PX1075_RaiseExceptionHandlingInEventHandlers_NonISV,
+									  node, _eventType);
 				}
 				else
 				{
-					base.VisitInvocationExpression(node);
+					ReportDiagnostic(_context.ReportDiagnostic, Descriptors.PX1075_RaiseExceptionHandlingInEventHandlers,
+									 node, _eventType);
 				}
 			}
 		}

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/RaiseExceptionHandling/RaiseExceptionHandlingInEventHandlersAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/RaiseExceptionHandling/RaiseExceptionHandlingInEventHandlersAnalyzer.cs
@@ -18,10 +18,17 @@ namespace Acuminator.Analyzers.StaticAnalysis.RaiseExceptionHandling
 {
 	public class RaiseExceptionHandlingInEventHandlersAnalyzer : LooseEventHandlerAggregatedAnalyzerBase
 	{
-		private static readonly List<EventType> _analyzedEventTypes =
+		private static readonly List<EventType> _analyzedEventTypesNonIsvMode =
+		[
+			EventType.FieldSelecting,
+			EventType.FieldUpdating,
+		];
+
+		private static readonly List<EventType> _analyzedEventTypesIsvMode =
 		[
 			EventType.FieldDefaulting,
 			EventType.FieldSelecting,
+			EventType.FieldUpdating,
 			EventType.RowSelecting,
 			EventType.RowPersisted
 		];
@@ -32,8 +39,17 @@ namespace Acuminator.Analyzers.StaticAnalysis.RaiseExceptionHandling
 				Descriptors.PX1075_RaiseExceptionHandlingInEventHandlers_NonISV
 			);
 
-		public override bool ShouldAnalyze(PXContext pxContext, EventHandlerLooseInfo eventHandlerInfo) =>
-			base.ShouldAnalyze(pxContext, eventHandlerInfo) && _analyzedEventTypes.Contains(eventHandlerInfo.Type);
+		public override bool ShouldAnalyze(PXContext pxContext, EventHandlerLooseInfo eventHandlerInfo)
+		{
+			if (!base.ShouldAnalyze(pxContext, eventHandlerInfo))
+				return false;
+
+			var supportedEventTypes = pxContext.CodeAnalysisSettings.IsvSpecificAnalyzersEnabled
+				? _analyzedEventTypesIsvMode
+				: _analyzedEventTypesNonIsvMode;
+
+			return supportedEventTypes.Contains(eventHandlerInfo.Type);
+		}
 
 		public override void Analyze(SymbolAnalysisContext context, PXContext pxContext, EventHandlerLooseInfo eventHandlerInfo)
 		{
@@ -53,13 +69,17 @@ namespace Acuminator.Analyzers.StaticAnalysis.RaiseExceptionHandling
 		private class Walker : NestedInvocationWalker
 		{
 			private readonly SymbolAnalysisContext _context;
-			private readonly EventType _eventType;
+			private readonly string _eventTypeName;
+			private readonly DiagnosticDescriptor _px1075DiagnosticDescriptor;
 
 			public Walker(SymbolAnalysisContext context, PXContext pxContext, EventType eventType)
 				: base(pxContext, context.CancellationToken)
 			{
 				_context = context;
-				_eventType= eventType;
+				_eventTypeName = eventType.ToString();
+				_px1075DiagnosticDescriptor = pxContext.CodeAnalysisSettings.IsvSpecificAnalyzersEnabled
+					? Descriptors.PX1075_RaiseExceptionHandlingInEventHandlers
+					: Descriptors.PX1075_RaiseExceptionHandlingInEventHandlers_NonISV;
 			}
 
 			public override void VisitInvocationExpression(InvocationExpressionSyntax node)
@@ -75,16 +95,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.RaiseExceptionHandling
 					return;
 				}
 
-				if (!Settings.IsvSpecificAnalyzersEnabled && _eventType == EventType.FieldSelecting)
-				{
-					ReportDiagnostic(_context.ReportDiagnostic, Descriptors.PX1075_RaiseExceptionHandlingInEventHandlers_NonISV,
-									  node, _eventType);
-				}
-				else
-				{
-					ReportDiagnostic(_context.ReportDiagnostic, Descriptors.PX1075_RaiseExceptionHandlingInEventHandlers,
-									 node, _eventType);
-				}
+				ReportDiagnostic(_context.ReportDiagnostic, _px1075DiagnosticDescriptor, node, _eventTypeName);
 			}
 		}
 	}

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/RaiseExceptionHandling/RaiseExceptionHandlingInEventHandlersNonIsvTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/RaiseExceptionHandling/RaiseExceptionHandlingInEventHandlersNonIsvTests.cs
@@ -27,7 +27,9 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.RaiseExceptionHandling
 			Descriptors.PX1075_RaiseExceptionHandlingInEventHandlers.CreateFor(14, 4, EventType.FieldDefaulting),
 			Descriptors.PX1075_RaiseExceptionHandlingInEventHandlers_NonISV.CreateFor(19, 4, EventType.FieldSelecting),
 			Descriptors.PX1075_RaiseExceptionHandlingInEventHandlers.CreateFor(24, 4, EventType.RowSelecting),
-			Descriptors.PX1075_RaiseExceptionHandlingInEventHandlers.CreateFor(29, 4, EventType.RowPersisted));
+			Descriptors.PX1075_RaiseExceptionHandlingInEventHandlers.CreateFor(29, 4, EventType.RowPersisted),
+			Descriptors.PX1075_RaiseExceptionHandlingInEventHandlers.CreateFor(34, 4, EventType.FieldUpdating),
+			Descriptors.PX1075_RaiseExceptionHandlingInEventHandlers.CreateFor(39, 4, EventType.FieldUpdating));
 
 		[Theory]
 		[EmbeddedFileData(@"EventHandlers\EventHandlersWithExternalMethod.cs")]
@@ -35,7 +37,9 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.RaiseExceptionHandling
 			Descriptors.PX1075_RaiseExceptionHandlingInEventHandlers.CreateFor(14, 4, EventType.FieldDefaulting),
 			Descriptors.PX1075_RaiseExceptionHandlingInEventHandlers_NonISV.CreateFor(19, 4, EventType.FieldSelecting),
 			Descriptors.PX1075_RaiseExceptionHandlingInEventHandlers.CreateFor(24, 4, EventType.RowSelecting),
-			Descriptors.PX1075_RaiseExceptionHandlingInEventHandlers.CreateFor(29, 4, EventType.RowPersisted));
+			Descriptors.PX1075_RaiseExceptionHandlingInEventHandlers.CreateFor(29, 4, EventType.RowPersisted),
+			Descriptors.PX1075_RaiseExceptionHandlingInEventHandlers.CreateFor(34, 4, EventType.FieldUpdating),
+			Descriptors.PX1075_RaiseExceptionHandlingInEventHandlers.CreateFor(39, 4, EventType.FieldUpdating));
 
 		[Theory]
 		[EmbeddedFileData(@"EventHandlers\ValidEventHandlers.cs")]

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/RaiseExceptionHandling/RaiseExceptionHandlingInEventHandlersNonIsvTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/RaiseExceptionHandling/RaiseExceptionHandlingInEventHandlersNonIsvTests.cs
@@ -24,22 +24,16 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.RaiseExceptionHandling
 		[Theory]
 		[EmbeddedFileData(@"EventHandlers\EventHandlers.cs")]
 		public async Task EventHandlers(string actual) => await VerifyCSharpDiagnosticAsync(actual,
-			Descriptors.PX1075_RaiseExceptionHandlingInEventHandlers.CreateFor(14, 4, EventType.FieldDefaulting),
 			Descriptors.PX1075_RaiseExceptionHandlingInEventHandlers_NonISV.CreateFor(19, 4, EventType.FieldSelecting),
-			Descriptors.PX1075_RaiseExceptionHandlingInEventHandlers.CreateFor(24, 4, EventType.RowSelecting),
-			Descriptors.PX1075_RaiseExceptionHandlingInEventHandlers.CreateFor(29, 4, EventType.RowPersisted),
-			Descriptors.PX1075_RaiseExceptionHandlingInEventHandlers.CreateFor(34, 4, EventType.FieldUpdating),
-			Descriptors.PX1075_RaiseExceptionHandlingInEventHandlers.CreateFor(39, 4, EventType.FieldUpdating));
+			Descriptors.PX1075_RaiseExceptionHandlingInEventHandlers_NonISV.CreateFor(34, 4, EventType.FieldUpdating),
+			Descriptors.PX1075_RaiseExceptionHandlingInEventHandlers_NonISV.CreateFor(39, 4, EventType.FieldUpdating));
 
 		[Theory]
 		[EmbeddedFileData(@"EventHandlers\EventHandlersWithExternalMethod.cs")]
 		public async Task EventHandlersWithExternalMethod(string actual) => await VerifyCSharpDiagnosticAsync(actual,
-			Descriptors.PX1075_RaiseExceptionHandlingInEventHandlers.CreateFor(14, 4, EventType.FieldDefaulting),
 			Descriptors.PX1075_RaiseExceptionHandlingInEventHandlers_NonISV.CreateFor(19, 4, EventType.FieldSelecting),
-			Descriptors.PX1075_RaiseExceptionHandlingInEventHandlers.CreateFor(24, 4, EventType.RowSelecting),
-			Descriptors.PX1075_RaiseExceptionHandlingInEventHandlers.CreateFor(29, 4, EventType.RowPersisted),
-			Descriptors.PX1075_RaiseExceptionHandlingInEventHandlers.CreateFor(34, 4, EventType.FieldUpdating),
-			Descriptors.PX1075_RaiseExceptionHandlingInEventHandlers.CreateFor(39, 4, EventType.FieldUpdating));
+			Descriptors.PX1075_RaiseExceptionHandlingInEventHandlers_NonISV.CreateFor(34, 4, EventType.FieldUpdating),
+			Descriptors.PX1075_RaiseExceptionHandlingInEventHandlers_NonISV.CreateFor(39, 4, EventType.FieldUpdating));
 
 		[Theory]
 		[EmbeddedFileData(@"EventHandlers\ValidEventHandlers.cs")]

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/RaiseExceptionHandling/RaiseExceptionHandlingInEventHandlersTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/RaiseExceptionHandling/RaiseExceptionHandlingInEventHandlersTests.cs
@@ -32,7 +32,9 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.RaiseExceptionHandling
 			Descriptors.PX1075_RaiseExceptionHandlingInEventHandlers.CreateFor(14, 4, EventType.FieldDefaulting),
 			Descriptors.PX1075_RaiseExceptionHandlingInEventHandlers.CreateFor(19, 4, EventType.FieldSelecting),
 			Descriptors.PX1075_RaiseExceptionHandlingInEventHandlers.CreateFor(24, 4, EventType.RowSelecting),
-			Descriptors.PX1075_RaiseExceptionHandlingInEventHandlers.CreateFor(29, 4, EventType.RowPersisted));
+			Descriptors.PX1075_RaiseExceptionHandlingInEventHandlers.CreateFor(29, 4, EventType.RowPersisted),
+			Descriptors.PX1075_RaiseExceptionHandlingInEventHandlers.CreateFor(34, 4, EventType.FieldUpdating),
+			Descriptors.PX1075_RaiseExceptionHandlingInEventHandlers.CreateFor(39, 4, EventType.FieldUpdating));
 
 		[Theory]
 		[EmbeddedFileData(@"EventHandlers\EventHandlersWithExternalMethod.cs")]
@@ -40,7 +42,9 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.RaiseExceptionHandling
 			Descriptors.PX1075_RaiseExceptionHandlingInEventHandlers.CreateFor(14, 4, EventType.FieldDefaulting),
 			Descriptors.PX1075_RaiseExceptionHandlingInEventHandlers.CreateFor(19, 4, EventType.FieldSelecting),
 			Descriptors.PX1075_RaiseExceptionHandlingInEventHandlers.CreateFor(24, 4, EventType.RowSelecting),
-			Descriptors.PX1075_RaiseExceptionHandlingInEventHandlers.CreateFor(29, 4, EventType.RowPersisted));
+			Descriptors.PX1075_RaiseExceptionHandlingInEventHandlers.CreateFor(29, 4, EventType.RowPersisted),
+			Descriptors.PX1075_RaiseExceptionHandlingInEventHandlers.CreateFor(34, 4, EventType.FieldUpdating),
+			Descriptors.PX1075_RaiseExceptionHandlingInEventHandlers.CreateFor(39, 4, EventType.FieldUpdating));
 		
 		[Theory]
 		[EmbeddedFileData(@"EventHandlers\ValidEventHandlers.cs")]

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/RaiseExceptionHandling/Sources/EventHandlers/EventHandlers.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/RaiseExceptionHandling/Sources/EventHandlers/EventHandlers.cs
@@ -28,6 +28,16 @@ namespace PX.Objects
 		{
 			e.Cache.RaiseExceptionHandling<SOInvoice.refNbr>(null, null, new PXSetPropertyException("Something bad happened"));
 		}
+
+		protected virtual void _(Events.FieldUpdating<SOInvoice.refNbr> e)
+		{
+			e.Cache.RaiseExceptionHandling<SOInvoice.refNbr>(null, null, new PXSetPropertyException("Something bad happened"));
+		}
+
+		protected virtual void _(Events.FieldUpdating<SOInvoice, SOInvoice.refNbr> e)
+		{
+			e.Cache.RaiseExceptionHandling<SOInvoice.refNbr>(null, null, new PXSetPropertyException("Something bad happened"));
+		}
 	}
 
 	public class SOInvoice : IBqlTable

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/RaiseExceptionHandling/Sources/EventHandlers/EventHandlersWithExternalMethod.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/RaiseExceptionHandling/Sources/EventHandlers/EventHandlersWithExternalMethod.cs
@@ -29,6 +29,16 @@ namespace PX.Objects
 			ShowErrors(e.Cache);
 		}
 
+		protected virtual void _(Events.FieldUpdating<SOInvoice.refNbr> e)
+		{
+			ShowErrors(e.Cache);
+		}
+
+		protected virtual void _(Events.FieldUpdating<SOInvoice, SOInvoice.refNbr> e)
+		{
+			ShowErrors(e.Cache);
+		}
+
 		private void ShowErrors(PXCache cache)
 		{
 			cache.RaiseExceptionHandling<SOInvoice.refNbr>(null, null, new PXSetPropertyException("Something bad happened"));


### PR DESCRIPTION
Changes overview:
- Added support for field updating event to PX1075
- Fixed  a legacy bug which made diagnostic in non-ISV mode display errors for `PXCache.RaiseExceptionHandling` calls for all event handler besides field selecting. This contradicted the existing documentation and the intent in the code. 
- Significantly optimized PX1075 analysis:
    - Now the diagnostics calculates whether it should analyze event handler based on its event type only once in `ShouldAnalyze`, instead of doing this for every invocation expression.
    - Made descriptor calculation only once instead of doing it per every invocation expression
    - Removed boxing of event type enum value and multiple conversionsof event type to string.
- minor refactoring of PX1075 analysis
- extended unit tests for PX1075 for field updating event handlers
- fixed incorrect unit tests that  check buggy behavior
- reworked the documentation for PX1075, fixed links and added info about field updating event