### PR TITLE
Bugfix/atr 633 dev px1031 allow to string

### DIFF
--- a/docs/diagnostics/PX1031.md
+++ b/docs/diagnostics/PX1031.md
@@ -9,7 +9,7 @@ This document describes the PX1031 diagnostic.
 
 ## Diagnostic Description
 DACs and DAC extensions cannot contain instance methods. DACs and DAC extensions are the classes that are used to read and write data. Therefore, for appropriate program architecture and design, such classes cannot contain any application logic.
-The only exception to this rule is an override of the `ToString` method which can be useful to provide DAC text representation.
+The only exception to this rule is an override of the `ToString` method which can be useful to provide the string representation of the DAC and its fields.
 
 To fix the issue, you should remove instance methods from the DAC or the DAC extension.
 

--- a/docs/diagnostics/PX1031.md
+++ b/docs/diagnostics/PX1031.md
@@ -8,7 +8,8 @@ This document describes the PX1031 diagnostic.
 | PX1031 | DACs cannot contain instance methods. | Error | Unavailable | 
 
 ## Diagnostic Description
-DACs and DAC extensions cannot contain instance methods. DACs and DAC extensions are the classes that are used to read and write data. Therefore, for appropriate program architecture and design, such classes cannot contain any application logic. 
+DACs and DAC extensions cannot contain instance methods. DACs and DAC extensions are the classes that are used to read and write data. Therefore, for appropriate program architecture and design, such classes cannot contain any application logic.
+The only exception to this rule is an override of the `ToString` method which can be useful to provide DAC text representation.
 
 To fix the issue, you should remove instance methods from the DAC or the DAC extension.
 
@@ -22,6 +23,8 @@ public class POALCLandedCost : PXBqlTable, IBqlTable
     protected virtual void SetStatus() // The PX1031 error is displayed for this line.
     {
     }
+
+    public override string ToString() => "DAC"; // The "ToString" method override is allowed 
     #endregion
 }
 ```

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/MethodsUsageInDac/MethodsUsageInDacAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/MethodsUsageInDac/MethodsUsageInDacAnalyzer.cs
@@ -25,25 +25,25 @@ namespace Acuminator.Analyzers.StaticAnalysis.MethodsUsageInDac
 				Descriptors.PX1032_DacPropertyCannotContainMethodInvocations
 			);
 
-		public override void Analyze(SymbolAnalysisContext context, PXContext pxContext, DacSemanticModel dac)
+		public override void Analyze(SymbolAnalysisContext context, PXContext pxContext, DacSemanticModel dacOrDacExt)
 		{
 			context.CancellationToken.ThrowIfCancellationRequested();
 
 			// Node is not null here because DAC aggregated analyzers run only on DACs declared in source code
-			SemanticModel? semanticModel = context.Compilation.GetSemanticModel(dac.Node!.SyntaxTree);
+			SemanticModel? semanticModel = context.Compilation.GetSemanticModel(dacOrDacExt.Node!.SyntaxTree);
 
 			if (semanticModel == null)
 				return;
 
-			foreach (MethodDeclarationSyntax method in dac.GetMemberNodes<MethodDeclarationSyntax>())
+			foreach (MethodDeclarationSyntax method in dacOrDacExt.GetMemberNodes<MethodDeclarationSyntax>())
 			{
 				context.CancellationToken.ThrowIfCancellationRequested();
-				AnalyzeMethodDeclarationInDac(method, context, pxContext);
+				AnalyzeMethodDeclarationInDac(method, dacOrDacExt, context, pxContext);
 			}
 
 			HashSet<INamedTypeSymbol> allowedApis = GetAllowedApis(pxContext);
 
-			foreach (DacPropertyInfo property in dac.AllDeclaredProperties)
+			foreach (DacPropertyInfo property in dacOrDacExt.AllDeclaredProperties)
 			{
 				AnalyzeMethodInvocationInDacProperty(property, allowedApis, context, pxContext, semanticModel);
 			}
@@ -70,15 +70,20 @@ namespace Acuminator.Analyzers.StaticAnalysis.MethodsUsageInDac
 			};
 		}
 
-		private void AnalyzeMethodDeclarationInDac(MethodDeclarationSyntax method, SymbolAnalysisContext context, PXContext pxContext)
+		private void AnalyzeMethodDeclarationInDac(MethodDeclarationSyntax method, DacSemanticModel dacOrDacExt, SymbolAnalysisContext context,
+												   PXContext pxContext)
 		{
-			if (!method.IsStatic())
+			if (!method.IsStatic() && !IsToStringMethod(method))
 			{
 				context.ReportDiagnosticWithSuppressionCheck(
 					Diagnostic.Create(Descriptors.PX1031_DacCannotContainInstanceMethods, method.Identifier.GetLocation()),
 					pxContext.CodeAnalysisSettings);
 			}
 		}
+
+		private bool IsToStringMethod(MethodDeclarationSyntax method) =>
+			method.ParameterList?.Parameters.Count == 0 && method.IsOverride() &&
+			method.Identifier.Text == "ToString";
 
 		private void AnalyzeMethodInvocationInDacProperty(DacPropertyInfo property, HashSet<INamedTypeSymbol> allowedApis,
 														  SymbolAnalysisContext context, PXContext pxContext, SemanticModel semanticModel)

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/MethodsUsageInDac/Sources/DacExtensionWithMethodsUsage.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/MethodsUsageInDac/Sources/DacExtensionWithMethodsUsage.cs
@@ -55,7 +55,9 @@ namespace Acuminator.Tests.Sources
         public static void Update()
         {
         }
-    }
+
+		public override string ToString() => "DAC";
+	}
 
 	public class IIGPOALCLandedCost : IBqlTable
 	{

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/MethodsUsageInDac/Sources/DacWithMethodsUsage.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/MethodsUsageInDac/Sources/DacWithMethodsUsage.cs
@@ -51,5 +51,7 @@ namespace Acuminator.Tests.Sources
         public static void Update()
         {
         }
-    }
+
+		public override string ToString() => "DAC";
+	}
 }

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Syntax/MethodDeclarationUtils.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Syntax/MethodDeclarationUtils.cs
@@ -187,6 +187,11 @@ namespace Acuminator.Utilities.Roslyn.Syntax
 				.Modifiers
 				.Any(m => m.IsKind(SyntaxKind.StaticKeyword));
 
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static bool IsOverride(this MethodDeclarationSyntax node) =>
+		node.CheckIfNull()
+			.Modifiers
+			.Any(m => m.IsKind(SyntaxKind.OverrideKeyword));
 
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static bool IsVoidMethod(this MethodDeclarationSyntax methodNode)


### PR DESCRIPTION
**Changes Overview:**
- enhanced PX1031 analysis for instance methods in DACs and DAC extensions by allowing `ToString` overrides
- added `IsOverride` syntax node helper
- added scenario with `ToString` to PX1031 unit tests
- extended documentation for PX1031