### PR TITLE
Bugfix/atr 662 dev support new() in graph creation

### DIFF
--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/DatabaseQueries/DatabaseQueriesInRowSelectingAnalyzer.DiagnosticWalker.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/DatabaseQueries/DatabaseQueriesInRowSelectingAnalyzer.DiagnosticWalker.cs
@@ -20,7 +20,9 @@ namespace Acuminator.Analyzers.StaticAnalysis.DatabaseQueries
 			public DiagnosticWalker(SymbolAnalysisContext context, PXContext pxContext)
 				: base(context, pxContext, Descriptors.PX1042_DatabaseQueriesInRowSelecting)
 			{
-				_connectionScopeVisitor = new PXConnectionScopeVisitor(this, pxContext);
+				_connectionScopeVisitor = new PXConnectionScopeVisitor(this, pxContext, 
+														semanticModelGetter: GetSemanticModel, 
+														CancellationToken);
 			}
 
 			public override void VisitUsingStatement(UsingStatementSyntax node)
@@ -47,18 +49,11 @@ namespace Acuminator.Analyzers.StaticAnalysis.DatabaseQueries
 
 			public override void VisitLocalDeclarationStatement(LocalDeclarationStatementSyntax node)
 			{
-				// This method supports expressions like "using var x = new PXConnectionScope();"
+				// Expressions like "using var x = new PXConnectionScope();" are not supported and won't be supported
+				// since PX1042 diagnostic is obsolete and works only for Acumatica 2022R2 and older.
+				// No reason to invest into it.
 				ThrowIfCancellationRequested();
-
-				if (node.UsingKeyword == default || !node.UsingKeyword.IsKind(SyntaxKind.UsingKeyword) || _insideConnectionScope)
-				{
-					base.VisitLocalDeclarationStatement(node);
-					return;
-				}
-
-				_insideConnectionScope = node.Accept(_connectionScopeVisitor);
 				base.VisitLocalDeclarationStatement(node);
-				_insideConnectionScope = false;
 			}
 
 			public override void VisitInvocationExpression(InvocationExpressionSyntax node)

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/DatabaseQueries/DatabaseQueriesInRowSelectingAnalyzer.DiagnosticWalker.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/DatabaseQueries/DatabaseQueriesInRowSelectingAnalyzer.DiagnosticWalker.cs
@@ -1,4 +1,5 @@
-﻿using Acuminator.Utilities.Common;
+﻿using System.Threading;
+
 using Acuminator.Utilities.Roslyn.Semantic;
 
 using Microsoft.CodeAnalysis;
@@ -10,35 +11,8 @@ namespace Acuminator.Analyzers.StaticAnalysis.DatabaseQueries
 {
 	public partial class DatabaseQueriesInRowSelectingAnalyzer
 	{
-		private class DiagnosticWalker : Walker
+		private partial class DiagnosticWalker : Walker
 		{
-			private class PXConnectionScopeVisitor : CSharpSyntaxVisitor<bool>
-			{
-				private readonly DiagnosticWalker _parent;
-				private readonly PXContext _pxContext;
-
-				public PXConnectionScopeVisitor(DiagnosticWalker parent, PXContext pxContext)
-				{
-					_parent = parent.CheckIfNull();
-					_pxContext = pxContext.CheckIfNull();
-				}
-
-				public override bool VisitUsingStatement(UsingStatementSyntax node)
-				{
-					return (node.Declaration?.Accept(this) ?? false) || (node.Expression?.Accept(this) ?? false);
-				}
-
-				public override bool VisitObjectCreationExpression(ObjectCreationExpressionSyntax node)
-				{
-					var semanticModel = _parent.GetSemanticModel(node.SyntaxTree);
-					if (semanticModel == null)
-						return false;
-
-					var symbolInfo = semanticModel.GetSymbolInfo(node.Type, _parent.CancellationToken);
-					return symbolInfo.Symbol?.OriginalDefinition != null
-					       && symbolInfo.Symbol.OriginalDefinition.Equals(_pxContext.PXConnectionScope, SymbolEqualityComparer.Default);
-				}
-			}
 
 			private readonly PXConnectionScopeVisitor _connectionScopeVisitor;
 			private bool _insideConnectionScope;
@@ -59,10 +33,32 @@ namespace Acuminator.Analyzers.StaticAnalysis.DatabaseQueries
 				}
 				else
 				{
-					_insideConnectionScope = node.Accept(_connectionScopeVisitor);
-					base.VisitUsingStatement(node);
-					_insideConnectionScope = false;
+					try
+					{
+						_insideConnectionScope = node.Accept(_connectionScopeVisitor);
+						base.VisitUsingStatement(node);
+					}
+					finally
+					{
+						_insideConnectionScope = false;
+					}
 				}
+			}
+
+			public override void VisitLocalDeclarationStatement(LocalDeclarationStatementSyntax node)
+			{
+				// This method supports expressions like "using var x = new PXConnectionScope();"
+				ThrowIfCancellationRequested();
+
+				if (node.UsingKeyword == default || !node.UsingKeyword.IsKind(SyntaxKind.UsingKeyword) || _insideConnectionScope)
+				{
+					base.VisitLocalDeclarationStatement(node);
+					return;
+				}
+
+				_insideConnectionScope = node.Accept(_connectionScopeVisitor);
+				base.VisitLocalDeclarationStatement(node);
+				_insideConnectionScope = false;
 			}
 
 			public override void VisitInvocationExpression(InvocationExpressionSyntax node)

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/DatabaseQueries/DatabaseQueriesInRowSelectingAnalyzer.DiagnosticWalker.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/DatabaseQueries/DatabaseQueriesInRowSelectingAnalyzer.DiagnosticWalker.cs
@@ -1,0 +1,75 @@
+﻿using Acuminator.Utilities.Common;
+using Acuminator.Utilities.Roslyn.Semantic;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Acuminator.Analyzers.StaticAnalysis.DatabaseQueries
+{
+	public partial class DatabaseQueriesInRowSelectingAnalyzer
+	{
+		private class DiagnosticWalker : Walker
+		{
+			private class PXConnectionScopeVisitor : CSharpSyntaxVisitor<bool>
+			{
+				private readonly DiagnosticWalker _parent;
+				private readonly PXContext _pxContext;
+
+				public PXConnectionScopeVisitor(DiagnosticWalker parent, PXContext pxContext)
+				{
+					_parent = parent.CheckIfNull();
+					_pxContext = pxContext.CheckIfNull();
+				}
+
+				public override bool VisitUsingStatement(UsingStatementSyntax node)
+				{
+					return (node.Declaration?.Accept(this) ?? false) || (node.Expression?.Accept(this) ?? false);
+				}
+
+				public override bool VisitObjectCreationExpression(ObjectCreationExpressionSyntax node)
+				{
+					var semanticModel = _parent.GetSemanticModel(node.SyntaxTree);
+					if (semanticModel == null)
+						return false;
+
+					var symbolInfo = semanticModel.GetSymbolInfo(node.Type, _parent.CancellationToken);
+					return symbolInfo.Symbol?.OriginalDefinition != null
+					       && symbolInfo.Symbol.OriginalDefinition.Equals(_pxContext.PXConnectionScope, SymbolEqualityComparer.Default);
+				}
+			}
+
+			private readonly PXConnectionScopeVisitor _connectionScopeVisitor;
+			private bool _insideConnectionScope;
+
+			public DiagnosticWalker(SymbolAnalysisContext context, PXContext pxContext)
+				: base(context, pxContext, Descriptors.PX1042_DatabaseQueriesInRowSelecting)
+			{
+				_connectionScopeVisitor = new PXConnectionScopeVisitor(this, pxContext);
+			}
+
+			public override void VisitUsingStatement(UsingStatementSyntax node)
+			{
+				ThrowIfCancellationRequested();
+
+				if (_insideConnectionScope)
+				{
+					base.VisitUsingStatement(node);
+				}
+				else
+				{
+					_insideConnectionScope = node.Accept(_connectionScopeVisitor);
+					base.VisitUsingStatement(node);
+					_insideConnectionScope = false;
+				}
+			}
+
+			public override void VisitInvocationExpression(InvocationExpressionSyntax node)
+			{
+				if (!_insideConnectionScope)
+					base.VisitInvocationExpression(node);
+			}
+		}
+	}
+}

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/DatabaseQueries/DatabaseQueriesInRowSelectingAnalyzer.PXConnectionScopeVisitor.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/DatabaseQueries/DatabaseQueriesInRowSelectingAnalyzer.PXConnectionScopeVisitor.cs
@@ -1,0 +1,45 @@
+﻿using System.Threading;
+
+using Acuminator.Utilities.Common;
+using Acuminator.Utilities.Roslyn.Semantic;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Acuminator.Analyzers.StaticAnalysis.DatabaseQueries
+{
+	public partial class DatabaseQueriesInRowSelectingAnalyzer
+	{
+		private class PXConnectionScopeVisitor : CSharpSyntaxVisitor<bool>
+		{
+			private readonly DiagnosticWalker _parent;
+			private readonly PXContext _pxContext;
+			private readonly SemanticModel _semanticModel;
+			private readonly CancellationToken _cancellation;
+
+			public PXConnectionScopeVisitor(DiagnosticWalker parent, PXContext pxContext, SemanticModel semanticModel, 
+											CancellationToken cancellation)
+			{
+				_parent 	   = parent;
+				_pxContext 	   = pxContext;
+				_semanticModel = semanticModel;
+				_cancellation  = cancellation;
+			}
+
+			public override bool VisitUsingStatement(UsingStatementSyntax node)
+			{
+				return (node.Declaration?.Accept(this) ?? false) || (node.Expression?.Accept(this) ?? false);
+			}
+
+			public override bool VisitObjectCreationExpression(ObjectCreationExpressionSyntax node)
+			{
+				var symbol = _semanticModel.GetSymbolOrFirstCandidate(node.Type, _cancellation);
+
+				return symbol != null && 
+					   (symbol.Equals(_pxContext.PXConnectionScope, SymbolEqualityComparer.Default) ||
+						symbol.OriginalDefinition?.Equals(_pxContext.PXConnectionScope, SymbolEqualityComparer.Default) == true);
+			}
+		}
+	}
+}

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/DatabaseQueries/DatabaseQueriesInRowSelectingAnalyzer.PXConnectionScopeVisitor.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/DatabaseQueries/DatabaseQueriesInRowSelectingAnalyzer.PXConnectionScopeVisitor.cs
@@ -1,6 +1,6 @@
-﻿using System.Threading;
+﻿using System;
+using System.Threading;
 
-using Acuminator.Utilities.Common;
 using Acuminator.Utilities.Roslyn.Semantic;
 
 using Microsoft.CodeAnalysis;
@@ -15,16 +15,16 @@ namespace Acuminator.Analyzers.StaticAnalysis.DatabaseQueries
 		{
 			private readonly DiagnosticWalker _parent;
 			private readonly PXContext _pxContext;
-			private readonly SemanticModel _semanticModel;
+			private readonly Func<SyntaxTree, SemanticModel?> _semanticModelGetter;
 			private readonly CancellationToken _cancellation;
 
-			public PXConnectionScopeVisitor(DiagnosticWalker parent, PXContext pxContext, SemanticModel semanticModel, 
+			public PXConnectionScopeVisitor(DiagnosticWalker parent, PXContext pxContext, Func<SyntaxTree, SemanticModel?> semanticModelGetter,
 											CancellationToken cancellation)
 			{
-				_parent 	   = parent;
-				_pxContext 	   = pxContext;
-				_semanticModel = semanticModel;
-				_cancellation  = cancellation;
+				_parent 			 = parent;
+				_pxContext 	   		 = pxContext;
+				_semanticModelGetter = semanticModelGetter;
+				_cancellation  		 = cancellation;
 			}
 
 			public override bool VisitUsingStatement(UsingStatementSyntax node)
@@ -34,12 +34,26 @@ namespace Acuminator.Analyzers.StaticAnalysis.DatabaseQueries
 
 			public override bool VisitObjectCreationExpression(ObjectCreationExpressionSyntax node)
 			{
-				var symbol = _semanticModel.GetSymbolOrFirstCandidate(node.Type, _cancellation);
-
-				return symbol != null && 
-					   (symbol.Equals(_pxContext.PXConnectionScope, SymbolEqualityComparer.Default) ||
-						symbol.OriginalDefinition?.Equals(_pxContext.PXConnectionScope, SymbolEqualityComparer.Default) == true);
+				var semanticModel = _semanticModelGetter(node.SyntaxTree);
+				var typeSymbol = semanticModel?.GetSymbolOrFirstCandidate(node.Type, _cancellation) as ITypeSymbol;
+				return IsPXConnectionScope(typeSymbol);
 			}
+
+			public override bool VisitImplicitObjectCreationExpression(ImplicitObjectCreationExpressionSyntax node)
+			{
+				var semanticModel = _semanticModelGetter(node.SyntaxTree);
+				var constructor = semanticModel?.GetSymbolOrFirstCandidate(node, _cancellation) as IMethodSymbol;
+
+				if (constructor?.ContainingType == null || constructor.MethodKind != MethodKind.Constructor)
+					return false;
+
+				return IsPXConnectionScope(constructor.ContainingType);
+			}
+
+			private bool IsPXConnectionScope(ITypeSymbol? typeSymbol) =>
+				typeSymbol != null &&
+				(typeSymbol.Equals(_pxContext.PXConnectionScope, SymbolEqualityComparer.Default) ||
+				 typeSymbol.OriginalDefinition?.Equals(_pxContext.PXConnectionScope, SymbolEqualityComparer.Default) == true);
 		}
 	}
 }

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/DatabaseQueries/DatabaseQueriesInRowSelectingAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/DatabaseQueries/DatabaseQueriesInRowSelectingAnalyzer.cs
@@ -1,24 +1,20 @@
-﻿
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 
 using Acuminator.Analyzers.StaticAnalysis.EventHandlers;
-using Acuminator.Utilities.Common;
-using Acuminator.Utilities.Roslyn;
 using Acuminator.Utilities.Roslyn.Semantic;
 using Acuminator.Utilities.Roslyn.Semantic.AcumaticaEvents;
 using Acuminator.Utilities.Roslyn.Syntax;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Acuminator.Analyzers.StaticAnalysis.DatabaseQueries
 {
-	public class DatabaseQueriesInRowSelectingAnalyzer : LooseEventHandlerAggregatedAnalyzerBase
+	public partial class DatabaseQueriesInRowSelectingAnalyzer : LooseEventHandlerAggregatedAnalyzerBase
 	{
 		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
 			ImmutableArray.Create(Descriptors.PX1042_DatabaseQueriesInRowSelecting);
@@ -34,69 +30,6 @@ namespace Acuminator.Analyzers.StaticAnalysis.DatabaseQueries
 			var methodSymbol = context.Symbol as IMethodSymbol;
 			var methodSyntax = methodSymbol?.GetSyntax(context.CancellationToken) as CSharpSyntaxNode;
 			methodSyntax?.Accept(new DiagnosticWalker(context, pxContext));
-		}
-
-
-		private class DiagnosticWalker : Walker
-		{
-			private class PXConnectionScopeVisitor : CSharpSyntaxVisitor<bool>
-			{
-				private readonly DiagnosticWalker _parent;
-				private readonly PXContext _pxContext;
-
-				public PXConnectionScopeVisitor(DiagnosticWalker parent, PXContext pxContext)
-				{
-					_parent = parent.CheckIfNull();
-					_pxContext = pxContext.CheckIfNull();
-				}
-
-				public override bool VisitUsingStatement(UsingStatementSyntax node)
-				{
-					return (node.Declaration?.Accept(this) ?? false) || (node.Expression?.Accept(this) ?? false);
-				}
-
-				public override bool VisitObjectCreationExpression(ObjectCreationExpressionSyntax node)
-				{
-					var semanticModel = _parent.GetSemanticModel(node.SyntaxTree);
-					if (semanticModel == null)
-						return false;
-
-					var symbolInfo = semanticModel.GetSymbolInfo(node.Type, _parent.CancellationToken);
-					return symbolInfo.Symbol?.OriginalDefinition != null
-					       && symbolInfo.Symbol.OriginalDefinition.Equals(_pxContext.PXConnectionScope, SymbolEqualityComparer.Default);
-				}
-			}
-
-			private readonly PXConnectionScopeVisitor _connectionScopeVisitor;
-			private bool _insideConnectionScope;
-
-			public DiagnosticWalker(SymbolAnalysisContext context, PXContext pxContext)
-				: base(context, pxContext, Descriptors.PX1042_DatabaseQueriesInRowSelecting)
-			{
-				_connectionScopeVisitor = new PXConnectionScopeVisitor(this, pxContext);
-			}
-
-			public override void VisitUsingStatement(UsingStatementSyntax node)
-			{
-				ThrowIfCancellationRequested();
-
-				if (_insideConnectionScope)
-				{
-					base.VisitUsingStatement(node);
-				}
-				else
-				{
-					_insideConnectionScope = node.Accept(_connectionScopeVisitor);
-					base.VisitUsingStatement(node);
-					_insideConnectionScope = false;
-				}
-			}
-
-			public override void VisitInvocationExpression(InvocationExpressionSyntax node)
-			{
-				if (!_insideConnectionScope)
-					base.VisitInvocationExpression(node);
-			}
 		}
 	}
 }

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXGraphCreateInstance/PXGraphCreateInstanceAnalyzer.Walker.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXGraphCreateInstance/PXGraphCreateInstanceAnalyzer.Walker.cs
@@ -43,8 +43,35 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXGraphCreateInstance
 					_context.ReportDiagnosticWithSuppressionCheck(Diagnostic.Create(descriptor, node.GetLocation()),
 						_pxContext.CodeAnalysisSettings);
 				}
+				else
+				{
+					base.VisitObjectCreationExpression(node);
+				}
+			}
 
-				base.VisitObjectCreationExpression(node);
+			public override void VisitImplicitObjectCreationExpression(ImplicitObjectCreationExpressionSyntax node)
+			{
+				_context.CancellationToken.ThrowIfCancellationRequested();
+
+				var constructor = _semanticModel.GetSymbolOrFirstCandidate(node, _context.CancellationToken) as IMethodSymbol;
+
+				if (constructor?.ContainingType == null || constructor.MethodKind != MethodKind.Constructor) 
+				{
+					base.VisitImplicitObjectCreationExpression(node);
+					return;
+				}
+
+				DiagnosticDescriptor? descriptor = GetDiagnosticDescriptor(constructor.ContainingType);
+
+				if (descriptor != null)
+				{
+					_context.ReportDiagnosticWithSuppressionCheck(Diagnostic.Create(descriptor, node.GetLocation()),
+						_pxContext.CodeAnalysisSettings);
+				}
+				else
+				{
+					base.VisitImplicitObjectCreationExpression(node);
+				}
 			}
 
 			private DiagnosticDescriptor? GetDiagnosticDescriptor(ITypeSymbol typeSymbol)

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXGraphCreateInstance/PXGraphCreateInstanceAnalyzer.Walker.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXGraphCreateInstance/PXGraphCreateInstanceAnalyzer.Walker.cs
@@ -1,0 +1,75 @@
+﻿using Acuminator.Utilities.DiagnosticSuppression;
+using Acuminator.Utilities.Roslyn.Semantic;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Acuminator.Analyzers.StaticAnalysis.PXGraphCreateInstance
+{
+	public partial class PXGraphCreateInstanceAnalyzer
+	{
+		private class Walker : CSharpSyntaxWalker
+		{
+			private readonly SyntaxNodeAnalysisContext _context;
+			private readonly PXContext _pxContext;
+			private readonly SemanticModel _semanticModel;
+
+			private static readonly DiagnosticDescriptor _px1001Descriptor = Descriptors.PX1001_PXGraphCreateInstance;
+			private static readonly DiagnosticDescriptor _px1003Descriptor = Descriptors.PX1003_NonSpecificPXGraphCreateInstance;
+
+			public Walker(SyntaxNodeAnalysisContext context, PXContext pxContext, SemanticModel semanticModel)
+			{
+				_context = context;
+				_pxContext = pxContext;
+				_semanticModel = semanticModel;
+			}
+
+			public override void VisitObjectCreationExpression(ObjectCreationExpressionSyntax node)
+			{
+				_context.CancellationToken.ThrowIfCancellationRequested();
+
+				if (node.Type == null || _semanticModel.GetSymbolOrFirstCandidate(node.Type, _context.CancellationToken) is not ITypeSymbol typeSymbol)
+				{
+					base.VisitObjectCreationExpression(node);
+					return;
+				}
+
+				DiagnosticDescriptor? descriptor = GetDiagnosticDescriptor(typeSymbol);
+
+				if (descriptor != null)
+				{
+					_context.ReportDiagnosticWithSuppressionCheck(Diagnostic.Create(descriptor, node.GetLocation()),
+						_pxContext.CodeAnalysisSettings);
+				}
+
+				base.VisitObjectCreationExpression(node);
+			}
+
+			private DiagnosticDescriptor? GetDiagnosticDescriptor(ITypeSymbol typeSymbol)
+			{
+				if (typeSymbol is ITypeParameterSymbol typeParameterSymbol && typeParameterSymbol.IsPXGraph(_pxContext))
+				{
+					return _px1001Descriptor;
+				}
+				else if (typeSymbol.InheritsFrom(_pxContext.PXGraph.Type))
+				{
+					return _px1001Descriptor;
+				}
+				else if (typeSymbol.Equals(_pxContext.PXGraph.Type, SymbolEqualityComparer.Default))
+				{
+					return _px1003Descriptor;
+				}
+
+				return null;
+			}
+
+			public override void DefaultVisit(SyntaxNode node)
+			{
+				_context.CancellationToken.ThrowIfCancellationRequested();
+				base.DefaultVisit(node);
+			}
+		}
+	}
+}

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXGraphCreateInstance/PXGraphCreateInstanceAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXGraphCreateInstance/PXGraphCreateInstanceAnalyzer.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Immutable;
 
 using Acuminator.Utilities;
-using Acuminator.Utilities.DiagnosticSuppression;
 using Acuminator.Utilities.Roslyn.Semantic;
 
 using Microsoft.CodeAnalysis;
@@ -12,70 +11,8 @@ using Microsoft.CodeAnalysis.Diagnostics;
 namespace Acuminator.Analyzers.StaticAnalysis.PXGraphCreateInstance
 {
 	[DiagnosticAnalyzer(LanguageNames.CSharp)]
-	public class PXGraphCreateInstanceAnalyzer : PXDiagnosticAnalyzer
+	public partial class PXGraphCreateInstanceAnalyzer : PXDiagnosticAnalyzer
 	{
-		private class Walker : CSharpSyntaxWalker
-		{
-			private readonly SyntaxNodeAnalysisContext _context;
-			private readonly PXContext _pxContext;
-			private readonly SemanticModel _semanticModel;
-
-			private static readonly DiagnosticDescriptor _px1001Descriptor = Descriptors.PX1001_PXGraphCreateInstance;
-			private static readonly DiagnosticDescriptor _px1003Descriptor = Descriptors.PX1003_NonSpecificPXGraphCreateInstance;
-
-			public Walker(SyntaxNodeAnalysisContext context, PXContext pxContext, SemanticModel semanticModel)
-			{
-				_context = context;
-				_pxContext = pxContext;
-				_semanticModel = semanticModel;
-			}
-
-			public override void VisitObjectCreationExpression(ObjectCreationExpressionSyntax node)
-			{
-				_context.CancellationToken.ThrowIfCancellationRequested();
-
-				if (node.Type == null || _semanticModel.GetSymbolOrFirstCandidate(node.Type, _context.CancellationToken) is not ITypeSymbol typeSymbol)
-				{
-					base.VisitObjectCreationExpression(node);
-					return;
-				}
-
-				DiagnosticDescriptor? descriptor = GetDiagnosticDescriptor(typeSymbol);
-
-				if (descriptor != null)
-				{
-					_context.ReportDiagnosticWithSuppressionCheck(Diagnostic.Create(descriptor, node.GetLocation()),
-						_pxContext.CodeAnalysisSettings);
-				}
-
-				base.VisitObjectCreationExpression(node);
-			}
-
-			private DiagnosticDescriptor? GetDiagnosticDescriptor(ITypeSymbol typeSymbol)
-			{
-				if (typeSymbol is ITypeParameterSymbol typeParameterSymbol && typeParameterSymbol.IsPXGraph(_pxContext))
-				{
-					return _px1001Descriptor;
-				}
-				else if (typeSymbol.InheritsFrom(_pxContext.PXGraph.Type))
-				{
-					return _px1001Descriptor;
-				}
-				else if (typeSymbol.Equals(_pxContext.PXGraph.Type, SymbolEqualityComparer.Default))
-				{
-					return _px1003Descriptor;
-				}
-
-				return null;
-			}
-
-			public override void DefaultVisit(SyntaxNode node)
-			{
-				_context.CancellationToken.ThrowIfCancellationRequested();
-				base.DefaultVisit(node);
-			}
-		}
-
 		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(
 				Descriptors.PX1001_PXGraphCreateInstance,
 				Descriptors.PX1003_NonSpecificPXGraphCreateInstance);

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXGraphCreateInstance/PXGraphCreateInstanceAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXGraphCreateInstance/PXGraphCreateInstanceAnalyzer.cs
@@ -1,5 +1,4 @@
-﻿
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 
 using Acuminator.Utilities;
 using Acuminator.Utilities.DiagnosticSuppression;
@@ -20,6 +19,9 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXGraphCreateInstance
 			private readonly SyntaxNodeAnalysisContext _context;
 			private readonly PXContext _pxContext;
 			private readonly SemanticModel _semanticModel;
+
+			private static readonly DiagnosticDescriptor _px1001Descriptor = Descriptors.PX1001_PXGraphCreateInstance;
+			private static readonly DiagnosticDescriptor _px1003Descriptor = Descriptors.PX1003_NonSpecificPXGraphCreateInstance;
 
 			public Walker(SyntaxNodeAnalysisContext context, PXContext pxContext, SemanticModel semanticModel)
 			{
@@ -51,30 +53,30 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXGraphCreateInstance
 			{
 				if (typeSymbol is ITypeParameterSymbol typeParameterSymbol && typeParameterSymbol.IsPXGraph(_pxContext))
 				{
-					return Descriptors.PX1001_PXGraphCreateInstance;
+					return _px1001Descriptor;
 				}
 				else if (typeSymbol.InheritsFrom(_pxContext.PXGraph.Type))
 				{
-					return Descriptors.PX1001_PXGraphCreateInstance;
+					return _px1001Descriptor;
 				}
 				else if (typeSymbol.Equals(_pxContext.PXGraph.Type, SymbolEqualityComparer.Default))
 				{
-					return Descriptors.PX1003_NonSpecificPXGraphCreateInstance;
+					return _px1003Descriptor;
 				}
 
 				return null;
 			}
 		}
 
+		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(
+				Descriptors.PX1001_PXGraphCreateInstance,
+				Descriptors.PX1003_NonSpecificPXGraphCreateInstance);
+
 		public PXGraphCreateInstanceAnalyzer() : this(null)
 		{ }
 
 		public PXGraphCreateInstanceAnalyzer(CodeAnalysisSettings? codeAnalysisSettings) : base(codeAnalysisSettings)
 		{ }
-
-		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(
-				Descriptors.PX1001_PXGraphCreateInstance,
-				Descriptors.PX1003_NonSpecificPXGraphCreateInstance);
 
 		protected override void AnalyzeCompilation(CompilationStartAnalysisContext compilationStartContext, PXContext pxContext)
 		{

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXGraphCreateInstance/PXGraphCreateInstanceAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXGraphCreateInstance/PXGraphCreateInstanceAnalyzer.cs
@@ -32,7 +32,9 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXGraphCreateInstance
 
 			public override void VisitObjectCreationExpression(ObjectCreationExpressionSyntax node)
 			{
-				if (node.Type == null || _semanticModel.GetSymbolInfo(node.Type).Symbol is not ITypeSymbol typeSymbol)
+				_context.CancellationToken.ThrowIfCancellationRequested();
+
+				if (node.Type == null || _semanticModel.GetSymbolOrFirstCandidate(node.Type, _context.CancellationToken) is not ITypeSymbol typeSymbol)
 				{
 					base.VisitObjectCreationExpression(node);
 					return;
@@ -65,6 +67,12 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXGraphCreateInstance
 				}
 
 				return null;
+			}
+
+			public override void DefaultVisit(SyntaxNode node)
+			{
+				_context.CancellationToken.ThrowIfCancellationRequested();
+				base.DefaultVisit(node);
 			}
 		}
 

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXGraphCreateInstance/PXGraphCreateInstanceFix.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXGraphCreateInstance/PXGraphCreateInstanceFix.cs
@@ -86,6 +86,22 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXGraphCreateInstance
 				return createInstanceCallNode ?? base.VisitObjectCreationExpression(node);
 			}
 
+			public override SyntaxNode? VisitImplicitObjectCreationExpression(ImplicitObjectCreationExpressionSyntax node)
+			{
+				_cancellation.ThrowIfCancellationRequested();
+
+				if (_generator == null)
+					return base.VisitImplicitObjectCreationExpression(node);
+
+				var constructor = _semanticModel.GetSymbolInfo(node, _cancellation).Symbol as IMethodSymbol;
+
+				if (constructor?.ContainingType == null || constructor.MethodKind != MethodKind.Constructor)
+					return base.VisitImplicitObjectCreationExpression(node);
+
+				var createInstanceCallNode = GeneratePXGraphCreateInstanceCall(constructor.ContainingType);
+				return createInstanceCallNode ?? base.VisitImplicitObjectCreationExpression(node);
+			}
+
 			private SyntaxNode? GeneratePXGraphCreateInstanceCall(ITypeSymbol? graphTypeSymbol)
 			{
 				if (graphTypeSymbol == null)

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXGraphCreateInstance/PXGraphCreateInstanceFix.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXGraphCreateInstance/PXGraphCreateInstanceFix.cs
@@ -37,15 +37,10 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXGraphCreateInstance
 
 		private static async Task<Document> RewriteGraphConstructionAsync(Document document, TextSpan span, CancellationToken cancellation)
 		{
-			var root = await document.GetSyntaxRootAsync(cancellation).ConfigureAwait(false);
+			var (semanticModel, root) = await document.GetSemanticModelAndRootAsync(cancellation).ConfigureAwait(false);
 			var nodeWithDiagnostic = root?.FindNode(span);
 
-			if (nodeWithDiagnostic == null)
-				return document;
-
-			var semanticModel = await document.GetSemanticModelAsync(cancellation).ConfigureAwait(false);
-
-			if (semanticModel == null)
+			if (semanticModel == null || nodeWithDiagnostic == null)
 				return document;
 
 			var pxContext = new PXContext(semanticModel.Compilation, codeAnalysisSettings: null);

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXGraphCreateInstance/PXGraphCreateInstanceFix.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXGraphCreateInstance/PXGraphCreateInstanceFix.cs
@@ -60,33 +60,47 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXGraphCreateInstance
 		{
 			private readonly PXContext _pxContext;
 			private readonly Document _document;
+			private readonly SyntaxGenerator? _generator;
 			private readonly SemanticModel _semanticModel;
 			private readonly CancellationToken _cancellation;
 
 			public Rewriter(PXContext pxContext, Document document, SemanticModel semanticModel, CancellationToken cancellation)
 			{
-				_pxContext = pxContext;
-				_document = document;
+				_pxContext 	   = pxContext;
+				_document 	   = document;
 				_semanticModel = semanticModel;
-				_cancellation = cancellation;
+				_cancellation  = cancellation;
+				_generator 	   = SyntaxGenerator.GetGenerator(_document);
 			}
 
 			public override SyntaxNode? VisitObjectCreationExpression(ObjectCreationExpressionSyntax node)
 			{
 				_cancellation.ThrowIfCancellationRequested();
 
-				var generator = SyntaxGenerator.GetGenerator(_document);
-				var typeSymbol = _semanticModel.GetSymbolInfo(node.Type, _cancellation).Symbol as ITypeSymbol;
+				if (_generator == null) 
+					return base.VisitObjectCreationExpression(node);
 
-				if (typeSymbol != null)
-				{
-					return generator.InvocationExpression(
-						generator.MemberAccessExpression(
-							generator.TypeExpression(_pxContext.PXGraph.Type),
-							generator.GenericName(DelegateNames.CreateInstance, typeSymbol)));
-				}
+				var graphTypeSymbol		   = _semanticModel.GetSymbolInfo(node.Type, _cancellation).Symbol as ITypeSymbol;
+				var createInstanceCallNode = GeneratePXGraphCreateInstanceCall(graphTypeSymbol);
 
-				return base.VisitObjectCreationExpression(node);
+				return createInstanceCallNode ?? base.VisitObjectCreationExpression(node);
+			}
+
+			private SyntaxNode? GeneratePXGraphCreateInstanceCall(ITypeSymbol? graphTypeSymbol)
+			{
+				if (graphTypeSymbol == null)
+					return null;
+
+				return _generator!.InvocationExpression(
+						_generator.MemberAccessExpression(
+							_generator.TypeExpression(_pxContext.PXGraph.Type),
+							_generator.GenericName(DelegateNames.CreateInstance, graphTypeSymbol)));
+			}
+
+			public override SyntaxNode? DefaultVisit(SyntaxNode node)
+			{
+				_cancellation.ThrowIfCancellationRequested();
+				return base.DefaultVisit(node);
 			}
 		}
 	}

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXGraphCreateInstance/PXGraphCreateInstanceFix.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXGraphCreateInstance/PXGraphCreateInstanceFix.cs
@@ -3,7 +3,6 @@ using System.Composition;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Xml.Linq;
 
 using Acuminator.Utilities.Roslyn.Constants;
 using Acuminator.Utilities.Roslyn.Semantic;
@@ -21,40 +20,6 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXGraphCreateInstance
 	[ExportCodeFixProvider(LanguageNames.CSharp), Shared]
 	public class PXGraphCreateInstanceFix : PXCodeFixProvider
 	{
-		private class Rewriter : CSharpSyntaxRewriter
-		{
-			private readonly PXContext _pxContext;
-			private readonly Document _document;
-			private readonly SemanticModel _semanticModel;
-			private readonly CancellationToken _cancellation;
-
-			public Rewriter(PXContext pxContext, Document document, SemanticModel semanticModel, CancellationToken cancellation)
-			{
-				_pxContext = pxContext;
-				_document = document;
-				_semanticModel = semanticModel;
-				_cancellation = cancellation;
-			}
-
-			public override SyntaxNode? VisitObjectCreationExpression(ObjectCreationExpressionSyntax node)
-			{
-				_cancellation.ThrowIfCancellationRequested();
-
-				var generator = SyntaxGenerator.GetGenerator(_document);
-				var typeSymbol = _semanticModel.GetSymbolInfo(node.Type, _cancellation).Symbol as ITypeSymbol;
-
-				if (typeSymbol != null)
-				{
-					return generator.InvocationExpression(
-						generator.MemberAccessExpression(
-							generator.TypeExpression(_pxContext.PXGraph.Type),
-							generator.GenericName(DelegateNames.CreateInstance, typeSymbol)));
-				}
-
-				return base.VisitObjectCreationExpression(node);
-			}
-		}
-
 		public override ImmutableArray<string> FixableDiagnosticIds { get; } =
 			ImmutableArray.Create(Descriptors.PX1001_PXGraphCreateInstance.Id);
 
@@ -93,6 +58,41 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXGraphCreateInstance
 			var newRoot = root!.ReplaceNode(nodeWithDiagnostic, newNode);
 
 			return document.WithSyntaxRoot(newRoot);
+		}
+
+
+		private class Rewriter : CSharpSyntaxRewriter
+		{
+			private readonly PXContext _pxContext;
+			private readonly Document _document;
+			private readonly SemanticModel _semanticModel;
+			private readonly CancellationToken _cancellation;
+
+			public Rewriter(PXContext pxContext, Document document, SemanticModel semanticModel, CancellationToken cancellation)
+			{
+				_pxContext = pxContext;
+				_document = document;
+				_semanticModel = semanticModel;
+				_cancellation = cancellation;
+			}
+
+			public override SyntaxNode? VisitObjectCreationExpression(ObjectCreationExpressionSyntax node)
+			{
+				_cancellation.ThrowIfCancellationRequested();
+
+				var generator = SyntaxGenerator.GetGenerator(_document);
+				var typeSymbol = _semanticModel.GetSymbolInfo(node.Type, _cancellation).Symbol as ITypeSymbol;
+
+				if (typeSymbol != null)
+				{
+					return generator.InvocationExpression(
+						generator.MemberAccessExpression(
+							generator.TypeExpression(_pxContext.PXGraph.Type),
+							generator.GenericName(DelegateNames.CreateInstance, typeSymbol)));
+				}
+
+				return base.VisitObjectCreationExpression(node);
+			}
 		}
 	}
 }

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXGraphCreateInstance/PXGraphCreateInstanceInEventHandlersAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXGraphCreateInstance/PXGraphCreateInstanceInEventHandlersAnalyzer.cs
@@ -1,15 +1,13 @@
-﻿
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 
 using Acuminator.Analyzers.StaticAnalysis.EventHandlers;
-using Acuminator.Utilities.Roslyn;
 using Acuminator.Utilities.Roslyn.Semantic;
 using Acuminator.Utilities.Roslyn.Semantic.AcumaticaEvents;
 using Acuminator.Utilities.Roslyn.Syntax;
+using Acuminator.Utilities.Roslyn.Walkers;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Acuminator.Analyzers.StaticAnalysis.PXGraphCreateInstance
@@ -32,59 +30,15 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXGraphCreateInstance
 			methodSyntax?.Accept(walker);
 		}
 
-		private class Walker : NestedInvocationWalker
+		private class Walker(SymbolAnalysisContext context, PXContext pxContext) : PXGraphCreateInstanceWalkerBase(context, pxContext)
 		{
-			private const string CreateInstanceMethodName = "CreateInstance";
+			private static readonly DiagnosticDescriptor _px1045_isv	= Descriptors.PX1045_PXGraphCreateInstanceInEventHandlers;
+			private static readonly DiagnosticDescriptor _px1045_nonIsv = Descriptors.PX1045_PXGraphCreateInstanceInEventHandlers_NonISV;
 
-			private readonly SymbolAnalysisContext _context;
-
-			public Walker(SymbolAnalysisContext context, PXContext pxContext)
-				: base(pxContext, context.CancellationToken)
-			{
-				_context = context;
-			}
-
-			public override void VisitInvocationExpression(InvocationExpressionSyntax node)
-			{
-				ThrowIfCancellationRequested();
-
-				var methodSymbol = GetSymbol<IMethodSymbol>(node);
-
-				if (methodSymbol?.ContainingType?.OriginalDefinition != null &&
-					methodSymbol.ContainingType.OriginalDefinition.IsPXGraph() &&
-					methodSymbol.Name == CreateInstanceMethodName)
-				{
-					ReportDiagnostic(
-						_context.ReportDiagnostic,
-						Settings.IsvSpecificAnalyzersEnabled
-							? Descriptors.PX1045_PXGraphCreateInstanceInEventHandlers
-							: Descriptors.PX1045_PXGraphCreateInstanceInEventHandlers_NonISV, node);
-				}
-				else
-				{
-					base.VisitInvocationExpression(node);
-				}
-			}
-
-			public override void VisitObjectCreationExpression(ObjectCreationExpressionSyntax node)
-			{
-				if (node.Type != null)
-				{
-					var typeSymbol = GetSymbol<ITypeSymbol>(node.Type);
-
-					if (typeSymbol != null && typeSymbol.IsPXGraph())
-					{
-						ReportDiagnostic(
-							_context.ReportDiagnostic,
-							Settings.IsvSpecificAnalyzersEnabled
-								? Descriptors.PX1045_PXGraphCreateInstanceInEventHandlers
-								: Descriptors.PX1045_PXGraphCreateInstanceInEventHandlers_NonISV,
-							node);
-					}
-				}
-
-				base.VisitObjectCreationExpression(node);
-			}
+			protected override DiagnosticDescriptor Descriptor =>
+				Settings.IsvSpecificAnalyzersEnabled
+					? _px1045_isv
+					: _px1045_nonIsv;
 		}
 	}
 }

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXGraphCreationInGraphInWrongPlaces/PXGraphCreateInstanceInGraphInitializationAndDataViewsWalker.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXGraphCreationInGraphInWrongPlaces/PXGraphCreateInstanceInGraphInitializationAndDataViewsWalker.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using Acuminator.Utilities.Common;
+using Acuminator.Utilities.Roslyn.Semantic;
+using Acuminator.Utilities.Roslyn.Walkers;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Acuminator.Analyzers.StaticAnalysis.PXGraphCreationInGraphInWrongPlaces
+{
+	/// <summary>
+	/// Recursive walker that reports graph creation in graph initialization and data views.
+	/// </summary>
+	public class PXGraphCreateInstanceInGraphInitializationAndDataViewsWalker : PXGraphCreateInstanceWalkerBase
+	{
+		protected override DiagnosticDescriptor Descriptor { get; }
+
+		public PXGraphCreateInstanceInGraphInitializationAndDataViewsWalker(SymbolAnalysisContext context, PXContext pxContext, 
+																			DiagnosticDescriptor descriptor) : 
+																		base(context, pxContext)
+		{
+			Descriptor = descriptor.CheckIfNull();
+		}
+	}
+}

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXGraphCreationInGraphInWrongPlaces/PXGraphCreationInGraphInWrongPlacesDacAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXGraphCreationInGraphInWrongPlaces/PXGraphCreationInGraphInWrongPlacesDacAnalyzer.cs
@@ -1,9 +1,6 @@
-﻿
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 
 using Acuminator.Analyzers.StaticAnalysis.Dac;
-using Acuminator.Utilities;
-using Acuminator.Utilities.Roslyn.Walkers;
 using Acuminator.Utilities.Roslyn.Semantic;
 using Acuminator.Utilities.Roslyn.Semantic.Dac;
 
@@ -28,8 +25,8 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXGraphCreationInGraphInWrongPlace
 		{
 			context.CancellationToken.ThrowIfCancellationRequested();
 
-			var graphIsActiveMethodWalker = new PXGraphCreateInstanceWalker(context, pxContext, Descriptors.PX1056_PXGraphCreationInIsActiveMethod);
-
+			var graphIsActiveMethodWalker = new PXGraphCreateInstanceInGraphInitializationAndDataViewsWalker(context, pxContext, 
+																							Descriptors.PX1056_PXGraphCreationInIsActiveMethod);
 			// Node not null here because it is checked in ShouldAnalyze
 			graphIsActiveMethodWalker.Visit(dacExtension.IsActiveMethodInfo!.Node);
 		}

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXGraphCreationInGraphInWrongPlaces/PXGraphCreationInGraphInWrongPlacesGraphAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXGraphCreationInGraphInWrongPlaces/PXGraphCreationInGraphInWrongPlacesGraphAnalyzer.cs
@@ -1,9 +1,6 @@
-﻿
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 
 using Acuminator.Analyzers.StaticAnalysis.PXGraph;
-using Acuminator.Utilities;
-using Acuminator.Utilities.Roslyn.Walkers;
 using Acuminator.Utilities.Roslyn.Semantic;
 using Acuminator.Utilities.Roslyn.Semantic.PXGraph;
 
@@ -29,7 +26,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXGraphCreationInGraphInWrongPlace
 		{
 			context.CancellationToken.ThrowIfCancellationRequested();
 
-			var graphInitializerWalker = new PXGraphCreateInstanceWalker(
+			var graphInitializerWalker = new PXGraphCreateInstanceInGraphInitializationAndDataViewsWalker(
 				context,
 				pxContext,
 				pxContext.CodeAnalysisSettings.IsvSpecificAnalyzersEnabled
@@ -42,7 +39,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXGraphCreationInGraphInWrongPlace
 				graphInitializerWalker.Visit(initializer.Node);
 			}
 
-			var graphViewDelegateWalker = new PXGraphCreateInstanceWalker(context, pxContext,
+			var graphViewDelegateWalker = new PXGraphCreateInstanceInGraphInitializationAndDataViewsWalker(context, pxContext,
 				Descriptors.PX1084_GraphCreationInDataViewDelegate);
 
 			foreach (DataViewDelegateInfo del in graphOrGraphExtension.ViewDelegates)
@@ -66,7 +63,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXGraphCreationInGraphInWrongPlace
 			{
 				context.CancellationToken.ThrowIfCancellationRequested();
 
-				var graphIsActiveMethodWalker = new PXGraphCreateInstanceWalker(context, pxContext, descriptor);
+				var graphIsActiveMethodWalker = new PXGraphCreateInstanceInGraphInitializationAndDataViewsWalker(context, pxContext, descriptor);
 				graphIsActiveMethodWalker.Visit(IsActiveMethodInfo.Node);
 			}
 		}

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/GraphCreation/PXGraphCreationInWrongPlaces_ISVTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/GraphCreation/PXGraphCreationInWrongPlaces_ISVTests.cs
@@ -42,7 +42,8 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.GraphCreation
 			VerifyCSharpDiagnosticAsync(source,
 				Descriptors.PX1057_PXGraphCreationDuringInitialization.CreateFor(13, 32),
 				Descriptors.PX1057_PXGraphCreationDuringInitialization.CreateFor(19, 32),
-				Descriptors.PX1057_PXGraphCreationDuringInitialization.CreateFor(25, 32));
+				Descriptors.PX1057_PXGraphCreationDuringInitialization.CreateFor(25, 32),
+				Descriptors.PX1057_PXGraphCreationDuringInitialization.CreateFor(27, 12));
 
 		[Theory]
 		[EmbeddedFileData("PXGraphExtensionWithCreateInstanceInInitialization.cs")]

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/GraphCreation/PXGraphCreationInWrongPlaces_NonISVTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/GraphCreation/PXGraphCreationInWrongPlaces_NonISVTests.cs
@@ -31,7 +31,8 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.GraphCreation
 			VerifyCSharpDiagnosticAsync(source,
 				Descriptors.PX1057_PXGraphCreationDuringInitialization_NonISV.CreateFor(13, 32),
 				Descriptors.PX1057_PXGraphCreationDuringInitialization_NonISV.CreateFor(19, 32),
-				Descriptors.PX1057_PXGraphCreationDuringInitialization_NonISV.CreateFor(25, 32));
+				Descriptors.PX1057_PXGraphCreationDuringInitialization_NonISV.CreateFor(25, 32),
+				Descriptors.PX1057_PXGraphCreationDuringInitialization_NonISV.CreateFor(27, 12));
 
 		[Theory]
 		[EmbeddedFileData("PXGraphExtensionWithCreateInstanceInInitialization.cs")]

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/GraphCreation/Sources/PXGraphWithCreateInstanceInInitialization.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/GraphCreation/Sources/PXGraphWithCreateInstanceInInitialization.cs
@@ -23,6 +23,8 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.PXGraphCreationInGraphInWrongPla
 		{
 			base.Configure(graph);
 			SWKMapadocConnMaint maint = PXGraph.CreateInstance<SWKMapadocConnMaint>();
+
+			maint = new();
 		}
 	}
 

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreateInstance/PXGraphCreateInstanceInEventHandlersNonISVTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreateInstance/PXGraphCreateInstanceInEventHandlersNonISVTests.cs
@@ -1,4 +1,6 @@
-﻿using Acuminator.Analyzers.StaticAnalysis;
+﻿using System.Threading.Tasks;
+
+using Acuminator.Analyzers.StaticAnalysis;
 using Acuminator.Analyzers.StaticAnalysis.EventHandlers;
 using Acuminator.Analyzers.StaticAnalysis.PXGraphCreateInstance;
 using Acuminator.Tests.Helpers;
@@ -16,33 +18,28 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.PXGraphCreateInstance
 		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer() =>
 			new LooseEventHandlerAggregatorAnalyzer(CodeAnalysisSettings.Default
 					.WithRecursiveAnalysisEnabled()
+					.WithStaticAnalysisEnabled()
 					.WithIsvSpecificAnalyzersDisabled(),
 				new PXGraphCreateInstanceInEventHandlersAnalyzer());
 
 		[Theory]
 		[EmbeddedFileData(@"EventHandlers\CreateInstance.cs")]
-		public void TestDiagnostic_CreateInstance(string actual)
-		{
-			VerifyCSharpDiagnostic(actual,
+		public Task CallTo_CreateInstance_InEventHandler(string actual) =>
+			VerifyCSharpDiagnosticAsync(actual,
 				Descriptors.PX1045_PXGraphCreateInstanceInEventHandlers_NonISV.CreateFor(16, 21));
-		}
 
 		[Theory]
 		[EmbeddedFileData(@"EventHandlers\Constructor.cs")]
-		public void TestDiagnostic_Constructor(string actual)
-		{
-			VerifyCSharpDiagnostic(actual,
+		public Task CallTo_Constructor_InEventHandler(string actual) =>
+			VerifyCSharpDiagnosticAsync(actual,
 				Descriptors.PX1045_PXGraphCreateInstanceInEventHandlers_NonISV.CreateFor(17, 21),
 				Descriptors.PX1045_PXGraphCreateInstanceInEventHandlers_NonISV.CreateFor(18, 17));
-		}
 
 		[Theory]
 		[EmbeddedFileData(@"EventHandlers\ConstructorForNonSpecificPXGraph.cs")]
-		public void TestDiagnostic_ConstructorForNonSpecificPXGraph(string actual)
-		{
-			VerifyCSharpDiagnostic(actual,
+		public Task CallTo_ConstructorForNonSpecificPXGraph_InEventHandler(string actual) =>
+			VerifyCSharpDiagnosticAsync(actual,
 				Descriptors.PX1045_PXGraphCreateInstanceInEventHandlers_NonISV.CreateFor(17, 16),
 				Descriptors.PX1045_PXGraphCreateInstanceInEventHandlers_NonISV.CreateFor(18, 12));
-		}
 	}
 }

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreateInstance/PXGraphCreateInstanceInEventHandlersNonISVTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreateInstance/PXGraphCreateInstanceInEventHandlersNonISVTests.cs
@@ -4,7 +4,9 @@ using Acuminator.Analyzers.StaticAnalysis.PXGraphCreateInstance;
 using Acuminator.Tests.Helpers;
 using Acuminator.Tests.Verification;
 using Acuminator.Utilities;
+
 using Microsoft.CodeAnalysis.Diagnostics;
+
 using Xunit;
 
 namespace Acuminator.Tests.Tests.StaticAnalysis.PXGraphCreateInstance
@@ -30,7 +32,8 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.PXGraphCreateInstance
 		public void TestDiagnostic_Constructor(string actual)
 		{
 			VerifyCSharpDiagnostic(actual,
-				Descriptors.PX1045_PXGraphCreateInstanceInEventHandlers_NonISV.CreateFor(16, 21));
+				Descriptors.PX1045_PXGraphCreateInstanceInEventHandlers_NonISV.CreateFor(17, 21),
+				Descriptors.PX1045_PXGraphCreateInstanceInEventHandlers_NonISV.CreateFor(18, 17));
 		}
 
 		[Theory]
@@ -38,7 +41,8 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.PXGraphCreateInstance
 		public void TestDiagnostic_ConstructorForNonSpecificPXGraph(string actual)
 		{
 			VerifyCSharpDiagnostic(actual,
-				Descriptors.PX1045_PXGraphCreateInstanceInEventHandlers_NonISV.CreateFor(16, 16));
+				Descriptors.PX1045_PXGraphCreateInstanceInEventHandlers_NonISV.CreateFor(17, 16),
+				Descriptors.PX1045_PXGraphCreateInstanceInEventHandlers_NonISV.CreateFor(18, 12));
 		}
 	}
 }

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreateInstance/PXGraphCreateInstanceInEventHandlersTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreateInstance/PXGraphCreateInstanceInEventHandlersTests.cs
@@ -20,32 +20,27 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.PXGraphCreateInstance
 		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer() =>
 			new LooseEventHandlerAggregatorAnalyzer(CodeAnalysisSettings.Default
 					.WithRecursiveAnalysisEnabled()
+					.WithStaticAnalysisEnabled()
 					.WithIsvSpecificAnalyzersEnabled(),
 				new PXGraphCreateInstanceInEventHandlersAnalyzer());
 
 		[Theory]
 		[EmbeddedFileData(@"EventHandlers\CreateInstance.cs")]
-		public void TestDiagnostic_CreateInstance(string actual)
-		{
-			VerifyCSharpDiagnostic(actual, Descriptors.PX1045_PXGraphCreateInstanceInEventHandlers.CreateFor(16, 21));
-		}
+		public Task CallTo_CreateInstance_InEventHandler(string actual) => 
+			VerifyCSharpDiagnosticAsync(actual, Descriptors.PX1045_PXGraphCreateInstanceInEventHandlers.CreateFor(16, 21));
 
 		[Theory]
 		[EmbeddedFileData(@"EventHandlers\Constructor.cs")]
-		public void TestDiagnostic_Constructor(string actual)
-		{
-			VerifyCSharpDiagnostic(actual,
+		public Task CallTo_Constructor_InEventHandler(string actual) =>
+			VerifyCSharpDiagnosticAsync(actual,
 				Descriptors.PX1045_PXGraphCreateInstanceInEventHandlers.CreateFor(17, 21),
 				Descriptors.PX1045_PXGraphCreateInstanceInEventHandlers.CreateFor(18, 17));
-		}
 
 		[Theory]
 		[EmbeddedFileData(@"EventHandlers\ConstructorForNonSpecificPXGraph.cs")]
-		public void TestDiagnostic_ConstructorForNonSpecificPXGraph(string actual)
-		{
-			VerifyCSharpDiagnostic(actual,
+		public Task CallTo_ConstructorForNonSpecificPXGraph_InEventHandler(string actual) =>
+			VerifyCSharpDiagnosticAsync(actual,
 				Descriptors.PX1045_PXGraphCreateInstanceInEventHandlers.CreateFor(17, 16),
 				Descriptors.PX1045_PXGraphCreateInstanceInEventHandlers.CreateFor(18, 12));
-		}
 	}
 }

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreateInstance/PXGraphCreateInstanceInEventHandlersTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreateInstance/PXGraphCreateInstanceInEventHandlersTests.cs
@@ -1,16 +1,16 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
+
 using Acuminator.Analyzers.StaticAnalysis;
 using Acuminator.Analyzers.StaticAnalysis.EventHandlers;
 using Acuminator.Analyzers.StaticAnalysis.PXGraphCreateInstance;
 using Acuminator.Tests.Helpers;
 using Acuminator.Tests.Verification;
 using Acuminator.Utilities;
-using Acuminator.Utilities.Roslyn;
+
 using Microsoft.CodeAnalysis.Diagnostics;
+
 using Xunit;
 
 namespace Acuminator.Tests.Tests.StaticAnalysis.PXGraphCreateInstance
@@ -34,14 +34,18 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.PXGraphCreateInstance
 		[EmbeddedFileData(@"EventHandlers\Constructor.cs")]
 		public void TestDiagnostic_Constructor(string actual)
 		{
-			VerifyCSharpDiagnostic(actual, Descriptors.PX1045_PXGraphCreateInstanceInEventHandlers.CreateFor(16, 21));
+			VerifyCSharpDiagnostic(actual,
+				Descriptors.PX1045_PXGraphCreateInstanceInEventHandlers.CreateFor(17, 21),
+				Descriptors.PX1045_PXGraphCreateInstanceInEventHandlers.CreateFor(18, 17));
 		}
 
 		[Theory]
 		[EmbeddedFileData(@"EventHandlers\ConstructorForNonSpecificPXGraph.cs")]
 		public void TestDiagnostic_ConstructorForNonSpecificPXGraph(string actual)
 		{
-			VerifyCSharpDiagnostic(actual, Descriptors.PX1045_PXGraphCreateInstanceInEventHandlers.CreateFor(16, 16));
+			VerifyCSharpDiagnostic(actual,
+				Descriptors.PX1045_PXGraphCreateInstanceInEventHandlers.CreateFor(17, 16),
+				Descriptors.PX1045_PXGraphCreateInstanceInEventHandlers.CreateFor(18, 12));
 		}
 	}
 }

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreateInstance/PXGraphCreateInstanceTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreateInstance/PXGraphCreateInstanceTests.cs
@@ -1,4 +1,6 @@
-﻿using Acuminator.Analyzers.StaticAnalysis;
+﻿using System.Threading.Tasks;
+
+using Acuminator.Analyzers.StaticAnalysis;
 using Acuminator.Analyzers.StaticAnalysis.PXGraphCreateInstance;
 using Acuminator.Tests.Helpers;
 using Acuminator.Tests.Verification;
@@ -12,65 +14,48 @@ using Xunit;
 
 namespace Acuminator.Tests.Tests.StaticAnalysis.PXGraphCreateInstance
 {
-    public class PXGraphCreateInstanceTests : CodeFixVerifier
-    {
-	    protected override CodeFixProvider GetCSharpCodeFixProvider() => new PXGraphCreateInstanceFix();
+	public class PXGraphCreateInstanceTests : CodeFixVerifier
+	{
+		protected override CodeFixProvider GetCSharpCodeFixProvider() => new PXGraphCreateInstanceFix();
 
-	    protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer() => 
+		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer() =>
 			new PXGraphCreateInstanceAnalyzer(CodeAnalysisSettings.Default
 																  .WithStaticAnalysisEnabled()
 																  .WithSuppressionMechanismDisabled());
 
 		[Theory]
-        [EmbeddedFileData("Method.cs")] 
-		public void TestDiagnostic_Method(string actual)
-        {
-            VerifyCSharpDiagnostic(actual, Descriptors.PX1001_PXGraphCreateInstance.CreateFor(14, 25));
-        }
+		[EmbeddedFileData("Method.cs")]
+		public Task CallTo_Constructor_In_Method(string actual) => 
+			VerifyCSharpDiagnosticAsync(actual, Descriptors.PX1001_PXGraphCreateInstance.CreateFor(14, 25));
 
-        [Theory]
-        [EmbeddedFileData("Field.cs")]
-        public void TestDiagnostic_Field(string actual)
-        {
-            VerifyCSharpDiagnostic(actual, Descriptors.PX1001_PXGraphCreateInstance.CreateFor(12, 43));
-        }
+		[Theory]
+		[EmbeddedFileData("Field.cs")]
+		public Task CallTo_Constructor_In_FieldInitializer(string actual) => 
+			VerifyCSharpDiagnosticAsync(actual, Descriptors.PX1001_PXGraphCreateInstance.CreateFor(12, 43));
 
-	    [Theory]
-	    [EmbeddedFileData("Property.cs")]
-	    public void TestDiagnostic_Property(string actual)
-	    {
-		    VerifyCSharpDiagnostic(actual, Descriptors.PX1001_PXGraphCreateInstance.CreateFor(14, 17));
-	    }
+		[Theory]
+		[EmbeddedFileData("Property.cs")]
+		public Task CallTo_Constructor_In_Property(string actual) => 
+			VerifyCSharpDiagnosticAsync(actual, Descriptors.PX1001_PXGraphCreateInstance.CreateFor(14, 17));
 
 		[Theory]
 		[EmbeddedFileData("MethodWithNonSpecificPXGraph.cs")]
-	    public void TestDiagnosticNonSpecificPXGraph_Method(string actual)
-	    {
-			VerifyCSharpDiagnostic(actual, Descriptors.PX1003_NonSpecificPXGraphCreateInstance.CreateFor(14, 16));
-		}
+		public Task CallTo_NonSpecificPXGraph_Constructor_In_Method(string actual) => 
+			VerifyCSharpDiagnosticAsync(actual, Descriptors.PX1003_NonSpecificPXGraphCreateInstance.CreateFor(14, 16));
 
-	    [Theory]
-	    [EmbeddedFileData("Method.cs",
-						  "Method_Expected.cs")]
-	    public void TestCodeFix_Method(string actual, string expected)
-	    {
-		    VerifyCSharpFix(actual, expected);
-	    }
+		[Theory]
+		[EmbeddedFileData("Method.cs", "Method_Expected.cs")]
+		public Task CodeFix_ReplaceConstructorCall_In_Method(string actual, string expected) =>
+			VerifyCSharpFixAsync(actual, expected);
 
-	    [Theory]
-	    [EmbeddedFileData("Field.cs",
-						  "Field_Expected.cs")]
-	    public void TestCodeFix_Field(string actual, string expected)
-	    {
-		    VerifyCSharpFix(actual, expected);
-	    }
+		[Theory]
+		[EmbeddedFileData("Field.cs", "Field_Expected.cs")]
+		public Task CodeFix_ReplaceConstructorCall_In_FieldInitializer(string actual, string expected) => 
+			VerifyCSharpFixAsync(actual, expected);
 
-	    [Theory]
-	    [EmbeddedFileData("Property.cs",
-						  "Property_Expected.cs")]
-	    public void TestCodeFix_Property(string actual, string expected)
-	    {
-		    VerifyCSharpFix(actual, expected);
-	    }
-    }
+		[Theory]
+		[EmbeddedFileData("Property.cs", "Property_Expected.cs")]
+		public Task CodeFix_ReplaceConstructorCall_In_Property(string actual, string expected) => 
+			VerifyCSharpFixAsync(actual, expected);
+	}
 }

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreateInstance/PXGraphCreateInstanceTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreateInstance/PXGraphCreateInstanceTests.cs
@@ -25,8 +25,10 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.PXGraphCreateInstance
 
 		[Theory]
 		[EmbeddedFileData("Method.cs")]
-		public Task CallTo_Constructor_In_Method(string actual) => 
-			VerifyCSharpDiagnosticAsync(actual, Descriptors.PX1001_PXGraphCreateInstance.CreateFor(14, 25));
+		public Task CallTo_Constructor_In_Method(string actual) =>
+			VerifyCSharpDiagnosticAsync(actual,
+				Descriptors.PX1001_PXGraphCreateInstance.CreateFor(15, 16),
+				Descriptors.PX1001_PXGraphCreateInstance.CreateFor(16, 17));
 
 		[Theory]
 		[EmbeddedFileData("Field.cs")]

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreateInstance/PXGraphCreateInstanceTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreateInstance/PXGraphCreateInstanceTests.cs
@@ -28,7 +28,7 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.PXGraphCreateInstance
 		public Task CallTo_Constructor_In_Method(string actual) =>
 			VerifyCSharpDiagnosticAsync(actual,
 				Descriptors.PX1001_PXGraphCreateInstance.CreateFor(15, 16),
-				Descriptors.PX1001_PXGraphCreateInstance.CreateFor(16, 17));
+				Descriptors.PX1001_PXGraphCreateInstance.CreateFor(16, 31));
 
 		[Theory]
 		[EmbeddedFileData("Field.cs")]

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreateInstance/Sources/EventHandlers/Constructor.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreateInstance/Sources/EventHandlers/Constructor.cs
@@ -2,13 +2,13 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 
 using PX.Data;
 
-namespace PX.Objects
+namespace Acuminator.Tests.Tests.StaticAnalysis.PXGraphCreateInstance
 {
-	public class BinExtension : PXGraphExtension<INSiteMaint>
+	// Acuminator disable once PX1016 ExtensionDoesNotDeclareIsActiveMethod extension should be constantly active
+	public class BinExtension : PXGraphExtension<PX.Objects.IN.INSiteMaint>
 	{
 		public void INLocation_RowPersisted(PXCache sender, PXRowPersistedEventArgs e)
 		{

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreateInstance/Sources/EventHandlers/Constructor.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreateInstance/Sources/EventHandlers/Constructor.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+
 using PX.Data;
 
 namespace PX.Objects
@@ -14,6 +15,7 @@ namespace PX.Objects
 			if (e.TranStatus != PXTranStatus.Completed) return;
 
 			var orderMaint = new SOOrderEntry();
+			orderMaint = new();
 		}
 	}
 

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreateInstance/Sources/EventHandlers/ConstructorForNonSpecificPXGraph.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreateInstance/Sources/EventHandlers/ConstructorForNonSpecificPXGraph.cs
@@ -2,13 +2,13 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 
 using PX.Data;
 
-namespace PX.Objects
+namespace Acuminator.Tests.Tests.StaticAnalysis.PXGraphCreateInstance
 {
-	public class BinExtension : PXGraphExtension<INSiteMaint>
+	// Acuminator disable once PX1016 ExtensionDoesNotDeclareIsActiveMethod extension should be constantly active
+	public class BinExtension : PXGraphExtension<PX.Objects.IN.INSiteMaint>
 	{
 		public void INLocation_RowPersisted(PXCache sender, PXRowPersistedEventArgs e)
 		{

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreateInstance/Sources/EventHandlers/ConstructorForNonSpecificPXGraph.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreateInstance/Sources/EventHandlers/ConstructorForNonSpecificPXGraph.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+
 using PX.Data;
 
 namespace PX.Objects
@@ -14,6 +15,7 @@ namespace PX.Objects
 			if (e.TranStatus != PXTranStatus.Completed) return;
 
 			var graph = new PXGraph();
+			graph = new();
 		}
 	}
 }

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreateInstance/Sources/EventHandlers/CreateInstance.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreateInstance/Sources/EventHandlers/CreateInstance.cs
@@ -2,14 +2,14 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 using PX.Data;
 
-namespace PX.Objects
+namespace Acuminator.Tests.Tests.StaticAnalysis.PXGraphCreateInstance
 {
-	public class BinExtension : PXGraphExtension<INSiteMaint>
+	// Acuminator disable once PX1016 ExtensionDoesNotDeclareIsActiveMethod extension should be constantly active
+	public class BinExtension : PXGraphExtension<PX.Objects.IN.INSiteMaint>
 	{
-		public void INLocation_RowPersisted(PXCache sender, PXRowPersistedEventArgs e)
+		protected virtual void INLocation_RowPersisted(PXCache sender, PXRowPersistedEventArgs e)
 		{
 			if (e.TranStatus != PXTranStatus.Completed) return;
 

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreateInstance/Sources/Field.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreateInstance/Sources/Field.cs
@@ -5,7 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 using PX.Data;
 
-namespace PX.Analyzers.Test.Sources
+namespace Acuminator.Tests.Tests.StaticAnalysis.PXGraphCreateInstance
 {
     class PX1001ClassWithField
     {

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreateInstance/Sources/Field_Expected.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreateInstance/Sources/Field_Expected.cs
@@ -5,7 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 using PX.Data;
 
-namespace PX.Analyzers.Test.Sources
+namespace Acuminator.Tests.Tests.StaticAnalysis.PXGraphCreateInstance
 {
     class PX1001ClassWithField
     {

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreateInstance/Sources/Method.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreateInstance/Sources/Method.cs
@@ -13,7 +13,7 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.PXGraphCreateInstance
 		public void Prefetch()
 		{
 			var graph = new PX1001MethodGraph();
-			var graph2 = new();
+			PX1001MethodGraph graph2 = new();
 		}
 	}
 

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreateInstance/Sources/Method.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreateInstance/Sources/Method.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 using PX.Data;
 
-namespace PX.Analyzers.Test.Sources
+namespace Acuminator.Tests.Tests.StaticAnalysis.PXGraphCreateInstance
 {
 	public class PX1001ClassWithMethod : IPrefetchable
 	{

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreateInstance/Sources/Method.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreateInstance/Sources/Method.cs
@@ -3,19 +3,21 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+
 using PX.Data;
 
 namespace PX.Analyzers.Test.Sources
 {
-    public class PX1001ClassWithMethod : IPrefetchable
-    {
-        public void Prefetch()
-        {
-            var graph = new PX1001MethodGraph();
-        }
-    }
+	public class PX1001ClassWithMethod : IPrefetchable
+	{
+		public void Prefetch()
+		{
+			var graph = new PX1001MethodGraph();
+			var graph2 = new();
+		}
+	}
 
-    public class PX1001MethodGraph : PXGraph<PX1001MethodGraph>
-    {
-    }
+	public class PX1001MethodGraph : PXGraph<PX1001MethodGraph>
+	{
+	}
 }

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreateInstance/Sources/MethodWithNonSpecificPXGraph.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreateInstance/Sources/MethodWithNonSpecificPXGraph.cs
@@ -5,7 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 using PX.Data;
 
-namespace PX.Analyzers.Test.Sources
+namespace Acuminator.Tests.Tests.StaticAnalysis.PXGraphCreateInstance
 {
 	class NonSpecificPXGraphCreateInstanceMethod : IPrefetchable
 	{

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreateInstance/Sources/Method_Expected.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreateInstance/Sources/Method_Expected.cs
@@ -13,7 +13,7 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.PXGraphCreateInstance
 		public void Prefetch()
 		{
 			var graph = PXGraph.CreateInstance<PX1001MethodGraph>();
-			var graph2 = PXGraph.CreateInstance<PX1001MethodGraph>();
+			PX1001MethodGraph graph2 = PXGraph.CreateInstance<PX1001MethodGraph>();
 		}
 	}
 

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreateInstance/Sources/Method_Expected.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreateInstance/Sources/Method_Expected.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 using PX.Data;
 
-namespace PX.Analyzers.Test.Sources
+namespace Acuminator.Tests.Tests.StaticAnalysis.PXGraphCreateInstance
 {
 	public class PX1001ClassWithMethod : IPrefetchable
 	{

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreateInstance/Sources/Method_Expected.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreateInstance/Sources/Method_Expected.cs
@@ -3,19 +3,21 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+
 using PX.Data;
 
 namespace PX.Analyzers.Test.Sources
 {
-    public class PX1001ClassWithMethod : IPrefetchable
-    {
-        public void Prefetch()
-        {
-            var graph = PXGraph.CreateInstance<PX1001MethodGraph>();
-        }
-    }
+	public class PX1001ClassWithMethod : IPrefetchable
+	{
+		public void Prefetch()
+		{
+			var graph = PXGraph.CreateInstance<PX1001MethodGraph>();
+			var graph2 = PXGraph.CreateInstance<PX1001MethodGraph>();
+		}
+	}
 
-    public class PX1001MethodGraph : PXGraph<PX1001MethodGraph>
-    {
-    }
+	public class PX1001MethodGraph : PXGraph<PX1001MethodGraph>
+	{
+	}
 }

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreateInstance/Sources/Property.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreateInstance/Sources/Property.cs
@@ -5,7 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 using PX.Data;
 
-namespace PX.Analyzers.Test.Sources
+namespace Acuminator.Tests.Tests.StaticAnalysis.PXGraphCreateInstance
 {
 	class PX1001ClassWithProperty
 	{

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreateInstance/Sources/Property_Expected.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreateInstance/Sources/Property_Expected.cs
@@ -5,7 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 using PX.Data;
 
-namespace PX.Analyzers.Test.Sources
+namespace Acuminator.Tests.Tests.StaticAnalysis.PXGraphCreateInstance
 {
 	class PX1001ClassWithProperty
 	{

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/NestedInvocationWalker.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/NestedInvocationWalker.cs
@@ -242,6 +242,18 @@ namespace Acuminator.Utilities.Roslyn
 
 		public override void VisitObjectCreationExpression(ObjectCreationExpressionSyntax node)
 		{
+			VisitInstanceConstructorCallExpression(node);
+			base.VisitObjectCreationExpression(node);
+		}
+
+		public override void VisitImplicitObjectCreationExpression(ImplicitObjectCreationExpressionSyntax node)
+		{
+			VisitInstanceConstructorCallExpression(node);
+			base.VisitImplicitObjectCreationExpression(node);
+		}
+
+		private void VisitInstanceConstructorCallExpression(BaseObjectCreationExpressionSyntax node)
+		{
 			ThrowIfCancellationRequested();
 
 			if (RecursiveAnalysisEnabled())
@@ -249,8 +261,6 @@ namespace Acuminator.Utilities.Roslyn
 				var methodSymbol = GetSymbol<IMethodSymbol>(node);
 				VisitCalledMethod(methodSymbol, node);
 			}
-
-			base.VisitObjectCreationExpression(node);
 		}
 
 		public override void VisitConditionalAccessExpression(ConditionalAccessExpressionSyntax node)

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/NestedInvocationWalker.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/NestedInvocationWalker.cs
@@ -193,7 +193,7 @@ namespace Acuminator.Utilities.Roslyn
 		{
 			ThrowIfCancellationRequested();
 
-			if (RecursiveAnalysisEnabled() && node.Parent?.Kind() != SyntaxKind.ConditionalAccessExpression)
+			if (RecursiveAnalysisEnabled() && node.Parent != null && !node.Parent.IsKind(SyntaxKind.ConditionalAccessExpression))
 			{
 				var methodSymbol = GetSymbol<IMethodSymbol>(node);
 				VisitCalledMethod(methodSymbol, node);

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Walkers/PXGraphCreateInstanceWalker.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Walkers/PXGraphCreateInstanceWalker.cs
@@ -48,8 +48,7 @@ namespace Acuminator.Utilities.Roslyn.Walkers
 		}
 
 		/// <summary>
-		/// Called when the visitor visits a ObjectCreationExpressionSyntax node (a constructor call via new).
-		/// We need to check that graphs are not created via "<see langword="new"/> PXGraph()" constructor call.
+		/// Called when the visitor visits a <see cref="ObjectCreationExpressionSyntax"/> node which represents a constructor call via "<c><see langword="new"/> MyGraph()</c>".<br/>
 		/// </summary>
 		/// <param name="node">The node.</param>
 		public override void VisitObjectCreationExpression(ObjectCreationExpressionSyntax node)
@@ -65,6 +64,32 @@ namespace Acuminator.Utilities.Roslyn.Walkers
 			else
 			{
 				base.VisitObjectCreationExpression(node);
+			}
+		}
+
+		/// <summary>
+		/// Called when the visitor visits a <see cref="ImplicitObjectCreationExpressionSyntax"/> node which represents a constructor call via "<c><see langword="new"/>()</c>".<br/>
+		/// </summary>
+		/// <param name="node">The node.</param>
+		public override void VisitImplicitObjectCreationExpression(ImplicitObjectCreationExpressionSyntax node)
+		{
+			ThrowIfCancellationRequested();
+
+			var constructor = GetSymbol<IMethodSymbol>(node);
+
+			if (constructor == null || constructor.MethodKind != MethodKind.Constructor)
+			{
+				base.VisitImplicitObjectCreationExpression(node);
+				return;
+			}
+
+			if (constructor?.ContainingType != null && constructor.ContainingType.IsPXGraph(PxContext))
+			{
+				ReportDiagnostic(_context.ReportDiagnostic, _descriptor, node);
+			}
+			else
+			{
+				base.VisitImplicitObjectCreationExpression(node);
 			}
 		}
 	}

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Walkers/PXGraphCreateInstanceWalkerBase.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Walkers/PXGraphCreateInstanceWalkerBase.cs
@@ -1,34 +1,28 @@
-﻿#nullable enable
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 
 using Acuminator.Utilities.Common;
-using Acuminator.Utilities.DiagnosticSuppression;
 using Acuminator.Utilities.Roslyn.Semantic;
-using Acuminator.Utilities.Roslyn.Syntax;
 
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Acuminator.Utilities.Roslyn.Walkers
 {
 	/// <summary>
-	/// A recursive walker that reports graph creation.
+	/// A base class for recursive walkers that report graph creation.
 	/// </summary>
-	public class PXGraphCreateInstanceWalker : NestedInvocationWalker
+	public abstract class PXGraphCreateInstanceWalkerBase : NestedInvocationWalker
 	{
-		private readonly SymbolAnalysisContext _context;
-		private readonly DiagnosticDescriptor _descriptor;
+		protected SymbolAnalysisContext Context { get; }
 
-		public PXGraphCreateInstanceWalker(SymbolAnalysisContext context, PXContext pxContext, DiagnosticDescriptor descriptor)
-			: base(pxContext, context.CancellationToken)
+		protected abstract DiagnosticDescriptor Descriptor { get; }
+
+		public PXGraphCreateInstanceWalkerBase(SymbolAnalysisContext context, PXContext pxContext) : base(pxContext, context.CancellationToken)
 		{
-			_context = context;
-			_descriptor = descriptor.CheckIfNull();
+			Context = context;
 		}
 
 		public override void VisitMemberAccessExpression(MemberAccessExpressionSyntax node)
@@ -39,7 +33,7 @@ namespace Acuminator.Utilities.Roslyn.Walkers
 
 			if (symbol != null && PxContext.PXGraph.CreateInstance.Contains<IMethodSymbol>(symbol.ConstructedFrom, SymbolEqualityComparer.Default))
 			{
-				ReportDiagnostic(_context.ReportDiagnostic, _descriptor, node);
+				ReportDiagnostic(Context.ReportDiagnostic, Descriptor, node);
 			}
 			else
 			{
@@ -59,7 +53,7 @@ namespace Acuminator.Utilities.Roslyn.Walkers
 
 			if (createdObjectType != null && createdObjectType.IsPXGraph(PxContext))
 			{
-				ReportDiagnostic(_context.ReportDiagnostic, _descriptor, node);
+				ReportDiagnostic(Context.ReportDiagnostic, Descriptor, node);
 			}
 			else
 			{
@@ -85,7 +79,7 @@ namespace Acuminator.Utilities.Roslyn.Walkers
 
 			if (constructor?.ContainingType != null && constructor.ContainingType.IsPXGraph(PxContext))
 			{
-				ReportDiagnostic(_context.ReportDiagnostic, _descriptor, node);
+				ReportDiagnostic(Context.ReportDiagnostic, Descriptor, node);
 			}
 			else
 			{


### PR DESCRIPTION
**Changes Overview**
- added support for stepping into constructor for `new()` expressions to inter-procedural analysis
- reworked walker reporting graph creation to be a base abstract class reused by multiple analyzers:
    - added capability to customize a descriptor of the diagnostic reported by the walker
    - added support for `new()` syntax
- added a new walker derived from the base walker that collects graph creation for PX1056, PX1057, and PX1084 diagnostics. This added support of  `new()` syntax to these diagnostics
- reworked PX1045 diagnostic for graph creation in event handlers:
    - Derived its walker from a new common walker that reports graph creation to eliminate code duplication
    - Supported `new()` expressions in the analysis
- added support of  `new()` expressions to PX1001 diagnostic
- added support of  `new()` expressions to PX1001 code fix
- optimized PX1001 and improved its cancellation support
- added support of `new()` expressions to PX1042 legacy diagnostic for DB queries in the connection scope.
- refactored big nested walker types into separate files
- updated unit tests for PX1001, PX1045, PX1056, PX1057, and PX1084 with test cases for  `new()` expressions
- improved some of the old unit tests:
   - fixed bad test names, removed useless prefixes like "TestDiagnostic"
   - made tests async