### PR TITLE
Feature/atr 900 dev px1100 diagnostic for obsolete elements usage in pxoverrides

### DIFF
--- a/docs/Summary.md
+++ b/docs/Summary.md
@@ -105,5 +105,5 @@ Acuminator does not perform static analysis of projects whose names contain `Tes
 | [PX1096](diagnostics/PX1096.md) | The signature of a method with the `PXOverride` attribute must match the overridden method. | Error | Unavailable |
 | [PX1097](diagnostics/PX1097.md) | Methods with the `PXOverride` attribute must be `public` and non-virtual. | Error | Available |
 | [PX1099](diagnostics/PX1099.md) | The API reported by the diagnostic should not be used with the Acumatica Framework. | Warning | Unavailable |
-| [PX1100](diagnostics/PX1100.md) | An element of a graph or DAC extension extends or overrides an obsolete code element. | Warning | Unavailable |
+| [PX1100](diagnostics/PX1100.md) | An element of a graph or a DAC extension extends or overrides an obsolete code element. | Warning | Unavailable |
 | [PX1101](diagnostics/PX1101.md) | The additional delegate parameter of the method with the `PXOverride` attribute must have the same signature as the base method. | Error | Available |

--- a/docs/Summary.md
+++ b/docs/Summary.md
@@ -83,8 +83,8 @@ Acuminator does not perform static analysis of projects whose names contain `Tes
 | [PX1073](diagnostics/PX1073.md) | Exceptions cannot be thrown in the `RowPersisted` and `FieldUpdating` event handlers. | Error | Unavailable |
 | [PX1074](diagnostics/PX1074.md) | `PXSetupNotEnteredException` cannot be thrown in any event handlers except for the `RowSelected` event handlers. | Warning (ISV Level 1: Significant) | Unavailable |
 | [PX1075](diagnostics/PX1075.md) | `PXCache.RaiseExceptionHandling` cannot be invoked from the `FieldDefaulting`, `FieldSelecting`, `FieldUpdating`, `RowSelecting`, and `RowPersisted` event handlers. | Error | Unavailable |
-| [PX1076](diagnostics/PX1076.md) | This code calls Acumatica internal API marked with PXInternalUseOnlyAttribute which is not intended for public use | Warning | Unavailable |
-| [PX1077](diagnostics/PX1077.md) | Event handlers in graphs and graph extensions should have the `protected` and `virtual` modifiers | Error | Available |
+| [PX1076](diagnostics/PX1076.md) | This code calls Acumatica internal API marked with PXInternalUseOnlyAttribute which is not intended for public use. | Warning | Unavailable |
+| [PX1077](diagnostics/PX1077.md) | Event handlers in graphs and graph extensions should have the `protected` and `virtual` modifiers. | Error | Available |
 | [PX1078](diagnostics/PX1078.md) | The DAC field and the referenced DAC field have different types or sizes. | Error | Unavailable |
 | [PX1079](diagnostics/PX1079.md) | Methods with the `PXOverride` attribute must have an additional delegate parameter for calling base methods. | Error | Available |
 | [PX1080](diagnostics/PX1080.md) | Data view delegates should not start long-running operations. | Error | Unavailable |
@@ -105,4 +105,5 @@ Acuminator does not perform static analysis of projects whose names contain `Tes
 | [PX1096](diagnostics/PX1096.md) | The signature of a method with the `PXOverride` attribute must match the overridden method. | Error | Unavailable |
 | [PX1097](diagnostics/PX1097.md) | Methods with the `PXOverride` attribute must be `public` and non-virtual. | Error | Available |
 | [PX1099](diagnostics/PX1099.md) | The API reported by the diagnostic should not be used with the Acumatica Framework. | Warning | Unavailable |
+| [PX1100](diagnostics/PX1100.md) | An element of a graph or DAC extension extends or overrides an obsolete code element. | Warning | Unavailable |
 | [PX1101](diagnostics/PX1101.md) | The additional delegate parameter of the method with the `PXOverride` attribute must have the same signature as the base method. | Error | Available |

--- a/docs/diagnostics/PX1100.md
+++ b/docs/diagnostics/PX1100.md
@@ -5,25 +5,25 @@ This document describes the PX1100 diagnostic.
 
 | Code   | Short Description                                                                     | Type    | Code Fix    | 
 | ------ | ------------------------------------------------------------------------------------- | ------- | ----------- | 
-| PX1100 | An element of a graph or DAC extension extends or overrides an obsolete code element. | Warning | Unavailable | 
+| PX1100 | An element of a graph or a DAC extension extends or overrides an obsolete code element. | Warning | Unavailable | 
 
 ## Diagnostic Description
-.NET Framework provides a standard way to mark code elements as obsolete using [`System.ObsoleteAttribute`](https://learn.microsoft.com/en-us/dotnet/api/system.obsoleteattribute?view=netframework-4.8.1). 
-This attribute can be applied to classes, methods, properties, fields, events, and other code elements. When a code element is marked as obsolete, it indicates that the element should not be used in new code and may be removed in future versions.
+.NET Framework provides a standard way to mark a code element as obsolete by using [`System.ObsoleteAttribute`](https://learn.microsoft.com/en-us/dotnet/api/system.obsoleteattribute?view=netframework-4.8.1). 
+This attribute can be applied to classes, methods, properties, fields, events, and other code elements. When a code element is marked as obsolete, it means that the element should not be used in the new code and may be removed in future versions.
 
-Acumatica frequently marks its obsolete public APIs with this element. However, because C# compiler does not recognize Acumatica Framework extension mechanisms, it does not report an error when an obsolete code element is extended via them.
-The affected scenarios include:
-* Override of an obsolete virtual method in a graph extension using the `PXOverride` mechanism.
-* Access to an obsolete protected method in a graph extension using the `PXProtectedAccess` mechanism.
-* Addition of a view delegate to the obsolete view.
-* Addition of an action delegate to the obsolete action.
-* Customization of attributes of an obsolete DAC field property in a DAC extension or via a cache attached event handler of a graph extension.
+In Acumatica ERP code, public APIs are frequently marked as obsolete with `System.ObsoleteAttribute`. However, because C# compiler does not recognize Acumatica Framework extension mechanisms, it does not report an error when an obsolete code element is extended via this attribute.
+The affected scenarios include the following:
+* Override of an obsolete virtual method in a graph extension by using the `PXOverride` mechanism
+* Access to an obsolete protected method in a graph extension by using the `PXProtectedAccess` mechanism
+* Addition of a view delegate to an obsolete view
+* Addition of an action delegate to an obsolete action.
+* Customization of attributes of an obsolete DAC field property in a DAC extension or via a cache attached event handler of a graph extension
 
-The diagnostic PX1100 attempts to fix this issue by reporting a warning when an obsolete code element is extended or overridden via a graph or DAC extension mechanisms. The diagnostic currently detects the following scenarios:
-* Override of an obsolete virtual method in a graph extension using the `PXOverride` mechanism.
+The PX1100 diagnostic attempts to fix this issue by reporting a warning when an obsolete code element is extended or overridden via a graph or DAC extension mechanisms. The diagnostic currently detects the following scenarios:
+* Override of an obsolete virtual method in a graph extension by using the `PXOverride` mechanism
 
 ## Example of a Method with the PXOverride Attribute Overriding the Obsolete Method
-In the following example, `PXOverride` method overrides an obsolete base method.
+In the following example, the `PXOverride` method overrides an obsolete base method.
 ```cs
 public class MyGraph : PXGraph<MyGraph>
 {

--- a/docs/diagnostics/PX1100.md
+++ b/docs/diagnostics/PX1100.md
@@ -1,0 +1,51 @@
+# PX1100
+This document describes the PX1100 diagnostic.
+
+## Summary
+
+| Code   | Short Description                                                                     | Type    | Code Fix    | 
+| ------ | ------------------------------------------------------------------------------------- | ------- | ----------- | 
+| PX1100 | An element of a graph or DAC extension extends or overrides an obsolete code element. | Warning | Unavailable | 
+
+## Diagnostic Description
+.NET Framework provides a standard way to mark code elements as obsolete using [`System.ObsoleteAttribute`](https://learn.microsoft.com/en-us/dotnet/api/system.obsoleteattribute?view=netframework-4.8.1). 
+This attribute can be applied to classes, methods, properties, fields, events, and other code elements. When a code element is marked as obsolete, it indicates that the element should not be used in new code and may be removed in future versions.
+
+Acumatica frequently marks its obsolete public APIs with this element. However, because C# compiler does not recognize Acumatica Framework extension mechanisms, it does not report an error when an obsolete code element is extended via them.
+The affected scenarios include:
+* Override of an obsolete virtual method in a graph extension using the `PXOverride` mechanism.
+* Access to an obsolete protected method in a graph extension using the `PXProtectedAccess` mechanism.
+* Addition of a view delegate to the obsolete view.
+* Addition of an action delegate to the obsolete action.
+* Customization of attributes of an obsolete DAC field property in a DAC extension or via a cache attached event handler of a graph extension.
+
+The diagnostic PX1100 attempts to fix this issue by reporting a warning when an obsolete code element is extended or overridden via a graph or DAC extension mechanisms. The diagnostic currently detects the following scenarios:
+* Override of an obsolete virtual method in a graph extension using the `PXOverride` mechanism.
+
+## Example of a Method with the PXOverride Attribute Overriding the Obsolete Method
+In the following example, `PXOverride` method overrides an obsolete base method.
+```cs
+public class MyGraph : PXGraph<MyGraph>
+{
+	[Obsolete("This method is obsolete and will be removed in future versions.")]
+	protected virtual void UpdateBalances()
+	{
+		// Implementation
+	}
+}
+
+public class BaseGraphExtension : PXGraphExtension<MyGraph>
+{
+	/// Overrides <seealso cref="MyGraph.UpdateBalances()"/>
+	[PXOverride]
+	public void UpdateBalances(Action base_UpdateBalances)		// Report PX1100
+	{
+		// Implementation
+	}
+}
+```
+
+## Related Articles
+- [Obsolete Attribute](https://learn.microsoft.com/en-us/dotnet/api/system.obsoleteattribute?view=netframework-4.8.1)
+- [To Override a Virtual Method](https://help.acumatica.com/Help?ScreenId=ShowWiki&pageid=6fa2a444-17b4-42f9-9e6a-64e85167626a)
+- [Override of a Method](https://help.acumatica.com/Help?ScreenId=ShowWiki&pageid=635c830e-4617-4d5c-9fa5-035952311aa9)

--- a/docs/diagnostics/PX1100.md
+++ b/docs/diagnostics/PX1100.md
@@ -17,7 +17,8 @@ The affected scenarios include the following:
 * Access to an obsolete protected method in a graph extension by using the `PXProtectedAccess` mechanism
 * Addition of a view delegate to an obsolete view
 * Addition of an action delegate to an obsolete action.
-* Customization of attributes of an obsolete DAC field property in a DAC extension or via a cache attached event handler of a graph extension
+* Customization of attributes of an obsolete DAC field property in a DAC extension
+* Customization via a cache attached event handler of a graph extension
 
 The PX1100 diagnostic attempts to fix this issue by reporting a warning when an obsolete code element is extended or overridden via a graph or DAC extension mechanisms. The diagnostic currently detects the following scenarios:
 * Override of an obsolete virtual method in a graph extension by using the `PXOverride` mechanism

--- a/src/Acuminator/Acuminator.Analyzers/DiagnosticsShortName.Designer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/DiagnosticsShortName.Designer.cs
@@ -1033,6 +1033,15 @@ namespace Acuminator.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to ExtensionOfObsoleteElement.
+        /// </summary>
+        public static string PX1100 {
+            get {
+                return ResourceManager.GetString("PX1100", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to PXOverrideWithInvalidDelegateParameter.
         /// </summary>
         public static string PX1101 {

--- a/src/Acuminator/Acuminator.Analyzers/DiagnosticsShortName.resx
+++ b/src/Acuminator/Acuminator.Analyzers/DiagnosticsShortName.resx
@@ -441,6 +441,9 @@
   <data name="PX1099" xml:space="preserve">
     <value>UsageOfForbiddenApi</value>
   </data>
+  <data name="PX1100" xml:space="preserve">
+    <value>ExtensionOfObsoleteElement</value>
+  </data>
   <data name="PX1101" xml:space="preserve">
     <value>PXOverrideWithInvalidDelegateParameter</value>
   </data>

--- a/src/Acuminator/Acuminator.Analyzers/Resources.Designer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/Resources.Designer.cs
@@ -2150,6 +2150,15 @@ namespace Acuminator.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to A method with the PXOverride attribute overrides an obsolete method.
+        /// </summary>
+        public static string PX1100TitlePXOverride {
+            get {
+                return ResourceManager.GetString("PX1100TitlePXOverride", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Fix the signature of the additional delegate parameter.
         /// </summary>
         public static string PX1101Fix {

--- a/src/Acuminator/Acuminator.Analyzers/Resources.resx
+++ b/src/Acuminator/Acuminator.Analyzers/Resources.resx
@@ -820,6 +820,9 @@ Reason: {2}</value>
   <data name="PX1099Title_TypeFormatArg" xml:space="preserve">
     <value>type</value>
   </data>
+  <data name="PX1100TitlePXOverride" xml:space="preserve">
+    <value>A method with the PXOverride attribute overrides an obsolete method</value>
+  </data>
   <data name="PX1101Fix" xml:space="preserve">
     <value>Fix the signature of the additional delegate parameter</value>
   </data>

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/Descriptors.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/Descriptors.cs
@@ -511,6 +511,9 @@ namespace Acuminator.Analyzers.StaticAnalysis
 			Rule("PX1099", nameof(Resources.PX1099Title).GetLocalized(), Category.Acuminator, DiagnosticSeverity.Warning, DiagnosticsShortName.PX1099,
 				 messageFormat: nameof(Resources.PX1099TitleFormatWithReason).GetLocalized());
 
+		public static DiagnosticDescriptor PX1100_PXOverrideOverridesObsoleteMethod { get; } =
+			Rule("PX1100", nameof(Resources.PX1100TitlePXOverride).GetLocalized(), Category.Acuminator, DiagnosticSeverity.Warning, DiagnosticsShortName.PX1100);
+
 		public static DiagnosticDescriptor PX1101_PXOverrideWithInvalidDelegateParameter { get; } =
 			Rule("PX1101", nameof(Resources.PX1101Title).GetLocalized(), Category.Acuminator, DiagnosticSeverity.Error, DiagnosticsShortName.PX1101);
 	}

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/ObsoleteElementsUsage/ObsoleteElementsUsageAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/ObsoleteElementsUsage/ObsoleteElementsUsageAnalyzer.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+
+using Acuminator.Analyzers.StaticAnalysis.PXGraph;
+using Acuminator.Utilities.Common;
+using Acuminator.Utilities.DiagnosticSuppression;
+using Acuminator.Utilities.Roslyn.Semantic;
+using Acuminator.Utilities.Roslyn.Semantic.PXGraph;
+using Acuminator.Utilities.Roslyn.Syntax;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Acuminator.Analyzers.StaticAnalysis.ObsoleteElementsUsage
+{
+	public class ObsoleteElementsUsageAnalyzer : IPXGraphAnalyzer
+	{
+		public ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = new[] 
+		{ 
+			Descriptors.PX1100_PXOverrideOverridesObsoleteMethod 
+		}
+		.Distinct()
+		.ToImmutableArray();
+
+		public bool ShouldAnalyze(PXContext pxContext, PXGraphEventSemanticModel graphExtension) =>
+			graphExtension != null && graphExtension.IsInSource && 
+			pxContext.AttributeTypes.ObsoleteAttribute != null &&
+			graphExtension.GraphType == GraphType.PXGraphExtension;
+
+		public void Analyze(SymbolAnalysisContext context, PXContext pxContext, PXGraphEventSemanticModel graphExtension)
+		{
+			context.CancellationToken.ThrowIfCancellationRequested();
+
+			var obsoleteAttribute = pxContext.AttributeTypes.ObsoleteAttribute;
+			CheckPXOverrideMethods(context, pxContext, graphExtension, obsoleteAttribute);
+		}
+
+		private void CheckPXOverrideMethods(SymbolAnalysisContext context, PXContext pxContext, PXGraphEventSemanticModel graphExtension, 
+											INamedTypeSymbol obsoleteAttribute)
+		{
+			foreach (PXOverrideInfo pxOverrideInfo in graphExtension.DeclaredPXOverrides)
+			{
+				context.CancellationToken.ThrowIfCancellationRequested();
+				CheckPXOverrideMethod(context, pxContext, pxOverrideInfo, obsoleteAttribute);
+			}
+		}
+
+		private void CheckPXOverrideMethod(SymbolAnalysisContext context, PXContext pxContext, PXOverrideInfo pxOverrideInfo,
+											INamedTypeSymbol obsoleteAttribute)
+		{
+			if (pxOverrideInfo.BaseMethod == null)
+				return;
+
+			var attributes = pxOverrideInfo.BaseMethod.GetAttributes();
+
+			if (attributes.IsDefaultOrEmpty)
+				return;
+
+			bool hasObsoleteAttribute = attributes.Any(attr => SymbolEqualityComparer.Default.Equals(attr.AttributeClass, obsoleteAttribute));
+
+			if (hasObsoleteAttribute)
+			{
+				var location = pxOverrideInfo.Symbol.Locations.FirstOrDefault();
+				context.ReportDiagnosticWithSuppressionCheck(
+						Diagnostic.Create(Descriptors.PX1100_PXOverrideOverridesObsoleteMethod, location),
+						pxContext.CodeAnalysisSettings);
+			}
+		}
+	}
+}

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXGraph/PXGraphAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXGraph/PXGraphAnalyzer.cs
@@ -11,13 +11,14 @@ using Acuminator.Analyzers.StaticAnalysis.CallingBaseDataViewDelegate;
 using Acuminator.Analyzers.StaticAnalysis.ChangesInPXCache;
 using Acuminator.Analyzers.StaticAnalysis.ConstructorInGraphExtension;
 using Acuminator.Analyzers.StaticAnalysis.DatabaseQueries;
+using Acuminator.Analyzers.StaticAnalysis.ForbidPrivateEventHandlers;
 using Acuminator.Analyzers.StaticAnalysis.InvalidPXActionSignature;
 using Acuminator.Analyzers.StaticAnalysis.LongOperationStart;
 using Acuminator.Analyzers.StaticAnalysis.NameConventionEventsInGraphsAndGraphExtensions;
 using Acuminator.Analyzers.StaticAnalysis.NoIsActiveMethodForExtension;
 using Acuminator.Analyzers.StaticAnalysis.NonPublicGraphsDacsAndExtensions;
 using Acuminator.Analyzers.StaticAnalysis.NoPrimaryViewForPrimaryDac;
-using Acuminator.Analyzers.StaticAnalysis.ForbidPrivateEventHandlers;
+using Acuminator.Analyzers.StaticAnalysis.ObsoleteElementsUsage;
 using Acuminator.Analyzers.StaticAnalysis.PXActionExecution;
 using Acuminator.Analyzers.StaticAnalysis.PXGraphCreationInGraphInWrongPlaces;
 using Acuminator.Analyzers.StaticAnalysis.PXOverride;
@@ -68,6 +69,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXGraph
 			new StaticFieldOrPropertyInGraphAnalyzer(),
 			new TypoInViewAndActionHandlerNameAnalyzer(),
 			new PXOverrideAnalyzer(),
+			new ObsoleteElementsUsageAnalyzer(),
 			new ForbidPrivateEventHandlersAnalyzer())
 		{
 		}

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PublicClassXmlComment/Helpers/ExcludeFromDocsAttributesChecker.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PublicClassXmlComment/Helpers/ExcludeFromDocsAttributesChecker.cs
@@ -41,8 +41,9 @@ namespace Acuminator.Analyzers.StaticAnalysis.PublicClassXmlComment
 		{
 			foreach (string attrName in attributeNames)
 			{
-				if (ObsoleteAttributeShortName.Equals(attrName) || PXInternalUseOnlyAttributeShortName.Equals(attrName) ||
-					(checkForPXHidden && PXHiddenAttributeShortName.Equals(attrName)))
+				if (ObsoleteAttributeShortName.Equals(attrName, StringComparison.Ordinal) ||
+					PXInternalUseOnlyAttributeShortName.Equals(attrName, StringComparison.Ordinal) ||
+					(checkForPXHidden && PXHiddenAttributeShortName.Equals(attrName, StringComparison.Ordinal)))
 				{
 					return true;
 				}
@@ -67,7 +68,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.PublicClassXmlComment
 
 			// perfomance optimization to avoid checking the suffix of attribute names 
 			// which are definitely shorter than any of the attributes we search with "Attribute" suffix
-			if (attributeName.Length >= minLengthWithSuffix && attributeName.EndsWith(AttributeSuffix))
+			if (attributeName.Length >= minLengthWithSuffix && attributeName.EndsWith(AttributeSuffix, StringComparison.Ordinal))
 			{
 				const int suffixLength = 9;
 				return attributeName.Substring(0, attributeName.Length - suffixLength);

--- a/src/Acuminator/Acuminator.Tests/Acuminator.Tests.csproj
+++ b/src/Acuminator/Acuminator.Tests/Acuminator.Tests.csproj
@@ -388,6 +388,8 @@
     <EmbeddedResource Include="Tests\StaticAnalysis\NonPublicGraphsDacsAndExtensions\Sources\NonPublicGraphWithBadModifiers.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\NonPublicGraphsDacsAndExtensions\Sources\NonPublicPartialGraph_Expected.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\NonPublicGraphsDacsAndExtensions\Sources\NonPublicPartialGraph.cs" />
+    <Compile Include="Tests\StaticAnalysis\ObsoleteElementsUsage\ObsoleteElementsUsageTests.cs" />
+    <EmbeddedResource Include="Tests\StaticAnalysis\ObsoleteElementsUsage\Sources\PXOverride\PXOverrideOfObsoleteMethods.cs" />
     <Compile Include="Tests\StaticAnalysis\PropertyAndBqlFieldTypesMismatch\PropertyAndBqlFieldTypesMismatchTests.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\PropertyAndBqlFieldTypesMismatch\Sources\DacWithInconsistentTypes_BqlFieldFirst_Expected.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\PropertyAndBqlFieldTypesMismatch\Sources\DacWithInconsistentTypes_BqlFieldFirst.cs" />

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/ObsoleteElementsUsage/ObsoleteElementsUsageTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/ObsoleteElementsUsage/ObsoleteElementsUsageTests.cs
@@ -1,0 +1,38 @@
+﻿#nullable enable
+using System.Threading.Tasks;
+
+using Acuminator.Analyzers.StaticAnalysis;
+using Acuminator.Analyzers.StaticAnalysis.ObsoleteElementsUsage;
+using Acuminator.Analyzers.StaticAnalysis.PXGraph;
+using Acuminator.Tests.Helpers;
+using Acuminator.Tests.Verification;
+using Acuminator.Utilities;
+using Acuminator.Utilities.Roslyn.Semantic;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using Xunit;
+
+namespace Acuminator.Tests.Tests.StaticAnalysis.ObsoleteElementsUsage
+{
+	public class ObsoleteElementsUsageTests : DiagnosticVerifier
+	{
+		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer() => new PXGraphAnalyzer(
+				CodeAnalysisSettings.Default
+									.WithRecursiveAnalysisEnabled()
+									.WithStaticAnalysisEnabled()
+									.WithSuppressionMechanismDisabled(),
+				new ObsoleteElementsUsageAnalyzer());
+
+		[Theory]
+		[EmbeddedFileData(@"PXOverride\PXOverrideOfObsoleteMethods.cs")]
+		public Task PXOverrides_With_Incorrect_BaseDelegate_Parameter(string source) =>
+			VerifyCSharpDiagnosticAsync(source,
+				Descriptors.PX1100_PXOverrideOverridesObsoleteMethod.CreateFor(12, 17),
+				Descriptors.PX1100_PXOverrideOverridesObsoleteMethod.CreateFor(18, 15),
+				Descriptors.PX1100_PXOverrideOverridesObsoleteMethod.CreateFor(23, 15),
+				Descriptors.PX1100_PXOverrideOverridesObsoleteMethod.CreateFor(29, 15),
+				Descriptors.PX1100_PXOverrideOverridesObsoleteMethod.CreateFor(39, 17));
+	}
+}

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/ObsoleteElementsUsage/Sources/PXOverride/PXOverrideOfObsoleteMethods.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/ObsoleteElementsUsage/Sources/PXOverride/PXOverrideOfObsoleteMethods.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Collections.Generic;
+
+using PX.Data;
+
+namespace Acuminator.Tests.Sources
+{
+	// Acuminator disable once PX1016 ExtensionDoesNotDeclareIsActiveMethod extension should be constantly active
+	public class DerivedExtension : PXGraphExtension<BaseExtension, MyGraph>
+	{
+		[PXOverride]
+		public object TestMethod1(int x, bool drilldown, double y, Func<int, bool, double, object> del)
+		{
+			return del(x, drilldown, y);
+		}
+
+		[PXOverride]
+		public void TestMethod2(int x)
+		{
+		}
+
+		[PXOverride]
+		public void TestMethod3(IEnumerable<string> source, Action<IEnumerable<string>> del)
+		{
+			del(source);
+		}
+
+		[PXOverride]
+		public void TestMethod4(Action del)
+		{
+			del();
+		}
+	}
+
+	// Acuminator disable once PX1016 ExtensionDoesNotDeclareIsActiveMethod extension should be constantly active
+	public class BaseExtension : PXGraphExtension<MyGraph>
+	{
+		[PXOverride]
+		public object TestMethod1(int x, bool drilldown, double y)
+		{
+			return new object();
+		}
+	}
+
+
+	public class MyGraph : PXGraph<MyGraph>
+	{
+		[Obsolete]
+		public virtual object TestMethod1(int x, bool drilldown, double y)
+		{
+			return new object();
+		}
+
+		[Obsolete("Obsolete")]
+		public virtual void TestMethod2(int x)
+		{	
+		}
+
+		[Obsolete("Obsolete", error: true)]
+		public virtual void TestMethod3(IEnumerable<string> source)
+		{
+		}
+
+		[Obsolete]
+		public virtual void TestMethod4()
+		{
+		}
+	}
+}

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/PXGraph/Infos/PXOverride/PXOverrideInfo.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/PXGraph/Infos/PXOverride/PXOverrideInfo.cs
@@ -58,7 +58,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic.PXGraph
 				if (!method.HasPXOverrideAttribute(pxOverrideAttribute))
 					continue;
 
-				var baseMethod = GetSuitableBaseMethod(method, graphAndGraphExtensionBaseTypes);
+				var baseMethod = GetBaseMethod(method, graphAndGraphExtensionBaseTypes, pxOverrideAttribute);
 				var pxOverrideType = GetPXOverrideType(method, baseMethod);
 
 				if (pxOverrideType != PXOverrideType.None)
@@ -69,14 +69,19 @@ namespace Acuminator.Utilities.Roslyn.Semantic.PXGraph
 			}
 		}
 
-		private static IMethodSymbol? GetSuitableBaseMethod(IMethodSymbol patchMethodWithPXOverride, List<INamedTypeSymbol> graphAndGraphExtensionBaseTypes)
+		private static IMethodSymbol? GetBaseMethod(IMethodSymbol patchMethodWithPXOverride, List<INamedTypeSymbol> graphAndGraphExtensionBaseTypes,
+													INamedTypeSymbol pxOverrideAttribute)
 		{
 			foreach (var baseType in graphAndGraphExtensionBaseTypes)
 			{
-				var suitableBaseMethod = baseType.GetMethods(patchMethodWithPXOverride.Name)
-												 .FirstOrDefault(patchMethodWithPXOverride.IsPXOverrideOf);
-				if (suitableBaseMethod != null)
-					return suitableBaseMethod;
+				// Base method search should look for the first suitable method in the base type hierarchy from the most derived type to the least derived type.
+				// The base method is the first one with the suitable signature that is not marked with PXOverrideAttribute.
+				// The additional condition is required to filter out overrides of the base method in base extensions.
+				var baseMethod = baseType.GetMethods(patchMethodWithPXOverride.Name)
+												 .FirstOrDefault(baseMethod => patchMethodWithPXOverride.IsPXOverrideOf(baseMethod) && 
+																			   !baseMethod.HasPXOverrideAttribute(pxOverrideAttribute));
+				if (baseMethod != null)
+					return baseMethod;
 			}
 
 			return null;


### PR DESCRIPTION
**Merge after PR https://github.com/Acumatica/Acuminator/pull/601**

Changes:
- Added PX1100 diagnostic analyzer
- Added detection of `PXOverrides` that override obsolete methods
- Enhanced the search of a base method for `PXOverride` by filtering out all overrides in base extensions. The correct base method shouldn't have `PXOverrideAttribute`.
- Added unit tests for PX1100
- Added docs for PX1100