### PR TITLE
Feature/atr 739 dev check px override has comment

### DIFF
--- a/docs/Summary.md
+++ b/docs/Summary.md
@@ -104,6 +104,7 @@ Acuminator does not perform static analysis of projects whose names contain `Tes
 | [PX1095](diagnostics/PX1095.md) | A field with the `PXDBCalced` or `PXDBScalar` attribute must have an unbound type attribute, such as `PXDate` or `PXDecimal`. | Error | Unavailable |
 | [PX1096](diagnostics/PX1096.md) | The signature of a method with the `PXOverride` attribute must match the overridden method. | Error | Unavailable |
 | [PX1097](diagnostics/PX1097.md) | Methods with the `PXOverride` attribute must be `public` and non-virtual. | Error | Available |
+| [PX1098](diagnostics/PX1098.md) | Methods with the `PXOverride` attribute must declare an XML documentation comment with a reference to the base method and the format `/// Overrides <seealso cref="{Base method}">`. | Warning | Available |
 | [PX1099](diagnostics/PX1099.md) | The API reported by the diagnostic should not be used with the Acumatica Framework. | Warning | Unavailable |
 | [PX1100](diagnostics/PX1100.md) | An element of a graph or a DAC extension extends or overrides an obsolete code element. | Warning | Unavailable |
 | [PX1101](diagnostics/PX1101.md) | The additional delegate parameter of the method with the `PXOverride` attribute must have the same signature as the base method. | Error | Available |

--- a/docs/Summary.md
+++ b/docs/Summary.md
@@ -104,7 +104,7 @@ Acuminator does not perform static analysis of projects whose names contain `Tes
 | [PX1095](diagnostics/PX1095.md) | A field with the `PXDBCalced` or `PXDBScalar` attribute must have an unbound type attribute, such as `PXDate` or `PXDecimal`. | Error | Unavailable |
 | [PX1096](diagnostics/PX1096.md) | The signature of a method with the `PXOverride` attribute must match the overridden method. | Error | Unavailable |
 | [PX1097](diagnostics/PX1097.md) | Methods with the `PXOverride` attribute must be `public` and non-virtual. | Error | Available |
-| [PX1098](diagnostics/PX1098.md) | Methods with the `PXOverride` attribute must declare an XML documentation comment with a reference to the base method which has the format `/// Overrides <seealso cref="{Base method}">`. | Warning | Available |
+| [PX1098](diagnostics/PX1098.md) | Methods with the `PXOverride` attribute must declare an XML documentation comment with a reference to the base method that has the format `/// Overrides <seealso cref="{Base method}">`. | Warning | Available |
 | [PX1099](diagnostics/PX1099.md) | The API reported by the diagnostic should not be used with the Acumatica Framework. | Warning | Unavailable |
 | [PX1100](diagnostics/PX1100.md) | An element of a graph or a DAC extension extends or overrides an obsolete code element. | Warning | Unavailable |
 | [PX1101](diagnostics/PX1101.md) | The additional delegate parameter of the method with the `PXOverride` attribute must have the same signature as the base method. | Error | Available |

--- a/docs/Summary.md
+++ b/docs/Summary.md
@@ -104,7 +104,7 @@ Acuminator does not perform static analysis of projects whose names contain `Tes
 | [PX1095](diagnostics/PX1095.md) | A field with the `PXDBCalced` or `PXDBScalar` attribute must have an unbound type attribute, such as `PXDate` or `PXDecimal`. | Error | Unavailable |
 | [PX1096](diagnostics/PX1096.md) | The signature of a method with the `PXOverride` attribute must match the overridden method. | Error | Unavailable |
 | [PX1097](diagnostics/PX1097.md) | Methods with the `PXOverride` attribute must be `public` and non-virtual. | Error | Available |
-| [PX1098](diagnostics/PX1098.md) | Methods with the `PXOverride` attribute must declare an XML documentation comment with a reference to the base method and the format `/// Overrides <seealso cref="{Base method}">`. | Warning | Available |
+| [PX1098](diagnostics/PX1098.md) | Methods with the `PXOverride` attribute must declare an XML documentation comment with a reference to the base method which has the format `/// Overrides <seealso cref="{Base method}">`. | Warning | Available |
 | [PX1099](diagnostics/PX1099.md) | The API reported by the diagnostic should not be used with the Acumatica Framework. | Warning | Unavailable |
 | [PX1100](diagnostics/PX1100.md) | An element of a graph or a DAC extension extends or overrides an obsolete code element. | Warning | Unavailable |
 | [PX1101](diagnostics/PX1101.md) | The additional delegate parameter of the method with the `PXOverride` attribute must have the same signature as the base method. | Error | Available |

--- a/docs/dev/CodingGuidelines/CodingGuidelines.md
+++ b/docs/dev/CodingGuidelines/CodingGuidelines.md
@@ -28,6 +28,8 @@
     * [Async Anonymous Delegates](#async-anonymous-delegates)
     * [Value Tuples (Obsolete)](#value-tuples-obsolete)
     * [Debugging Hints](#debugging-hints)
+        * [Out-Of-Process Analysis](#out-of-process-analysis)
+        * [Parallel Execution of Diagnostics Under Debug](#parallel-execution-of-diagnostics-under-debug)
     * [Checking Acumatica DLL Version](#checking-acumatica-dll-version)
 
 ## Code Style
@@ -459,12 +461,22 @@ Therefore, until we drop the support for Visual Studio 2017, do not declare publ
 
 ### Debugging Hints
 
+#### Out-Of-Process Analysis
+
 There is an unobvious issue with debugging observed on the latest versions of Visual Studio 2019 (starting from 16.8.0). The breakpoints set inside Roslyn analyzers are not hit for no obvious reason. The root cause of this problem lies in a new Visual Studio perfomance optimization which moves execution of all Roslyn analyzers out of the Visual Studio process into a separate 64-bit process. This action is regulated by the  following Visual Studio setting: *Tools -> Options -> Text Editor -> C# -> Advanced -> Use 64-bit process for code analysis*.
 You need to do one of the following:
 * Disable this setting in an experimental instance of Visual Studio.
 * Perform a multiprocess debugging by attaching your debugger to a second process with loaded Roslyn analyzers. The name of the process should look like the following: *ServiceHub.RoslynCodeAnalysisService.exe*.
 
 The first option is much simpler but you have to check that your diagnostic works correctly when the out of process analysis is enabled for Visual Studio.
+
+#### Parallel Execution of Diagnostics Under Debug
+
+ Acuminator analyzers in general are executed in parallel. This may lead to confusion when you debug your analyzer because the debugger may switch between different threads executing different analyzers. 
+ To avoid this confusion, Acuminator contains checks in various places that detect whether the debugger is attached to the process. If the debugger is attached, Acuminator forces sequential execution of analyzers.
+
+ Usually, this is a desired behavior. However, in some scenarios you may want to analyze a big solution with the debugger attached. For example, you may want to investigate an unhandled exception thrown by some analyzer on a big solution.
+ In this case you can disable the sequential execution of analyzers by finding all usages of the `System.Diagnostics.Debugger.IsAttached` property in the Acuminator codebase and replacing them with appropriate boolean constants.
 
 ### Checking Acumatica DLL Version
 

--- a/docs/dev/CodingGuidelines/CodingGuidelines.md
+++ b/docs/dev/CodingGuidelines/CodingGuidelines.md
@@ -472,11 +472,13 @@ The first option is much simpler but you have to check that your diagnostic work
 
 #### Parallel Execution of Diagnostics Under Debug
 
- Acuminator analyzers in general are executed in parallel. This may lead to confusion when you debug your analyzer because the debugger may switch between different threads executing different analyzers. 
+ Acuminator analyzers are generally executed in parallel. This may lead to confusion when you debug your analyzer because the debugger may switch between different threads that execute different analyzers. 
  To avoid this confusion, Acuminator contains checks in various places that detect whether the debugger is attached to the process. If the debugger is attached, Acuminator forces sequential execution of analyzers.
 
  Usually, this is a desired behavior. However, in some scenarios you may want to analyze a big solution with the debugger attached. For example, you may want to investigate an unhandled exception thrown by some analyzer on a big solution.
- In this case you can disable the sequential execution of analyzers by finding all usages of the `System.Diagnostics.Debugger.IsAttached` property in the Acuminator codebase and replacing them with appropriate boolean constants.
+ In this case, you can disable the sequential execution of analyzers by doing the following:
+ 1. Find all uses of the `System.Diagnostics.Debugger.IsAttached` property in the Acuminator codebase.
+ 2. Replace the property with appropriate boolean constant.
 
 ### Checking Acumatica DLL Version
 

--- a/docs/diagnostics/PX1079.md
+++ b/docs/diagnostics/PX1079.md
@@ -36,6 +36,7 @@ The name of the delegate parameter is generated according to the naming conventi
 * The overriding method cannot be `virtual`, `abstract`, or `override`.
 * The overriding method should not be `static`.
 * The overriding method cannot be a generic method.
+* The overriding method should declare an XML documentation comment with a reference to the base method in the format `/// Overrides <seealso cref="{Base method}">`.
 * The signature of the overriding method must be compatible with the signature of the overridden base method. The names of the derived method and the base method must match.
 * The base method must be `virtual` (have either `virtual` or `override` modifiers).
 * The base method must have one of the following accessibility levels: `public`, `protected`, or `protected internal`.

--- a/docs/diagnostics/PX1096.md
+++ b/docs/diagnostics/PX1096.md
@@ -19,6 +19,7 @@ The signatures of the overridden and overriding methods must comply with one of 
 * The overriding method cannot be `virtual`, `abstract`, or `override`.
 * The overriding method cannot be a generic method.
 * The overriding method should always declare an additional delegate parameter.
+* The overriding method should declare an XML documentation comment with a reference to the base method in the format `/// Overrides <seealso cref="{Base method}">`.
 * The base method must be `virtual` (have either `virtual` or `override` modifiers).
 * The base method must have one of the following accessibility levels: `public`, `protected`, or `protected internal`.
 * The names of the derived method and the base method must match.

--- a/docs/diagnostics/PX1097.md
+++ b/docs/diagnostics/PX1097.md
@@ -16,8 +16,9 @@ A method with the `PXOverride` attribute must be declared as `public` and must n
 * The overriding method must be declared in a graph extension.
 * The overriding method should not be `static`.
 * The overriding method cannot be a generic method.
-* The signature of the overriding method must be compatible with the signature of the overridden base method. The names of the derived method and the base method must match.
 * The overriding method should always declare an additional delegate parameter.
+* The overriding method should declare an XML documentation comment with a reference to the base method in the format `/// Overrides <seealso cref="{Base method}">`.
+* The signature of the overriding method must be compatible with the signature of the overridden base method. The names of the derived method and the base method must match.
 * The base method must be `virtual` (have either `virtual` or `override` modifiers).
 * The base method must have one of the following accessibility levels: `public`, `protected`, or `protected internal`.
 

--- a/docs/diagnostics/PX1098.md
+++ b/docs/diagnostics/PX1098.md
@@ -1,0 +1,108 @@
+# PX1098
+This document describes the PX1098 diagnostic.
+
+## Summary
+
+| Code   | Short Description                                                                                                                                                                    |  Type   | Code Fix    | 
+| ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------- | ----------- | 
+| PX1098 | Methods with the `PXOverride` attribute must declare an XML documentation comment with a reference to the base method and the format `/// Overrides <seealso cref="{Base method}">`. | Warning |  Available  | 
+
+## Diagnostic Description
+Acumatica best practices for methods with `PXOverride` attributes require from such methods to have an XML documentation comment with a reference to the base method and the format `/// Overrides <seealso cref="{Base method}">`.
+This XML comment should not be enclosed inside `summary` or any other XML documentation comment tags because it is not a part of method's documentation. 
+The method with the `PXOverride` attribute can optionally have other XML documentation comments, but the comment with the `Overrides` reference must be present.
+
+This Acumatica convention ensures that for a base method declared in a graph or a graph extension it is reasonably simple to find all `PXOverride` methods that customize it with the Reference Search IDE feature.
+The "Overrides" prefix is used to allow developers to quickly distinguish found `PXOverride` methods from other references to the base method found by Reference Search.
+
+## Further Constraints of Methods with the PXOverride Attribute
+* The overriding method must be declared in a graph extension.
+* The overriding method should not be `static`.
+* The overriding method must have the `public` access modifier.
+* The overriding method cannot be `virtual`, `abstract`, or `override`.
+* The overriding method cannot be a generic method.
+* The signature of the overriding method must be compatible with the signature of the overridden base method. The names of the derived method and the base method must match.
+* The overriding method should always declare an additional delegate parameter.
+* The base method must be `virtual` (have either `virtual` or `override` modifiers).
+* The base method must have one of the following accessibility levels: `public`, `protected`, or `protected internal`.
+
+## Code Fix
+The code fix for the PX1098 diagnostic will generate a missing XML doc comment with a reference to the base method in the required format. 
+Like many other Acuminator code fixes this code fix can be used for the entire solution or project to quickly address all places with missing XML comments for methods with the `PXOverride` attribute.
+
+## Example of Correct Code
+The following example demonstrates the correct declaration of the `PXOverride` method.
+```cs
+public class MyGraph : PXGraph<MyGraph>
+{
+}
+
+public class BaseGraphExtension : PXGraphExtension<MyGraph>
+{
+	public virtual int Add(int x, string y)
+	{
+		return x + Convert.ToInt32(y);
+	}
+}
+
+public class DerivedGraphExtension : PXGraphExtension<BaseGraphExtension, MyGraph>
+{
+	/// Overrides <seealso cref="BaseGraphExtension.Add(int, string)"/>
+	[PXOverride]
+	public int Add(int x, string y, Func<int, string, int> base_Add)
+	{
+		if (x < 10)
+		{
+			return x + Convert.ToInt32(y) * 2;
+		}
+		return base_Add(x, y);
+	}
+}
+```
+
+## Example of Incorrect Code
+In the following example, `PXOverride` methods do not have XML doc comments with a reference to the base method in a required format.
+```cs
+public class MyGraph : PXGraph<MyGraph>
+{
+	protected virtual void UpdateBalances()
+	{
+		// Implementation
+	}
+}
+
+public class BaseGraphExtension : PXGraphExtension<MyGraph>
+{
+	public virtual int Add(int x, string y)
+	{
+		return x + Convert.ToInt32(y);
+	}
+}
+
+public class DerivedGraphExtension : PXGraphExtension<BaseGraphExtension, MyGraph>
+{
+	[PXOverride]
+	public int Add(int x, string y, Func<int, string, int> base_Add)
+	{
+		if (x < 10)
+		{
+			return x + Convert.ToInt32(y) * 2;
+		}
+
+		return base_Add(x, y);
+	}
+
+	[PXOverride]
+	protected void UpdateBalances(Action base_UpdateBalances)
+	{
+		base_UpdateBalances();
+
+		// Implementation
+	}
+}
+```
+
+## Related Articles
+- [To Override a Virtual Method](https://help.acumatica.com/Help?ScreenId=ShowWiki&pageid=6fa2a444-17b4-42f9-9e6a-64e85167626a)
+- [Override of a Method](https://help.acumatica.com/Help?ScreenId=ShowWiki&pageid=635c830e-4617-4d5c-9fa5-035952311aa9)
+- [PXOverrideAttribute](https://help.acumatica.com/Help?ScreenId=ShowWiki&pageid=cdc4f1df-a4cc-5de5-a379-5078ad449965)

--- a/docs/diagnostics/PX1098.md
+++ b/docs/diagnostics/PX1098.md
@@ -5,15 +5,15 @@ This document describes the PX1098 diagnostic.
 
 | Code   | Short Description                                                                                                                                                                    |  Type   | Code Fix    | 
 | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------- | ----------- | 
-| PX1098 | Methods with the `PXOverride` attribute must declare an XML documentation comment with a reference to the base method and the format `/// Overrides <seealso cref="{Base method}">`. | Warning |  Available  | 
+| PX1098 | Methods with the `PXOverride` attribute must declare an XML documentation comment with a reference to the base method which has the format `/// Overrides <seealso cref="{Base method}">`. | Warning |  Available  | 
 
 ## Diagnostic Description
-Acumatica best practices for methods with `PXOverride` attributes require from such methods to have an XML documentation comment with a reference to the base method and the format `/// Overrides <seealso cref="{Base method}">`.
-This XML comment should not be enclosed inside `summary` or any other XML documentation comment tags because it is not a part of method's documentation. 
-The method with the `PXOverride` attribute can optionally have other XML documentation comments, but the comment with the `Overrides` reference must be present.
+Acumatica best practices for methods with the `PXOverride` attribute require such methods to have an XML documentation comment with a reference to the base method. The format of the comment is the following: `/// Overrides <seealso cref="{Base method}">`.
+This XML comment should not be inside the `summary` tag or any other XML documentation comment tags because this comment is not a part of method's documentation. 
+A method with the `PXOverride` attribute can optionally have other XML documentation comments, but the comment with the `Overrides` reference must be present.
 
-This Acumatica convention ensures that for a base method declared in a graph or a graph extension it is reasonably simple to find all `PXOverride` methods that customize it with the Reference Search IDE feature.
-The "Overrides" prefix is used to allow developers to quickly distinguish found `PXOverride` methods from other references to the base method found by Reference Search.
+This Acumatica convention ensures that, for a base method declared in a graph or a graph extension, the reference search feature of the IDE can easily find all `PXOverride` methods that customize the base method.
+The "Overrides" prefix is used to give developers an opportunity to quickly distinguish the detected `PXOverride` methods from other references to the base method found by reference search.
 
 ## Further Constraints of Methods with the PXOverride Attribute
 * The overriding method must be declared in a graph extension.
@@ -27,8 +27,8 @@ The "Overrides" prefix is used to allow developers to quickly distinguish found 
 * The base method must have one of the following accessibility levels: `public`, `protected`, or `protected internal`.
 
 ## Code Fix
-The code fix for the PX1098 diagnostic will generate a missing XML doc comment with a reference to the base method in the required format. 
-Like many other Acuminator code fixes this code fix can be used for the entire solution or project to quickly address all places with missing XML comments for methods with the `PXOverride` attribute.
+The code fix for the PX1098 diagnostic will generate a missing XML documentation comment with a reference to the base method in the required format. 
+Like many other Acuminator code fixes, this code fix can be used for the entire solution or project to quickly address all places with missing XML comments for methods with the `PXOverride` attribute.
 
 ## Example of Correct Code
 The following example demonstrates the correct declaration of the `PXOverride` method.
@@ -61,7 +61,7 @@ public class DerivedGraphExtension : PXGraphExtension<BaseGraphExtension, MyGrap
 ```
 
 ## Example of Incorrect Code
-In the following example, `PXOverride` methods do not have XML doc comments with a reference to the base method in a required format.
+In the following example, the `PXOverride` methods do not have the XML doc comments with a reference to the base method in the required format.
 ```cs
 public class MyGraph : PXGraph<MyGraph>
 {

--- a/docs/diagnostics/PX1098.md
+++ b/docs/diagnostics/PX1098.md
@@ -5,7 +5,7 @@ This document describes the PX1098 diagnostic.
 
 | Code   | Short Description                                                                                                                                                                    |  Type   | Code Fix    | 
 | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------- | ----------- | 
-| PX1098 | Methods with the `PXOverride` attribute must declare an XML documentation comment with a reference to the base method which has the format `/// Overrides <seealso cref="{Base method}">`. | Warning |  Available  | 
+| PX1098 | Methods with the `PXOverride` attribute must declare an XML documentation comment with a reference to the base method that has the format `/// Overrides <seealso cref="{Base method}">`. | Warning |  Available  | 
 
 ## Diagnostic Description
 Acumatica best practices for methods with the `PXOverride` attribute require such methods to have an XML documentation comment with a reference to the base method. The format of the comment is the following: `/// Overrides <seealso cref="{Base method}">`.

--- a/docs/diagnostics/PX1101.md
+++ b/docs/diagnostics/PX1101.md
@@ -24,6 +24,7 @@ The convention is to name the delegate parameter as `base_<MethodName>`, where `
 * The overriding method should not be `static`.
 * The overriding method cannot be a generic method.
 * The overriding method should always declare an additional delegate parameter.
+* The overriding method should declare an XML documentation comment with a reference to the base method in the format `/// Overrides <seealso cref="{Base method}">`.
 * The signature of the overriding method must be compatible with the signature of the overridden base method. The names of the derived method and the base method must match.
 * The base method must be `virtual` (have either `virtual` or `override` modifiers).
 * The base method must have one of the following accessibility levels: `public`, `protected`, or `protected internal`.

--- a/docs/diagnostics/PX1102.md
+++ b/docs/diagnostics/PX1102.md
@@ -24,6 +24,7 @@ The code fix for the PX1102 diagnostic renames the delegate parameter to `base_<
 * The overriding method should not be `static`.
 * The overriding method cannot be a generic method.
 * The overriding method should always declare an additional delegate parameter.
+* The overriding method should declare an XML documentation comment with a reference to the base method in the format `/// Overrides <seealso cref="{Base method}">`.
 * The signature of the overriding method must be compatible with the signature of the overridden base method. The names of the derived method and the base method must match.
 * The base method must be `virtual` (have either `virtual` or `override` modifiers).
 * The base method must have one of the following accessibility levels: `public`, `protected`, or `protected internal`.

--- a/src/Acuminator/Acuminator.Analyzers/DiagnosticsShortName.Designer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/DiagnosticsShortName.Designer.cs
@@ -1024,6 +1024,15 @@ namespace Acuminator.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to PXOverrideMethodWithoutXmlDocComment.
+        /// </summary>
+        public static string PX1098 {
+            get {
+                return ResourceManager.GetString("PX1098", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to UsageOfForbiddenApi.
         /// </summary>
         public static string PX1099 {

--- a/src/Acuminator/Acuminator.Analyzers/DiagnosticsShortName.resx
+++ b/src/Acuminator/Acuminator.Analyzers/DiagnosticsShortName.resx
@@ -438,6 +438,9 @@
   <data name="PX1097" xml:space="preserve">
     <value>PXOverrideMethodMustBePublicNonVirtual</value>
   </data>
+  <data name="PX1098" xml:space="preserve">
+    <value>PXOverrideMethodWithoutXmlDocComment</value>
+  </data>
   <data name="PX1099" xml:space="preserve">
     <value>UsageOfForbiddenApi</value>
   </data>

--- a/src/Acuminator/Acuminator.Analyzers/Resources.Designer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/Resources.Designer.cs
@@ -2068,6 +2068,25 @@ namespace Acuminator.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Add the XML documentation comment with the reference to the base method.
+        /// </summary>
+        public static string PX1098Fix {
+            get {
+                return ResourceManager.GetString("PX1098Fix", resourceCulture);
+            }
+        }
+
+		/// <summary>
+		///   Looks up a localized string similar to A method with the PXOverride attribute must declare an XML documentation comment with a reference to the base method. The format of the comment is:<br/>
+		/// &#47;&#47;&#47; Overrides &lt;seealso cref=&quot;{Base method}&quot;/&gt;.
+		/// </summary>
+		public static string PX1098Title {
+            get {
+                return ResourceManager.GetString("PX1098Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The forbidden API is used.
         /// </summary>
         public static string PX1099Title {

--- a/src/Acuminator/Acuminator.Analyzers/Resources.resx
+++ b/src/Acuminator/Acuminator.Analyzers/Resources.resx
@@ -796,7 +796,7 @@ public virtual int? SomeDacField{ get; set; }</value>
     <value>Add the XML documentation comment with the reference to the base method</value>
   </data>
   <data name="PX1098Title" xml:space="preserve">
-    <value>A method with the PXOverride attribute must declare an XML documentation comment with a reference to the base method. The format of the comment is:
+    <value>A method with the PXOverride attribute must declare an XML documentation comment with a reference to the base method. The format of the comment:
 /// Overrides &lt;seealso cref="{Base method}"/&gt;</value>
   </data>
   <data name="PX1099Title" xml:space="preserve">

--- a/src/Acuminator/Acuminator.Analyzers/Resources.resx
+++ b/src/Acuminator/Acuminator.Analyzers/Resources.resx
@@ -792,6 +792,13 @@ public virtual int? SomeDacField{ get; set; }</value>
   <data name="PX1097Title" xml:space="preserve">
     <value>A method with the PXOverride attribute must be public and non-virtual</value>
   </data>
+  <data name="PX1098Fix" xml:space="preserve">
+    <value>Add the XML documentation comment with the reference to the base method</value>
+  </data>
+  <data name="PX1098Title" xml:space="preserve">
+    <value>A method with the PXOverride attribute must declare an XML documentation comment with a reference to the base method. The format of the comment is:
+/// Overrides &lt;seealso cref="{Base method}"/&gt;</value>
+  </data>
   <data name="PX1099Title" xml:space="preserve">
     <value>The forbidden API is used</value>
   </data>

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/AnalyzersAggregator/SymbolAnalyzersAggregator.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/AnalyzersAggregator/SymbolAnalyzersAggregator.cs
@@ -10,6 +10,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 
 using Acuminator.Utilities;
 using Acuminator.Utilities.Roslyn.Semantic;
+using System.Diagnostics;
 
 namespace Acuminator.Analyzers.StaticAnalysis.AnalyzersAggregator
 {
@@ -68,23 +69,25 @@ namespace Acuminator.Analyzers.StaticAnalysis.AnalyzersAggregator
 				case 1:
 					aggregatedAnalyserAction(0);
 					return;
-				default:
-				{
-#if DEBUG
-					for (int analyzerIndex = 0; analyzerIndex < effectiveAnalyzers.Count; analyzerIndex++)
+				default:	
+					if (Debugger.IsAttached)
 					{
-						aggregatedAnalyserAction(analyzerIndex);
+						for (int analyzerIndex = 0; analyzerIndex < effectiveAnalyzers.Count; analyzerIndex++)
+						{
+							aggregatedAnalyserAction(analyzerIndex);
+						}
 					}
-#else
-					parallelOptions = parallelOptions ?? new ParallelOptions
+					else
 					{
-						CancellationToken = context.CancellationToken
-					};
+						parallelOptions = parallelOptions ?? new ParallelOptions
+						{
+							CancellationToken = context.CancellationToken
+						};
 
-					Parallel.For(0, effectiveAnalyzers.Count, parallelOptions, aggregatedAnalyserAction);
-#endif
+						Parallel.For(0, effectiveAnalyzers.Count, parallelOptions, aggregatedAnalyserAction);
+					}
+
 					return;
-				}
 			}
 		}
 	}

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/ChangesInPXCache/ChangesInPXCacheInEventHandlersAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/ChangesInPXCache/ChangesInPXCacheInEventHandlersAnalyzer.cs
@@ -5,6 +5,7 @@ using System.Collections.Immutable;
 using System.Linq;
 
 using Acuminator.Analyzers.StaticAnalysis.EventHandlers;
+using Acuminator.Utilities.Common;
 using Acuminator.Utilities.Roslyn.Semantic;
 using Acuminator.Utilities.Roslyn.Semantic.AcumaticaEvents;
 using Acuminator.Utilities.Roslyn.Syntax;
@@ -17,18 +18,20 @@ namespace Acuminator.Analyzers.StaticAnalysis.ChangesInPXCache
 {
 	public class ChangesInPXCacheInEventHandlersAnalyzer : LooseEventHandlerAggregatedAnalyzerBase
 	{
-		private static readonly ImmutableHashSet<EventType> AnalyzedEventTypes = new []
+		private static readonly EventType[] AnalyzedEventTypes =
 		{
 			EventType.FieldDefaulting,
 			EventType.FieldVerifying,
 			EventType.RowSelected,
 			EventType.RowSelecting,
-		}.ToImmutableHashSet();
+		};
 
-		private static readonly ImmutableHashSet<EventType> AnalyzedEventTypesForIsv = AnalyzedEventTypes
-			.Add(EventType.RowInserting)
-			.Add(EventType.RowUpdating)
-			.Add(EventType.RowDeleting);
+		private static readonly EventType[] AnalyzedEventTypesForIsv = 
+			AnalyzedEventTypes
+				.AppendItem(EventType.RowInserting)
+				.AppendItem(EventType.RowUpdating)
+				.AppendItem(EventType.RowDeleting)
+				.ToArray();
 
 		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => 
 			ImmutableArray.Create(Descriptors.PX1044_ChangesInPXCacheInEventHandlers);

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/DacReferentialIntegrity/DacPrimaryKeyDeclaration/CodeFixes/DacMissingPrimaryKeyFix.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/DacReferentialIntegrity/DacPrimaryKeyDeclaration/CodeFixes/DacMissingPrimaryKeyFix.cs
@@ -154,7 +154,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.DacReferentialIntegrity
 				// Node checked earlier
 				var trivia = dacSemanticModel.Node!.GetLeadingTrivia()
 												   .Add(Whitespace("\t\t"))
-												   .Where(trivia => trivia.IsKind(SyntaxKind.WhitespaceTrivia));
+												   .Where((in SyntaxTrivia trivia) => trivia.IsKind(SyntaxKind.WhitespaceTrivia));
 
 				findByInvocation = findByInvocation.WithLeadingTrivia(trivia);
 			}

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/DacReferentialIntegrity/SharedCodeFixes/IncorrectDeclarationOfDacKeyFix.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/DacReferentialIntegrity/SharedCodeFixes/IncorrectDeclarationOfDacKeyFix.cs
@@ -312,9 +312,9 @@ namespace Acuminator.Analyzers.StaticAnalysis.DacReferentialIntegrity
 				return keyNode;
 
 			var nonStructuredLeadingTrivia = keyNode.GetLeadingTrivia()
-													.Where(trivia => !trivia.HasStructure);
+													.Where((in SyntaxTrivia trivia) => !trivia.HasStructure);
 			var nonStructuredTrailingTrivia = keyNode.GetTrailingTrivia()
-													 .Where(trivia => !trivia.HasStructure);
+													 .Where((in SyntaxTrivia trivia) => !trivia.HasStructure);
 
 			return keyNode.WithLeadingTrivia(nonStructuredLeadingTrivia)
 						  .WithTrailingTrivia(nonStructuredTrailingTrivia);

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/Descriptors.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/Descriptors.cs
@@ -503,6 +503,9 @@ namespace Acuminator.Analyzers.StaticAnalysis
 		public static DiagnosticDescriptor PX1097_PXOverrideMethodMustBePublicNonVirtual { get; } =
 			Rule("PX1097", nameof(Resources.PX1097Title).GetLocalized(), Category.Acuminator, DiagnosticSeverity.Error, DiagnosticsShortName.PX1097);
 
+		public static DiagnosticDescriptor PX1098_PXOverrideMethodWithoutXmlDocComment { get; } =
+			Rule("PX1098", nameof(Resources.PX1098Title).GetLocalized(), Category.Acuminator, DiagnosticSeverity.Warning, DiagnosticsShortName.PX1098);
+
 		public static DiagnosticDescriptor PX1099_ForbiddenApiUsage_WithoutReason { get; } =
 			Rule("PX1099", nameof(Resources.PX1099Title).GetLocalized(), Category.Acuminator, DiagnosticSeverity.Warning, DiagnosticsShortName.PX1099,
 				 messageFormat: nameof(Resources.PX1099TitleFormat).GetLocalized());

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/NonPublicGraphsDacsAndExtensions/NonPublicDacGraphAndExtensionFix.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/NonPublicGraphsDacsAndExtensions/NonPublicDacGraphAndExtensionFix.cs
@@ -132,7 +132,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.NonPublicGraphsDacsAndExtensions
 				SyntaxFactory.TokenList(
 					SyntaxFactory.Token(SyntaxKind.PublicKeyword));
 
-			var modifiersToTransfer = nonPublicTypeNode.Modifiers.Where(token => !SyntaxFacts.IsAccessibilityModifier(token.Kind()));
+			var modifiersToTransfer = nonPublicTypeNode.Modifiers.Where((in SyntaxToken token) => !SyntaxFacts.IsAccessibilityModifier(token.Kind()));
 			modifiersWithPublicAccesibility = modifiersWithPublicAccesibility.AddRange(modifiersToTransfer);
 			return nonPublicTypeNode.WithModifiers(modifiersWithPublicAccesibility);
 		}

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXOverride/AddXmlDocCommentWithReferenceToBaseMethodFix.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXOverride/AddXmlDocCommentWithReferenceToBaseMethodFix.cs
@@ -1,0 +1,212 @@
+﻿using System;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Acuminator.Utilities.Common;
+using Acuminator.Utilities.Roslyn.Syntax;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Acuminator.Analyzers.StaticAnalysis.PXOverride
+{
+	[ExportCodeFixProvider(LanguageNames.CSharp), Shared]
+	public partial class AddXmlDocCommentWithReferenceToBaseMethodFix : PXCodeFixProvider
+	{
+		public override ImmutableArray<string> FixableDiagnosticIds { get; } =
+			ImmutableArray.Create
+			(
+				Descriptors.PX1098_PXOverrideMethodWithoutXmlDocComment.Id
+			);
+
+		protected override Task RegisterCodeFixesForDiagnosticAsync(CodeFixContext context, Diagnostic diagnostic)
+		{
+			context.CancellationToken.ThrowIfCancellationRequested();
+
+			string title = nameof(Resources.PX1098Fix).GetLocalized().ToString();
+			var document = context.Document;
+			var codeAction = CodeAction.Create(title,
+											   cToken => AddXmlDocCommentToPatchMethod(document, context.Span, cToken),
+											   equivalenceKey: nameof(Resources.PX1097Fix));
+			context.RegisterCodeFix(codeAction, diagnostic);
+			return Task.CompletedTask;
+		}
+
+		private static async Task<Document> AddXmlDocCommentToPatchMethod(Document document, TextSpan span, CancellationToken cancellation)
+		{
+			cancellation.ThrowIfCancellationRequested();
+
+			var root = await document.GetSyntaxRootAsync(cancellation).ConfigureAwait(false);
+			var patchMethodNode = root?.FindNode(span)?.FirstAncestorOrSelf<MethodDeclarationSyntax>();
+
+			if (patchMethodNode == null)
+				return document;
+
+			var newPatchMethodNode = AddXmlDocCommentToPatchMethod(patchMethodNode);
+
+			if (newPatchMethodNode == null || ReferenceEquals(patchMethodNode, newPatchMethodNode))
+				return document;
+
+			var newRoot = root!.ReplaceNode(patchMethodNode, newPatchMethodNode);
+			return document.WithSyntaxRoot(newRoot);
+		}
+
+		private static MethodDeclarationSyntax? AddXmlDocCommentToPatchMethod(MethodDeclarationSyntax patchMethodNode)
+		{
+			if (patchMethodNode.AttributeLists.Count > 0)
+			{
+				var firstAttributeList = patchMethodNode.AttributeLists[0];
+				var tokenWithTrivia = AddXmlDocCommentToToken(firstAttributeList.OpenBracketToken);
+
+				if (tokenWithTrivia == null)
+					return null;
+
+				var newAttributeLists =
+					patchMethodNode.AttributeLists.RemoveAt(0)
+												  .Insert(0, firstAttributeList.WithOpenBracketToken(tokenWithTrivia.Value));
+				var newPatchMethodNode = patchMethodNode.WithAttributeLists(newAttributeLists);
+				return newPatchMethodNode;
+			}
+
+			var modifiers = patchMethodNode.Modifiers;
+
+			if (modifiers.Count > 0)
+			{
+				var firstModifier = modifiers[0];
+				var tokenWithTrivia = AddXmlDocCommentToToken(firstModifier);
+
+				if (tokenWithTrivia == null)
+					return null;
+
+				var newModifiers = modifiers.RemoveAt(0)
+											.Insert(0, tokenWithTrivia.Value);
+				var newPatchMethodNode = patchMethodNode.WithModifiers(newModifiers);
+				return newPatchMethodNode;
+			}
+
+			var newReturnType = AddXmlDocCommentToReturnType(patchMethodNode.ReturnType, recursionDepth: 0);
+
+			if (newReturnType == null)
+				return null;
+
+			return patchMethodNode.WithReturnType(newReturnType);
+		}
+
+		private static TypeSyntax? AddXmlDocCommentToReturnType(TypeSyntax returnType, int recursionDepth)
+		{
+			const int recursionMaxDepth = 100;
+
+			if (recursionDepth > recursionMaxDepth)
+				return null; 
+
+			switch (returnType)
+			{
+				case PredefinedTypeSyntax predefinedType:
+					{
+						var tokenWithTrivia = AddXmlDocCommentToToken(predefinedType.Keyword);
+						return tokenWithTrivia != null
+							? predefinedType.WithKeyword(tokenWithTrivia.Value)
+							: null;
+					}
+				case SimpleNameSyntax simpleOrGenericTypeName:
+					{
+						var newReturnType = AddXmlDocCommentToSimpleName(simpleOrGenericTypeName);
+						return newReturnType;
+					}
+				case QualifiedNameSyntax qualifiedTypeName:
+					{
+						var newReturnType = AddXmlDocCommentToQualifiedName(qualifiedTypeName);
+						return newReturnType;
+					}
+
+				case NullableTypeSyntax:
+				case ArrayTypeSyntax:
+				case PointerTypeSyntax:
+					var elementType = GetElementType(returnType);
+
+					if (elementType == null)
+						return null;
+
+					var newElementType = AddXmlDocCommentToReturnType(elementType, recursionDepth: recursionDepth + 1);
+					if (newElementType == null)
+						return null;
+
+					return WithElementType(returnType, elementType);
+				case TupleTypeSyntax tupleType:
+					{
+						var tokenWithTrivia = AddXmlDocCommentToToken(tupleType.OpenParenToken);
+						return tokenWithTrivia != null
+							? tupleType.WithOpenParenToken(tokenWithTrivia.Value)
+							: null;
+					}
+				case RefTypeSyntax refType:
+					{
+						var tokenWithTrivia = AddXmlDocCommentToToken(refType.RefKeyword);
+						return tokenWithTrivia != null
+							? refType.WithRefKeyword(tokenWithTrivia.Value)
+							: null;
+					}
+				case FunctionPointerTypeSyntax functionPointerType:
+					{
+						var tokenWithTrivia = AddXmlDocCommentToToken(functionPointerType.DelegateKeyword);
+						return tokenWithTrivia != null
+							? functionPointerType.WithDelegateKeyword(tokenWithTrivia.Value)
+							: null;
+					}
+				default:
+					return null;
+			}
+		}
+
+		private static QualifiedNameSyntax? AddXmlDocCommentToQualifiedName(QualifiedNameSyntax qualifiedTypeName)
+		{
+			 
+
+		
+		}
+
+		private static SimpleNameSyntax? AddXmlDocCommentToSimpleName(SimpleNameSyntax simpleOrGenericTypeName)
+		{
+			var tokenWithTrivia = AddXmlDocCommentToToken(simpleOrGenericTypeName.Identifier);
+			return tokenWithTrivia != null
+				? simpleOrGenericTypeName.WithIdentifier(tokenWithTrivia.Value)
+				: null;
+		}
+
+		private static TypeSyntax? GetElementType(TypeSyntax? typeNode)
+		{
+			return typeNode switch
+			{
+				ArrayTypeSyntax arrayType 		=> arrayType.ElementType,
+				NullableTypeSyntax nullableType => nullableType.ElementType,
+				PointerTypeSyntax pointerType 	=> pointerType.ElementType,
+				_ 								=> null
+			};
+		}
+
+		private static TypeSyntax? WithElementType(TypeSyntax? typeNode, TypeSyntax newElementType)
+		{
+			return typeNode switch
+			{
+				ArrayTypeSyntax arrayType 		=> arrayType.WithElementType(newElementType),
+				NullableTypeSyntax nullableType => nullableType.WithElementType(newElementType),
+				PointerTypeSyntax pointerType 	=> pointerType.WithElementType(newElementType),
+				_ 								=> null
+			};
+		}
+
+		private static SyntaxToken? AddXmlDocCommentToToken(SyntaxToken tokenToAddTrivia)
+		{
+			
+		}
+	}
+}

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXOverride/AddXmlDocCommentWithReferenceToBaseMethodFix.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXOverride/AddXmlDocCommentWithReferenceToBaseMethodFix.cs
@@ -294,8 +294,13 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXOverride
 															  .TakeWhile((in SyntaxTrivia t) => !t.IsKind(SyntaxKind.EndOfLineTrivia))
 															  .Where(t => t.IsKind(SyntaxKind.WhitespaceTrivia));
 			var newTrivias = whiteSpaceIndentationTrivia.PrependItem(EndOfLine(Environment.NewLine))
-														.AppendItem(commentTrivia)
-														.Concat(oldLeadingTrivia);
+														.AppendItem(commentTrivia);
+
+			if (!oldLeadingTrivia.Any(SyntaxKind.EndOfLineTrivia))
+				newTrivias = newTrivias.AppendItem(EndOfLine(Environment.NewLine));
+
+			newTrivias = newTrivias.Concat(oldLeadingTrivia);
+
 			var newLeadingTrivia = TriviaList(newTrivias);
 			var newToken = tokenToAddTrivia.WithLeadingTrivia(newLeadingTrivia)
 										   .WithAdditionalAnnotations(Simplifier.Annotation);

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXOverride/AddXmlDocCommentWithReferenceToBaseMethodFix.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXOverride/AddXmlDocCommentWithReferenceToBaseMethodFix.cs
@@ -289,7 +289,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXOverride
 				commentTrivia = Trivia(xmlDocCommentNode).WithAdditionalAnnotations(Simplifier.Annotation);
 			}
 
-			var oldLeadingTrivia = tokenToAddTrivia.LeadingTrivia;var x = oldLeadingTrivia.Reverse();
+			var oldLeadingTrivia = tokenToAddTrivia.LeadingTrivia;
 			var whiteSpaceIndentationTrivia = oldLeadingTrivia.Reverse()
 															  .TakeWhile((in SyntaxTrivia t) => !t.IsKind(SyntaxKind.EndOfLineTrivia))
 															  .Where(t => t.IsKind(SyntaxKind.WhitespaceTrivia));

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXOverride/AddXmlDocCommentWithReferenceToBaseMethodFix.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXOverride/AddXmlDocCommentWithReferenceToBaseMethodFix.cs
@@ -290,9 +290,77 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXOverride
 			}
 
 			var oldLeadingTrivia = tokenToAddTrivia.LeadingTrivia;
+			int? indexOfExistingTriviaWithCommentOrDirective = FindIndexOfLastTriviaWithCommentOrPreprocessorDirective(oldLeadingTrivia);
+			IEnumerable<SyntaxTrivia> newTrivias;
+
+			if (indexOfExistingTriviaWithCommentOrDirective != null)
+			{
+				int existingCommentTriviasCount = indexOfExistingTriviaWithCommentOrDirective.Value + 1;
+				newTrivias = InsertNewXmlCommentAfterExistingCommentsAndDirectives(commentTrivia, existingCommentTriviasCount, oldLeadingTrivia);
+			}
+			else
+			{
+				newTrivias = InsertNewXmlCommentWhenNoCommentsAndDirectivesExisted(commentTrivia, oldLeadingTrivia);
+			}
+
+			var newLeadingTrivia = TriviaList(newTrivias);
+			var newToken = tokenToAddTrivia.WithLeadingTrivia(newLeadingTrivia)
+										   .WithAdditionalAnnotations(Simplifier.Annotation);
+			return newToken;
+		}
+
+		private static int? FindIndexOfLastTriviaWithCommentOrPreprocessorDirective(in SyntaxTriviaList triviaList)
+		{
+			for (int i = triviaList.Count - 1; i >= 0; i--)
+			{
+				SyntaxTrivia trivia = triviaList[i];
+
+				if (trivia.IsDirective || trivia.HasStructure || trivia.IsCommentTrivia())
+					return i;
+			}
+
+			return null;
+		}
+
+		private static IEnumerable<SyntaxTrivia> InsertNewXmlCommentAfterExistingCommentsAndDirectives(in SyntaxTrivia commentTrivia,
+																										int countOfExistingCommentTrivia,
+																										in SyntaxTriviaList oldLeadingTrivia)
+		{
+			// for existing comments or preprocessor directives we add new comment after them
+			var existingCommentsAndDirectives = oldLeadingTrivia.Take(countOfExistingCommentTrivia);
+			var remainingExistingTrivias = oldLeadingTrivia.Skip(countOfExistingCommentTrivia);
+
+			if (remainingExistingTrivias.Count == 0)
+			{
+				var newTrivias = existingCommentsAndDirectives.AppendItem(commentTrivia);
+				return newTrivias;
+			}
+			else
+			{
+				var whiteSpaceIndentationTrivia = remainingExistingTrivias.Reverse()
+																		  .TakeWhile((in SyntaxTrivia t) => !t.IsKind(SyntaxKind.EndOfLineTrivia))
+																		  .Where(t => t.IsKind(SyntaxKind.WhitespaceTrivia))
+																		  .Reverse();
+
+				var newTrivias = existingCommentsAndDirectives.Concat(whiteSpaceIndentationTrivia)
+															  .AppendItem(commentTrivia);
+
+				if (!remainingExistingTrivias.Any(SyntaxKind.EndOfLineTrivia))
+					newTrivias = newTrivias.AppendItem(EndOfLine(Environment.NewLine));
+
+				newTrivias = newTrivias.Concat(remainingExistingTrivias);
+				return newTrivias;
+			}
+		}
+
+		private static IEnumerable<SyntaxTrivia> InsertNewXmlCommentWhenNoCommentsAndDirectivesExisted(in SyntaxTrivia commentTrivia, 
+																									   in SyntaxTriviaList oldLeadingTrivia)
+		{
 			var whiteSpaceIndentationTrivia = oldLeadingTrivia.Reverse()
 															  .TakeWhile((in SyntaxTrivia t) => !t.IsKind(SyntaxKind.EndOfLineTrivia))
-															  .Where(t => t.IsKind(SyntaxKind.WhitespaceTrivia));
+															  .Where(t => t.IsKind(SyntaxKind.WhitespaceTrivia))
+															  .Reverse();
+
 			var newTrivias = whiteSpaceIndentationTrivia.PrependItem(EndOfLine(Environment.NewLine))
 														.AppendItem(commentTrivia);
 
@@ -300,11 +368,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXOverride
 				newTrivias = newTrivias.AppendItem(EndOfLine(Environment.NewLine));
 
 			newTrivias = newTrivias.Concat(oldLeadingTrivia);
-
-			var newLeadingTrivia = TriviaList(newTrivias);
-			var newToken = tokenToAddTrivia.WithLeadingTrivia(newLeadingTrivia)
-										   .WithAdditionalAnnotations(Simplifier.Annotation);
-			return newToken;
+			return newTrivias;
 		}
 	}
 }

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXOverride/AddXmlDocCommentWithReferenceToBaseMethodFix.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXOverride/AddXmlDocCommentWithReferenceToBaseMethodFix.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 
 using Acuminator.Utilities.Common;
+using Acuminator.Utilities.Roslyn.Semantic;
 using Acuminator.Utilities.Roslyn.Syntax;
 
 using Microsoft.CodeAnalysis;
@@ -14,6 +15,8 @@ using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.Simplification;
 using Microsoft.CodeAnalysis.Text;
 
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
@@ -23,6 +26,8 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXOverride
 	[ExportCodeFixProvider(LanguageNames.CSharp), Shared]
 	public partial class AddXmlDocCommentWithReferenceToBaseMethodFix : PXCodeFixProvider
 	{
+		private const string XmlDocCommentOverridesPrefix = "Overrides";
+
 		public override ImmutableArray<string> FixableDiagnosticIds { get; } =
 			ImmutableArray.Create
 			(
@@ -33,8 +38,8 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXOverride
 		{
 			context.CancellationToken.ThrowIfCancellationRequested();
 
-			if (!diagnostic.TryGetPropertyValue(PXOverrideDiagnosticProperties.BaseMethodContainingTypeClrName, out var baseMethodContainingTypeClrName) ||
-				baseMethodContainingTypeClrName.IsNullOrWhiteSpace())
+			if (!diagnostic.TryGetPropertyValue(PXOverrideDiagnosticProperties.BaseMethodDocCommentId, out var baseMethodDocCommentId) ||
+				baseMethodDocCommentId.IsNullOrWhiteSpace())
 			{
 				return Task.CompletedTask;
 			}
@@ -42,13 +47,14 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXOverride
 			string title = nameof(Resources.PX1098Fix).GetLocalized().ToString();
 			var document = context.Document;
 			var codeAction = CodeAction.Create(title,
-											   cToken => AddXmlDocCommentToPatchMethod(document, context.Span, cToken),
+											   cToken => AddXmlDocCommentToPatchMethod(document, baseMethodDocCommentId, context.Span, cToken),
 											   equivalenceKey: nameof(Resources.PX1097Fix));
 			context.RegisterCodeFix(codeAction, diagnostic);
 			return Task.CompletedTask;
 		}
 
-		private static async Task<Document> AddXmlDocCommentToPatchMethod(Document document, TextSpan span, CancellationToken cancellation)
+		private static async Task<Document> AddXmlDocCommentToPatchMethod(Document document, string baseMethodDocCommentId, TextSpan span,
+																		  CancellationToken cancellation)
 		{
 			cancellation.ThrowIfCancellationRequested();
 
@@ -58,21 +64,24 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXOverride
 			if (patchMethodNode == null)
 				return document;
 
-			var newPatchMethodNode = AddXmlDocCommentToPatchMethod(patchMethodNode);
+			var newPatchMethodNode = AddXmlDocCommentToPatchMethod(patchMethodNode, baseMethodDocCommentId);
 
 			if (newPatchMethodNode == null || ReferenceEquals(patchMethodNode, newPatchMethodNode))
 				return document;
 
 			var newRoot = root!.ReplaceNode(patchMethodNode, newPatchMethodNode);
-			return document.WithSyntaxRoot(newRoot);
+			var modifiedDocument = document.WithSyntaxRoot(newRoot);
+			var simplifiedDocument = await Simplifier.ReduceAsync(modifiedDocument, cancellationToken: cancellation)
+													 .ConfigureAwait(false);
+			return simplifiedDocument;
 		}
 
-		private static MethodDeclarationSyntax? AddXmlDocCommentToPatchMethod(MethodDeclarationSyntax patchMethodNode)
+		private static MethodDeclarationSyntax? AddXmlDocCommentToPatchMethod(MethodDeclarationSyntax patchMethodNode, string baseMethodDocCommentId)
 		{
 			if (patchMethodNode.AttributeLists.Count > 0)
 			{
 				var firstAttributeList = patchMethodNode.AttributeLists[0];
-				var tokenWithTrivia = AddXmlDocCommentToToken(firstAttributeList.OpenBracketToken);
+				var tokenWithTrivia = AddXmlDocCommentToToken(firstAttributeList.OpenBracketToken, baseMethodDocCommentId);
 
 				if (tokenWithTrivia == null)
 					return null;
@@ -80,7 +89,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXOverride
 				var newAttributeLists =
 					patchMethodNode.AttributeLists.RemoveAt(0)
 												  .Insert(0, firstAttributeList.WithOpenBracketToken(tokenWithTrivia.Value));
-				var newPatchMethodNode = patchMethodNode.WithAttributeLists(newAttributeLists);
+				var newPatchMethodNode = patchMethodNode.WithAttributeLists(newAttributeLists).WithAdditionalAnnotations(Simplifier.Annotation);
 				return newPatchMethodNode;
 			}
 
@@ -89,18 +98,18 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXOverride
 			if (modifiers.Count > 0)
 			{
 				var firstModifier = modifiers[0];
-				var tokenWithTrivia = AddXmlDocCommentToToken(firstModifier);
+				var tokenWithTrivia = AddXmlDocCommentToToken(firstModifier, baseMethodDocCommentId);
 
 				if (tokenWithTrivia == null)
 					return null;
 
 				var newModifiers = modifiers.RemoveAt(0)
 											.Insert(0, tokenWithTrivia.Value);
-				var newPatchMethodNode = patchMethodNode.WithModifiers(newModifiers);
+				var newPatchMethodNode = patchMethodNode.WithModifiers(newModifiers).WithAdditionalAnnotations(Simplifier.Annotation);
 				return newPatchMethodNode;
 			}
 
-			var newReturnType = AddXmlDocCommentToReturnType(patchMethodNode.ReturnType, recursionDepth: 0);
+			var newReturnType = AddXmlDocCommentToReturnType(patchMethodNode.ReturnType, baseMethodDocCommentId, recursionDepth: 0);
 
 			if (newReturnType == null)
 				return null;
@@ -108,30 +117,30 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXOverride
 			return patchMethodNode.WithReturnType(newReturnType);
 		}
 
-		private static TypeSyntax? AddXmlDocCommentToReturnType(TypeSyntax returnType, int recursionDepth)
+		private static TypeSyntax? AddXmlDocCommentToReturnType(TypeSyntax returnType, string baseMethodDocCommentId, int recursionDepth)
 		{
 			const int recursionMaxDepth = 100;
 
 			if (recursionDepth > recursionMaxDepth)
-				return null; 
+				return null;
 
 			switch (returnType)
 			{
 				case PredefinedTypeSyntax predefinedType:
 					{
-						var tokenWithTrivia = AddXmlDocCommentToToken(predefinedType.Keyword);
+						var tokenWithTrivia = AddXmlDocCommentToToken(predefinedType.Keyword, baseMethodDocCommentId);
 						return tokenWithTrivia != null
-							? predefinedType.WithKeyword(tokenWithTrivia.Value)
+							? predefinedType.WithKeyword(tokenWithTrivia.Value).WithAdditionalAnnotations(Simplifier.Annotation)
 							: null;
 					}
 				case SimpleNameSyntax simpleOrGenericTypeName:
 					{
-						var newReturnType = AddXmlDocCommentToSimpleName(simpleOrGenericTypeName);
+						var newReturnType = AddXmlDocCommentToSimpleName(simpleOrGenericTypeName, baseMethodDocCommentId);
 						return newReturnType;
 					}
 				case QualifiedNameSyntax qualifiedTypeName:
 					{
-						var newReturnType = AddXmlDocCommentToQualifiedName(qualifiedTypeName);
+						var newReturnType = AddXmlDocCommentToQualifiedName(qualifiedTypeName, baseMethodDocCommentId);
 						return newReturnType;
 					}
 
@@ -143,30 +152,31 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXOverride
 					if (elementType == null)
 						return null;
 
-					var newElementType = AddXmlDocCommentToReturnType(elementType, recursionDepth: recursionDepth + 1);
+					var newElementType = AddXmlDocCommentToReturnType(elementType, baseMethodDocCommentId,
+																	  recursionDepth: recursionDepth + 1);
 					if (newElementType == null)
 						return null;
 
 					return WithElementType(returnType, elementType);
 				case TupleTypeSyntax tupleType:
 					{
-						var tokenWithTrivia = AddXmlDocCommentToToken(tupleType.OpenParenToken);
+						var tokenWithTrivia = AddXmlDocCommentToToken(tupleType.OpenParenToken, baseMethodDocCommentId);
 						return tokenWithTrivia != null
-							? tupleType.WithOpenParenToken(tokenWithTrivia.Value)
+							? tupleType.WithOpenParenToken(tokenWithTrivia.Value).WithAdditionalAnnotations(Simplifier.Annotation)
 							: null;
 					}
 				case RefTypeSyntax refType:
 					{
-						var tokenWithTrivia = AddXmlDocCommentToToken(refType.RefKeyword);
+						var tokenWithTrivia = AddXmlDocCommentToToken(refType.RefKeyword, baseMethodDocCommentId);
 						return tokenWithTrivia != null
-							? refType.WithRefKeyword(tokenWithTrivia.Value)
+							? refType.WithRefKeyword(tokenWithTrivia.Value).WithAdditionalAnnotations(Simplifier.Annotation)
 							: null;
 					}
 				case FunctionPointerTypeSyntax functionPointerType:
 					{
-						var tokenWithTrivia = AddXmlDocCommentToToken(functionPointerType.DelegateKeyword);
+						var tokenWithTrivia = AddXmlDocCommentToToken(functionPointerType.DelegateKeyword, baseMethodDocCommentId);
 						return tokenWithTrivia != null
-							? functionPointerType.WithDelegateKeyword(tokenWithTrivia.Value)
+							? functionPointerType.WithDelegateKeyword(tokenWithTrivia.Value).WithAdditionalAnnotations(Simplifier.Annotation)
 							: null;
 					}
 				default:
@@ -174,7 +184,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXOverride
 			}
 		}
 
-		private static QualifiedNameSyntax? AddXmlDocCommentToQualifiedName(QualifiedNameSyntax qualifiedTypeName)
+		private static QualifiedNameSyntax? AddXmlDocCommentToQualifiedName(QualifiedNameSyntax qualifiedTypeName, string baseMethodDocCommentId)
 		{
 			var prefixQualifiedNameSyntaxes = new Stack<QualifiedNameSyntax>(capacity: 4);
 			prefixQualifiedNameSyntaxes.Push(qualifiedTypeName);
@@ -193,14 +203,14 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXOverride
 
 					case SimpleNameSyntax identifierNameSyntax:
 						currentLeftPart = null;
-						newMostLeftPart = AddXmlDocCommentToSimpleName(identifierNameSyntax);
+						newMostLeftPart = AddXmlDocCommentToSimpleName(identifierNameSyntax, baseMethodDocCommentId);
 						continue;
 
 					case AliasQualifiedNameSyntax aliasQualifiedName:
 						currentLeftPart = null;
-						var newAliasNode = AddXmlDocCommentToSimpleName(aliasQualifiedName.Alias) as IdentifierNameSyntax;
+						var newAliasNode = AddXmlDocCommentToSimpleName(aliasQualifiedName.Alias, baseMethodDocCommentId) as IdentifierNameSyntax;
 						newMostLeftPart = newAliasNode != null
-							? aliasQualifiedName.WithAlias(newAliasNode)
+							? aliasQualifiedName.WithAlias(newAliasNode).WithAdditionalAnnotations(Simplifier.Annotation)
 							: null;
 						continue;
 
@@ -218,18 +228,18 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXOverride
 			while (prefixQualifiedNameSyntaxes.Count > 0)
 			{
 				var currentMostLeftOldNode = prefixQualifiedNameSyntaxes.Pop();
-				newReturnType = currentMostLeftOldNode.WithLeft(currentMostLeftNewQualifiedName);
+				newReturnType = currentMostLeftOldNode.WithLeft(currentMostLeftNewQualifiedName).WithAdditionalAnnotations(Simplifier.Annotation);
 				currentMostLeftNewQualifiedName = newReturnType;
 			}
 
 			return newReturnType;
 		}
 
-		private static SimpleNameSyntax? AddXmlDocCommentToSimpleName(SimpleNameSyntax simpleOrGenericTypeName)
+		private static SimpleNameSyntax? AddXmlDocCommentToSimpleName(SimpleNameSyntax simpleOrGenericTypeName, string baseMethodDocCommentId)
 		{
-			var tokenWithTrivia = AddXmlDocCommentToToken(simpleOrGenericTypeName.Identifier);
+			var tokenWithTrivia = AddXmlDocCommentToToken(simpleOrGenericTypeName.Identifier, baseMethodDocCommentId);
 			return tokenWithTrivia != null
-				? simpleOrGenericTypeName.WithIdentifier(tokenWithTrivia.Value)
+				? simpleOrGenericTypeName.WithIdentifier(tokenWithTrivia.Value).WithAdditionalAnnotations(Simplifier.Annotation)
 				: null;
 		}
 
@@ -255,9 +265,97 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXOverride
 			};
 		}
 
-		private static SyntaxToken? AddXmlDocCommentToToken(SyntaxToken tokenToAddTrivia)
+		///// Overrides <seealso cref="WorksheetPicking.IsWorksheetMode(string)"/>
+		//public bool IsWorksheetMode(string modeCode, Func<string, bool> base_IsWorksheetMode) => base_IsWorksheetMode(modeCode);
+
+		private static SyntaxToken? AddXmlDocCommentToToken(SyntaxToken tokenToAddTrivia, string baseMethodDocCommentId)
 		{
-			
+			////var n = SyntaxFactory.Comment(comment);
+			//var xmlTextNodeWithOverridesPrefix = XmlText(
+			//										XmlTextLiteral(XmlDocCommentOverridesPrefix));
+			//var seeAlsoElement = CreateSeeAlsoElementWithReferenceToBaseMethod(patchMethodNode, );
+			//var xmlTextSuffixWithNewLine = XmlText(
+			//									XmlTextNewLine(Environment.NewLine, continueXmlDocumentationComment: false));
+			//XmlNodeSyntax[] xmlDocComments =
+			//[
+			//	xmlTextNodeWithOverridesPrefix,
+			//	seeAlsoElement,
+			//	xmlTextSuffixWithNewLine
+			//];
+
+			//var documentationTrivia =
+			//	DocumentationCommentTrivia(
+			//		SyntaxKind.SingleLineDocumentationCommentTrivia,
+			//		List(xmlDocComments))
+			//	.WithEndOfComment(
+			//		Token(SyntaxKind.EndOfDocumentationCommentToken));
+
+			string comment = $"/// {XmlDocCommentOverridesPrefix} <seealso cref=\"{baseMethodDocCommentId}\"/>";
+			SyntaxTrivia commentTrivia = Comment(comment).WithAdditionalAnnotations(Simplifier.Annotation);
+
+			var whiteSpaceIndentationTrivia = tokenToAddTrivia.LeadingTrivia.Reverse()
+																			.TakeWhile(t => !t.IsKind(SyntaxKind.EndOfLineTrivia))
+																			.Where(t => t.IsKind(SyntaxKind.WhitespaceTrivia));
+			var newTrivia = TriviaList(EndOfLine(Environment.NewLine))
+								.AddRange(whiteSpaceIndentationTrivia)
+								.Add(commentTrivia)
+								.AddRange(tokenToAddTrivia.LeadingTrivia);
+			var newToken = tokenToAddTrivia.WithLeadingTrivia(newTrivia)
+										   .WithAdditionalAnnotations(Simplifier.Annotation);
+			return newToken;
 		}
+
+		//private static XmlEmptyElementSyntax? CreateSeeAlsoElementWithReferenceToBaseMethod(MethodDeclarationSyntax patchMethodNode)
+		//{
+			
+
+
+
+		//	XmlCrefAttribute(
+		//		QualifiedCref(
+		//			IdentifierName("WorksheetPicking"),
+		//			NameMemberCref(
+		//				IdentifierName("IsWorksheetMode"))
+		//			.WithParameters(
+		//				CrefParameterList(
+		//					SingletonSeparatedList(
+		//						CrefParameter(
+		//							PredefinedType(
+		//								Token(SyntaxKind.StringKeyword)))))
+		//				.WithOpenParenToken(
+		//					Token(SyntaxKind.OpenParenToken))
+		//				.WithCloseParenToken(
+		//					Token(SyntaxKind.CloseParenToken))))
+		//		.WithDotToken(
+		//			Token(SyntaxKind.DotToken)))
+		//	.WithName(
+		//		XmlName(
+		//			Identifier(
+		//				TriviaList(
+		//					Space),
+		//				"cref",
+		//				TriviaList())))
+		//	.WithEqualsToken(
+		//		Token(SyntaxKind.EqualsToken))
+		//	.WithStartQuoteToken(
+		//		Token(SyntaxKind.DoubleQuoteToken))
+		//	.WithEndQuoteToken(
+		//		Token(SyntaxKind.DoubleQuoteToken))
+
+
+		//	var seeAlsoElement = XmlSeeAlsoElement(cRefAttribute); XmlEmptyElement(
+		//		   XmlName(
+		//			   Identifier("seealso")))
+		//	   .WithLessThanToken(
+		//		   Token(SyntaxKind.LessThanToken))
+		//	   .WithAttributes(
+		//		   SingletonList<XmlAttributeSyntax>(
+
+		//			   ))
+		//	   .WithSlashGreaterThanToken(
+		//		   Token(SyntaxKind.SlashGreaterThanToken));
+
+		//	return seeAlsoElement;
+		//}
 	}
 }

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXOverride/AddXmlDocCommentWithReferenceToBaseMethodFix.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXOverride/AddXmlDocCommentWithReferenceToBaseMethodFix.cs
@@ -33,6 +33,12 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXOverride
 		{
 			context.CancellationToken.ThrowIfCancellationRequested();
 
+			if (!diagnostic.TryGetPropertyValue(PXOverrideDiagnosticProperties.BaseMethodContainingTypeClrName, out var baseMethodContainingTypeClrName) ||
+				baseMethodContainingTypeClrName.IsNullOrWhiteSpace())
+			{
+				return Task.CompletedTask;
+			}
+
 			string title = nameof(Resources.PX1098Fix).GetLocalized().ToString();
 			var document = context.Document;
 			var codeAction = CodeAction.Create(title,

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXOverride/AddXmlDocCommentWithReferenceToBaseMethodFix.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXOverride/AddXmlDocCommentWithReferenceToBaseMethodFix.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
 using System.Linq;
@@ -169,9 +170,53 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXOverride
 
 		private static QualifiedNameSyntax? AddXmlDocCommentToQualifiedName(QualifiedNameSyntax qualifiedTypeName)
 		{
-			 
+			var prefixQualifiedNameSyntaxes = new Stack<QualifiedNameSyntax>(capacity: 4);
+			prefixQualifiedNameSyntaxes.Push(qualifiedTypeName);
 
-		
+			NameSyntax? currentLeftPart = qualifiedTypeName.Left;
+			NameSyntax? newMostLeftPart = null;
+
+			while (currentLeftPart != null)
+			{
+				switch (currentLeftPart)
+				{
+					case QualifiedNameSyntax qualifiedNameLeftPart:
+						prefixQualifiedNameSyntaxes.Push(qualifiedNameLeftPart);
+						currentLeftPart = qualifiedNameLeftPart.Left;
+						continue;
+
+					case SimpleNameSyntax identifierNameSyntax:
+						currentLeftPart = null;
+						newMostLeftPart = AddXmlDocCommentToSimpleName(identifierNameSyntax);
+						continue;
+
+					case AliasQualifiedNameSyntax aliasQualifiedName:
+						currentLeftPart = null;
+						var newAliasNode = AddXmlDocCommentToSimpleName(aliasQualifiedName.Alias) as IdentifierNameSyntax;
+						newMostLeftPart = newAliasNode != null
+							? aliasQualifiedName.WithAlias(newAliasNode)
+							: null;
+						continue;
+
+					default:
+						break;
+				}
+			}
+
+			if (newMostLeftPart == null)
+				return null;
+
+			NameSyntax currentMostLeftNewQualifiedName = newMostLeftPart;
+			QualifiedNameSyntax? newReturnType = null;
+
+			while (prefixQualifiedNameSyntaxes.Count > 0)
+			{
+				var currentMostLeftOldNode = prefixQualifiedNameSyntaxes.Pop();
+				newReturnType = currentMostLeftOldNode.WithLeft(currentMostLeftNewQualifiedName);
+				currentMostLeftNewQualifiedName = newReturnType;
+			}
+
+			return newReturnType;
 		}
 
 		private static SimpleNameSyntax? AddXmlDocCommentToSimpleName(SimpleNameSyntax simpleOrGenericTypeName)

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXOverride/AddXmlDocCommentWithReferenceToBaseMethodFix.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXOverride/AddXmlDocCommentWithReferenceToBaseMethodFix.cs
@@ -265,97 +265,41 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXOverride
 			};
 		}
 
-		///// Overrides <seealso cref="WorksheetPicking.IsWorksheetMode(string)"/>
-		//public bool IsWorksheetMode(string modeCode, Func<string, bool> base_IsWorksheetMode) => base_IsWorksheetMode(modeCode);
-
 		private static SyntaxToken? AddXmlDocCommentToToken(SyntaxToken tokenToAddTrivia, string baseMethodDocCommentId)
 		{
-			////var n = SyntaxFactory.Comment(comment);
-			//var xmlTextNodeWithOverridesPrefix = XmlText(
-			//										XmlTextLiteral(XmlDocCommentOverridesPrefix));
-			//var seeAlsoElement = CreateSeeAlsoElementWithReferenceToBaseMethod(patchMethodNode, );
-			//var xmlTextSuffixWithNewLine = XmlText(
-			//									XmlTextNewLine(Environment.NewLine, continueXmlDocumentationComment: false));
-			//XmlNodeSyntax[] xmlDocComments =
-			//[
-			//	xmlTextNodeWithOverridesPrefix,
-			//	seeAlsoElement,
-			//	xmlTextSuffixWithNewLine
-			//];
-
-			//var documentationTrivia =
-			//	DocumentationCommentTrivia(
-			//		SyntaxKind.SingleLineDocumentationCommentTrivia,
-			//		List(xmlDocComments))
-			//	.WithEndOfComment(
-			//		Token(SyntaxKind.EndOfDocumentationCommentToken));
-
 			string comment = $"/// {XmlDocCommentOverridesPrefix} <seealso cref=\"{baseMethodDocCommentId}\"/>";
-			SyntaxTrivia commentTrivia = Comment(comment).WithAdditionalAnnotations(Simplifier.Annotation);
+			var triviaList = ParseLeadingTrivia(comment);
+			var commentTrivia = triviaList.FirstOrDefault(triviaList => triviaList.IsKind(SyntaxKind.SingleLineDocumentationCommentTrivia));
 
-			var whiteSpaceIndentationTrivia = tokenToAddTrivia.LeadingTrivia.Reverse()
-																			.TakeWhile(t => !t.IsKind(SyntaxKind.EndOfLineTrivia))
-																			.Where(t => t.IsKind(SyntaxKind.WhitespaceTrivia));
-			var newTrivia = TriviaList(EndOfLine(Environment.NewLine))
-								.AddRange(whiteSpaceIndentationTrivia)
-								.Add(commentTrivia)
-								.AddRange(tokenToAddTrivia.LeadingTrivia);
-			var newToken = tokenToAddTrivia.WithLeadingTrivia(newTrivia)
+			if (commentTrivia == default)
+				return null;
+
+			if (commentTrivia.HasStructure && commentTrivia.GetStructure() is DocumentationCommentTriviaSyntax xmlDocCommentNode)
+			{
+				var crefNode = xmlDocCommentNode.DescendantNodes()
+												.OfType<CrefSyntax>()
+												.FirstOrDefault();
+				if (crefNode != null)
+				{
+					crefNode = crefNode.WithAdditionalAnnotations(Simplifier.Annotation);
+					xmlDocCommentNode = xmlDocCommentNode.ReplaceNode(crefNode, crefNode);
+				}
+
+				xmlDocCommentNode = xmlDocCommentNode.WithAdditionalAnnotations(Simplifier.Annotation);
+				commentTrivia = Trivia(xmlDocCommentNode).WithAdditionalAnnotations(Simplifier.Annotation);
+			}
+
+			var oldLeadingTrivia = tokenToAddTrivia.LeadingTrivia;var x = oldLeadingTrivia.Reverse();
+			var whiteSpaceIndentationTrivia = oldLeadingTrivia.Reverse()
+															  .TakeWhile((in SyntaxTrivia t) => !t.IsKind(SyntaxKind.EndOfLineTrivia))
+															  .Where(t => t.IsKind(SyntaxKind.WhitespaceTrivia));
+			var newTrivias = whiteSpaceIndentationTrivia.PrependItem(EndOfLine(Environment.NewLine))
+														.AppendItem(commentTrivia)
+														.Concat(oldLeadingTrivia);
+			var newLeadingTrivia = TriviaList(newTrivias);
+			var newToken = tokenToAddTrivia.WithLeadingTrivia(newLeadingTrivia)
 										   .WithAdditionalAnnotations(Simplifier.Annotation);
 			return newToken;
 		}
-
-		//private static XmlEmptyElementSyntax? CreateSeeAlsoElementWithReferenceToBaseMethod(MethodDeclarationSyntax patchMethodNode)
-		//{
-			
-
-
-
-		//	XmlCrefAttribute(
-		//		QualifiedCref(
-		//			IdentifierName("WorksheetPicking"),
-		//			NameMemberCref(
-		//				IdentifierName("IsWorksheetMode"))
-		//			.WithParameters(
-		//				CrefParameterList(
-		//					SingletonSeparatedList(
-		//						CrefParameter(
-		//							PredefinedType(
-		//								Token(SyntaxKind.StringKeyword)))))
-		//				.WithOpenParenToken(
-		//					Token(SyntaxKind.OpenParenToken))
-		//				.WithCloseParenToken(
-		//					Token(SyntaxKind.CloseParenToken))))
-		//		.WithDotToken(
-		//			Token(SyntaxKind.DotToken)))
-		//	.WithName(
-		//		XmlName(
-		//			Identifier(
-		//				TriviaList(
-		//					Space),
-		//				"cref",
-		//				TriviaList())))
-		//	.WithEqualsToken(
-		//		Token(SyntaxKind.EqualsToken))
-		//	.WithStartQuoteToken(
-		//		Token(SyntaxKind.DoubleQuoteToken))
-		//	.WithEndQuoteToken(
-		//		Token(SyntaxKind.DoubleQuoteToken))
-
-
-		//	var seeAlsoElement = XmlSeeAlsoElement(cRefAttribute); XmlEmptyElement(
-		//		   XmlName(
-		//			   Identifier("seealso")))
-		//	   .WithLessThanToken(
-		//		   Token(SyntaxKind.LessThanToken))
-		//	   .WithAttributes(
-		//		   SingletonList<XmlAttributeSyntax>(
-
-		//			   ))
-		//	   .WithSlashGreaterThanToken(
-		//		   Token(SyntaxKind.SlashGreaterThanToken));
-
-		//	return seeAlsoElement;
-		//}
 	}
 }

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXOverride/Helpers/BaseMethodReferenceInXmlDocComment.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXOverride/Helpers/BaseMethodReferenceInXmlDocComment.cs
@@ -1,0 +1,131 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+
+using Acuminator.Utilities.Common;
+using Acuminator.Utilities.Roslyn.Semantic;
+using Acuminator.Utilities.Roslyn.Syntax;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Acuminator.Analyzers.StaticAnalysis.PXOverride
+{
+	internal static class BaseMethodReferenceInXmlDocComment
+	{
+		public static bool HasCorrectReference(SemanticModel semanticModel, MethodDeclarationSyntax patchMethodNode, 
+												IMethodSymbol baseMethod, CancellationToken cancellation)
+		{
+			SyntaxTriviaList leadingTrivia = patchMethodNode.GetLeadingTrivia();
+
+			if (leadingTrivia.Count == 0)
+				return false;
+
+			for (int i = 0; i < leadingTrivia.Count; i++)
+			{
+				var trivia = leadingTrivia[i];
+
+				if (!trivia.IsKind(SyntaxKind.SingleLineDocumentationCommentTrivia) ||
+					trivia.GetStructure() is not DocumentationCommentTriviaSyntax xmlDocCommentNode ||
+					xmlDocCommentNode.Content.Count == 0)
+				{
+					continue;
+				}
+
+				if (HasCorrectXmlDocCommentWithReferenceToBaseMethod(semanticModel, xmlDocCommentNode, baseMethod, cancellation))
+					return true;
+			}
+
+			return false;
+		}
+
+		private static bool HasCorrectXmlDocCommentWithReferenceToBaseMethod(SemanticModel semanticModel, DocumentationCommentTriviaSyntax xmlDocCommentNode, 
+																			 IMethodSymbol baseMethod, CancellationToken cancellation)
+		{
+			for (int i = 0; i < xmlDocCommentNode.Content.Count; i++)
+			{
+				var xmlNode = xmlDocCommentNode.Content[i];
+
+				if (!IsSeeAlsoWithCrefAttributeToBaseMethod(semanticModel, xmlNode, baseMethod, cancellation))
+					continue;
+
+				// The <seealso cref="BaseMethod"/> element is found. Now we need to check the "Overrides" prefix
+				var previousText = i > 0
+					? xmlDocCommentNode.Content[i - 1] as XmlTextSyntax
+					: null;
+
+				if (previousText == null)
+					continue;
+
+				if (HasOverridesPrefix(previousText))
+					return true;
+			}
+
+			return false;
+		} 
+
+		private static bool IsSeeAlsoWithCrefAttributeToBaseMethod(SemanticModel semanticModel, XmlNodeSyntax xmlNode, IMethodSymbol baseMethod, 
+																	CancellationToken cancellation)
+		{
+			const string seeAlsoName = "seealso";
+			string? elementName = xmlNode.GetDocTagName().NullIfWhiteSpace();
+
+			if (seeAlsoName != elementName)
+				return false;
+
+			SyntaxList<XmlAttributeSyntax>? attributes = xmlNode switch
+			{
+				XmlEmptyElementSyntax xmlEmptyElement => xmlEmptyElement.Attributes,
+				XmlElementSyntax xmlElement 		  => xmlElement.StartTag?.Attributes,
+				_ 									  => null
+			};
+
+			if (attributes?.Count is null or 0)
+				return false;
+
+			for (int i = 0; i < attributes.Value.Count; i++)
+			{
+				if (attributes.Value[i] is not XmlCrefAttributeSyntax crefAttribute)
+					continue;
+
+				var referencedSymbol = semanticModel.GetSymbolOrFirstCandidate(crefAttribute.Cref, cancellation);
+
+				if (referencedSymbol is not IMethodSymbol referencedMethod)
+					continue;
+
+				if (SymbolEqualityComparer.Default.Equals(referencedMethod, baseMethod) ||
+					SymbolEqualityComparer.Default.Equals(referencedMethod.OriginalDefinition, baseMethod.OriginalDefinition))
+				{
+					return true;
+				}
+			}
+
+			return false;
+		}
+
+		private static bool HasOverridesPrefix(XmlTextSyntax previousText)
+		{
+			const string overridesPrefix = "Overrides";
+
+			if (previousText.TextTokens.Count == 0)
+				return false;
+
+			for (int i = 0; i < previousText.TextTokens.Count; i++)
+			{
+				var token = previousText.TextTokens[i];
+				
+				if (token.IsKind(SyntaxKind.XmlTextLiteralToken))
+				{
+					string text = token.Text.Trim();
+
+					if (text.Equals(overridesPrefix, StringComparison.OrdinalIgnoreCase))
+						return true;
+				}
+			}
+
+			return false;
+		}
+	}
+}

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXOverride/Model/PXOverrideDiagnosticProperties.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXOverride/Model/PXOverrideDiagnosticProperties.cs
@@ -23,8 +23,8 @@
 		public const string DelegateParameterFixMode = nameof(DelegateParameterFixMode);
 
 		/// <summary>
-		/// Property stores the name of the type containing the base method in a CLR format.
+		/// Property stores the XML documentation comment ID name of the base method.
 		/// </summary>
-		public const string BaseMethodContainingTypeClrName = nameof(BaseMethodContainingTypeClrName);
+		public const string BaseMethodDocCommentId = nameof(BaseMethodDocCommentId);
 	}
 }

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXOverride/Model/PXOverrideDiagnosticProperties.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXOverride/Model/PXOverrideDiagnosticProperties.cs
@@ -21,5 +21,10 @@
 		/// Property stores the <see cref="BaseDelegateParameterFixMode"/> value for a patch method.
 		/// </summary>
 		public const string DelegateParameterFixMode = nameof(DelegateParameterFixMode);
+
+		/// <summary>
+		/// Property stores the name of the type containing the base method in a CLR format.
+		/// </summary>
+		public const string BaseMethodContainingTypeClrName = nameof(BaseMethodContainingTypeClrName);
 	}
 }

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXOverride/PXOverrideAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXOverride/PXOverrideAnalyzer.cs
@@ -218,7 +218,14 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXOverride
 
 			var location = patchMethodNode.Identifier.GetLocation().NullIfLocationKindIsNone() ??
 						   pxOverrideInfo.Symbol.Locations.FirstOrDefault();
-			var diagnostic = Diagnostic.Create(Descriptors.PX1098_PXOverrideMethodWithoutXmlDocComment, location);
+			var baseMethodContaiingTypeClrName = pxOverrideInfo.BaseMethod.ContainingType.GetCLRTypeNameFromType();
+
+			var diagnosticProperties = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase)
+			{
+				{ PXOverrideDiagnosticProperties.BaseMethodContainingTypeClrName, pxOverrideInfo.Symbol.Name }
+			}
+			.ToImmutableDictionary();
+			var diagnostic = Diagnostic.Create(Descriptors.PX1098_PXOverrideMethodWithoutXmlDocComment, location, diagnosticProperties);
 
 			context.ReportDiagnosticWithSuppressionCheck(diagnostic, pxContext.CodeAnalysisSettings);
 		}

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXOverride/PXOverrideAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXOverride/PXOverrideAnalyzer.cs
@@ -12,6 +12,7 @@ using Acuminator.Utilities.Roslyn.Semantic.PXGraph;
 using Acuminator.Utilities.Roslyn.Syntax;
 
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
@@ -25,6 +26,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXOverride
 				Descriptors.PX1079_PXOverrideWithoutDelegateParameter,
 				Descriptors.PX1096_PXOverrideMustMatchSignature,
 				Descriptors.PX1097_PXOverrideMethodMustBePublicNonVirtual,
+				Descriptors.PX1098_PXOverrideMethodWithoutXmlDocComment,
 				Descriptors.PX1101_PXOverrideWithInvalidDelegateParameter,
 				Descriptors.PX1102_PXOverrideInvalidNameOfDelegateParameter
 			);
@@ -60,10 +62,16 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXOverride
 			context.CancellationToken.ThrowIfCancellationRequested();
 
 			if (pxOverrideInfo.BaseMethod == null)
+			{
 				ReportPatchMethodWithIncompatibleSignature(context, pxContext, pxOverrideInfo.Symbol);
+			}
+			else
+			{
+				CheckPatchMethodForXmlDocComment(context, pxContext, pxOverrideInfo);
+			}
 		}
 
-		protected virtual void CheckPatchMethodIsPublicNonVirtual(SymbolAnalysisContext context, PXContext pxContext, 
+		protected virtual void CheckPatchMethodIsPublicNonVirtual(SymbolAnalysisContext context, PXContext pxContext,
 																  IMethodSymbol patchMethodWithPXOverride)
 		{
 			bool isNonPublic = patchMethodWithPXOverride.DeclaredAccessibility != Accessibility.Public;
@@ -76,7 +84,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXOverride
 				{
 					{ PXOverrideDiagnosticProperties.IsNonPublicPatchMethod,    isNonPublic.ToString() },
 					{ PXOverrideDiagnosticProperties.PatchMethodVirtualityKind, virtualityKind.ToString() },
-					{ PXOverrideDiagnosticProperties.PatchMethodName,			patchMethodWithPXOverride.Name }
+					{ PXOverrideDiagnosticProperties.PatchMethodName,           patchMethodWithPXOverride.Name }
 				}
 				.ToImmutableDictionary();
 
@@ -92,8 +100,8 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXOverride
 			else if (patchMethodWithPXOverride.IsAbstract)
 				return MemberVirtualityKind.Abstract;
 			else if (patchMethodWithPXOverride.IsOverride)
-				return patchMethodWithPXOverride.IsSealed 
-					? MemberVirtualityKind.SealedOverride 
+				return patchMethodWithPXOverride.IsSealed
+					? MemberVirtualityKind.SealedOverride
 					: MemberVirtualityKind.Override;
 			else
 				return MemberVirtualityKind.None;
@@ -122,8 +130,8 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXOverride
 				case PXOverrideType.WithValidBaseDelegate
 				when !IsCorrectDelegateParameterName(pxOverrideInfo.Symbol):
 					descriptor = Descriptors.PX1102_PXOverrideInvalidNameOfDelegateParameter;
-					location   = GetLocationForDelegateParameterWithIncorrectName(pxOverrideInfo.Symbol, context.CancellationToken);
-					fixMode    = BaseDelegateParameterFixMode.RenameDelegateParameter;
+					location = GetLocationForDelegateParameterWithIncorrectName(pxOverrideInfo.Symbol, context.CancellationToken);
+					fixMode = BaseDelegateParameterFixMode.RenameDelegateParameter;
 					break;
 
 				default:
@@ -137,7 +145,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXOverride
 			}
 			.ToImmutableDictionary();
 
-			 
+
 			var diagnostic = Diagnostic.Create(descriptor, location, diagnosticProperties);
 
 			context.ReportDiagnosticWithSuppressionCheck(diagnostic, pxContext.CodeAnalysisSettings);
@@ -186,6 +194,31 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXOverride
 		{
 			var location = patchMethodWithPXOverride.Locations.FirstOrDefault();
 			var diagnostic = Diagnostic.Create(Descriptors.PX1096_PXOverrideMustMatchSignature, location);
+
+			context.ReportDiagnosticWithSuppressionCheck(diagnostic, pxContext.CodeAnalysisSettings);
+		}
+
+		protected virtual void CheckPatchMethodForXmlDocComment(SymbolAnalysisContext context, PXContext pxContext, PXOverrideInfo pxOverrideInfo)
+		{
+			if (pxOverrideInfo.BaseMethod == null || pxOverrideInfo.OverrideType is (PXOverrideType.WithoutBaseDelegate or PXOverrideType.None))
+				return;
+
+			context.CancellationToken.ThrowIfCancellationRequested();
+
+			if (pxOverrideInfo.BaseMethod.GetSyntax(context.CancellationToken) is not MethodDeclarationSyntax patchMethodNode)
+				return;
+
+			var semanticModel = context.Compilation.GetSemanticModel(patchMethodNode.SyntaxTree);
+
+			if (semanticModel == null || 
+				BaseMethodReferenceInXmlDocComment.HasCorrectReference(semanticModel, patchMethodNode, pxOverrideInfo.BaseMethod, context.CancellationToken))
+			{
+				return;
+			}
+
+			var location = patchMethodNode.Identifier.GetLocation().NullIfLocationKindIsNone() ??
+						   pxOverrideInfo.Symbol.Locations.FirstOrDefault();
+			var diagnostic = Diagnostic.Create(Descriptors.PX1098_PXOverrideMethodWithoutXmlDocComment, location);
 
 			context.ReportDiagnosticWithSuppressionCheck(diagnostic, pxContext.CodeAnalysisSettings);
 		}

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXOverride/PXOverrideAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXOverride/PXOverrideAnalyzer.cs
@@ -205,7 +205,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXOverride
 
 			context.CancellationToken.ThrowIfCancellationRequested();
 
-			if (pxOverrideInfo.BaseMethod.GetSyntax(context.CancellationToken) is not MethodDeclarationSyntax patchMethodNode)
+			if (pxOverrideInfo.Symbol.GetSyntax(context.CancellationToken) is not MethodDeclarationSyntax patchMethodNode)
 				return;
 
 			var semanticModel = context.Compilation.GetSemanticModel(patchMethodNode.SyntaxTree);
@@ -216,21 +216,30 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXOverride
 				return;
 			}
 
-			var location = pxOverrideInfo.Symbol.Locations.FirstOrDefault();
-			
-			var baseMethodDocCommentID = pxOverrideInfo.BaseMethod.GetDocumentationCommentId().NullIfWhiteSpace();
-			baseMethodDocCommentID = baseMethodDocCommentID?.Length > 2
-				? baseMethodDocCommentID.Substring(2) 
-				: null;
-
+			var location = patchMethodNode.Identifier.GetLocation().NullIfLocationKindIsNone() ?? 
+						   pxOverrideInfo.Symbol.Locations.FirstOrDefault();
+			var baseMethodDocCommentID = GetPreparedReferenceToMethodText(pxOverrideInfo.BaseMethod);
 			var diagnosticProperties = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase)
 			{
 				{ PXOverrideDiagnosticProperties.BaseMethodDocCommentId, baseMethodDocCommentID }
 			}
 			.ToImmutableDictionary();
+
 			var diagnostic = Diagnostic.Create(Descriptors.PX1098_PXOverrideMethodWithoutXmlDocComment, location, diagnosticProperties);
 
 			context.ReportDiagnosticWithSuppressionCheck(diagnostic, pxContext.CodeAnalysisSettings);
+		}
+
+		private static string? GetPreparedReferenceToMethodText(IMethodSymbol method)
+		{
+			string? methodDocCommentID = method.GetDocumentationCommentId().NullIfWhiteSpace();
+			methodDocCommentID = methodDocCommentID?.Length > 2
+				? methodDocCommentID.Substring(2)						 // Remove "M:" prefix
+				: null;
+
+			return methodDocCommentID != null
+				? methodDocCommentID.Replace(",", ", ")		// make parameters list more readable and look like the one VS inserts
+				: null;
 		}
 	}
 }

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXOverride/PXOverrideAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXOverride/PXOverrideAnalyzer.cs
@@ -216,13 +216,16 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXOverride
 				return;
 			}
 
-			var location = patchMethodNode.Identifier.GetLocation().NullIfLocationKindIsNone() ??
-						   pxOverrideInfo.Symbol.Locations.FirstOrDefault();
-			var baseMethodContaiingTypeClrName = pxOverrideInfo.BaseMethod.ContainingType.GetCLRTypeNameFromType();
+			var location = pxOverrideInfo.Symbol.Locations.FirstOrDefault();
+			
+			var baseMethodDocCommentID = pxOverrideInfo.BaseMethod.GetDocumentationCommentId().NullIfWhiteSpace();
+			baseMethodDocCommentID = baseMethodDocCommentID?.Length > 2
+				? baseMethodDocCommentID.Substring(2) 
+				: null;
 
 			var diagnosticProperties = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase)
 			{
-				{ PXOverrideDiagnosticProperties.BaseMethodContainingTypeClrName, pxOverrideInfo.Symbol.Name }
+				{ PXOverrideDiagnosticProperties.BaseMethodDocCommentId, baseMethodDocCommentID }
 			}
 			.ToImmutableDictionary();
 			var diagnostic = Diagnostic.Create(Descriptors.PX1098_PXOverrideMethodWithoutXmlDocComment, location, diagnosticProperties);

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PublicClassXmlComment/Parser/Model/XmlCommentTagsInfo.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PublicClassXmlComment/Parser/Model/XmlCommentTagsInfo.cs
@@ -39,22 +39,21 @@ namespace Acuminator.Analyzers.StaticAnalysis.PublicClassXmlComment
 		public IEnumerable<XmlNodeSyntax> GetTagNodes(bool includeSummaryTag, bool includeInheritdocTag, bool includeExcludeTag)
 		{
 			if (NoXmlComments || (!includeSummaryTag && !includeInheritdocTag && !includeExcludeTag))
-				return Enumerable.Empty<XmlNodeSyntax>();
+				return [];
 
-			return GetTagNodesImplementation(includeSummaryTag, includeInheritdocTag, includeExcludeTag);
-		}
-
-		private IEnumerable<XmlNodeSyntax> GetTagNodesImplementation(bool includeSummaryTag, bool includeInheritdocTag, bool includeExcludeTag)
-		{
-			var tags = HasSummaryTag && includeSummaryTag
+			IEnumerable<XmlNodeSyntax> tags = HasSummaryTag && includeSummaryTag
 				? SummaryTags
-				: Enumerable.Empty<XmlNodeSyntax>();
+				: [];
 
 			if (HasInheritdocTag && includeInheritdocTag)
-				tags.Concat(InheritdocTagInfos.Select(info => info.Tag));
+			{
+				var inheritdocTags = InheritdocTagInfos.Where(info => info.HasInheritdocTag)
+													   .Select(info => info.Tag!);
+				tags = tags.Concat(inheritdocTags);
+			}
 
 			if (HasExcludeTag && includeExcludeTag)
-				tags.Concat(ExcludeTags);
+				tags = tags.Concat(ExcludeTags);
 
 			return tags;
 		}

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PublicClassXmlComment/Parser/XmlCommentsParser.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PublicClassXmlComment/Parser/XmlCommentsParser.cs
@@ -116,7 +116,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.PublicClassXmlComment
 
 		private IEnumerable<DocumentationCommentTriviaSyntax> GetXmlComments(MemberDeclarationSyntax member) =>
 			member.GetLeadingTrivia()
-				  .Select(t => t.GetStructure())
+				  .Select((in SyntaxTrivia t) => t.GetStructure())
 				  .OfType<DocumentationCommentTriviaSyntax>();
 
 		private XmlCommentTagsInfo GetDocumentationTags(DocumentationCommentTriviaSyntax xmlComment)

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/StaticFieldOrPropertyInGraph/StaticFieldOrPropertyInGraphAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/StaticFieldOrPropertyInGraph/StaticFieldOrPropertyInGraphAnalyzer.cs
@@ -71,7 +71,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.StaticFieldOrPropertyInGraph
 			var fieldOrPropertyNode = staticFieldOrProperty.GetSyntax(cancellation);
 			var fieldOrPropertyDeclaration = fieldOrPropertyNode?.ParentOrSelf<MemberDeclarationSyntax>();
 			var staticModifier = fieldOrPropertyDeclaration?.GetModifiers()
-															.FirstOrDefault(modifier => modifier.IsKind(SyntaxKind.StaticKeyword));
+															.FirstOrDefault((in SyntaxToken modifier) => modifier.IsKind(SyntaxKind.StaticKeyword));
 
 			if (staticModifier != null && staticModifier != default(SyntaxToken))
 				return staticModifier.Value.GetLocation().NullIfLocationKindIsNone();

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/ThrowingExceptions/ThrowingExceptionsInDataViewDelegateAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/ThrowingExceptions/ThrowingExceptionsInDataViewDelegateAnalyzer.cs
@@ -1,5 +1,4 @@
-﻿
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
@@ -15,93 +14,93 @@ using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Acuminator.Analyzers.StaticAnalysis.ThrowingExceptions
 {
-    public class ThrowingExceptionsInLongRunningOperationAnalyzer : PXGraphAggregatedAnalyzerBase
-    {
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
-            ImmutableArray.Create(Descriptors.PX1086_ThrowingSetupNotEnteredExceptionInLongRunningOperation);
+	public class ThrowingExceptionsInLongRunningOperationAnalyzer : PXGraphAggregatedAnalyzerBase
+	{
+		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+			ImmutableArray.Create(Descriptors.PX1086_ThrowingSetupNotEnteredExceptionInLongRunningOperation);
 
 		public override void Analyze(SymbolAnalysisContext context, PXContext pxContext, PXGraphEventSemanticModel pxGraph)
-        {
-            context.CancellationToken.ThrowIfCancellationRequested();
+		{
+			context.CancellationToken.ThrowIfCancellationRequested();
 
-            var walker = new WalkerForGraphAnalyzer(context, pxContext, Descriptors.PX1086_ThrowingSetupNotEnteredExceptionInLongRunningOperation);
+			var walker = new WalkerForGraphAnalyzer(context, pxContext, Descriptors.PX1086_ThrowingSetupNotEnteredExceptionInLongRunningOperation);
 
-            CheckProcessingDelegates(pxGraph, walker, context.CancellationToken);
-            CheckLongOperationStartDelegates(pxGraph.Symbol, walker, pxContext, context.CancellationToken);
-        }
+			CheckProcessingDelegates(pxGraph, walker, context.CancellationToken);
+			CheckLongOperationStartDelegates(pxGraph.Symbol, walker, pxContext, context.CancellationToken);
+		}
 
-        private void CheckProcessingDelegates(PXGraphEventSemanticModel pxGraph, WalkerForGraphAnalyzer walker, CancellationToken cancellation)
-        {
-            cancellation.ThrowIfCancellationRequested();
+		private void CheckProcessingDelegates(PXGraphEventSemanticModel pxGraph, WalkerForGraphAnalyzer walker, CancellationToken cancellation)
+		{
+			cancellation.ThrowIfCancellationRequested();
 
-            if (!pxGraph.IsProcessing)
-            {
-                return;
-            }
+			if (!pxGraph.IsProcessing)
+			{
+				return;
+			}
 
-            var processingViews = pxGraph.Views.Where(v => v.IsProcessing);
+			var processingViews = pxGraph.Views.Where(v => v.IsProcessing);
 
-            foreach (var viewDel in processingViews)
-            {
-                var finallyDelegates = viewDel.FinallyProcessDelegates.Where(d => d.Node != null);
+			foreach (var viewDel in processingViews)
+			{
+				var finallyDelegates = viewDel.FinallyProcessDelegates.Where(d => d.Node != null);
 
-                foreach (var finDel in finallyDelegates)
-                {
-                    cancellation.ThrowIfCancellationRequested();
-                    walker.Visit(finDel.Node);
-                }
+				foreach (var finDel in finallyDelegates)
+				{
+					cancellation.ThrowIfCancellationRequested();
+					walker.Visit(finDel.Node);
+				}
 
-                var parametersDelegates = viewDel.ParametersDelegates.Where(d => d.Node != null);
+				var parametersDelegates = viewDel.ParametersDelegates.Where(d => d.Node != null);
 
-                foreach (var parDel in parametersDelegates)
-                {
-                    cancellation.ThrowIfCancellationRequested();
-                    walker.Visit(parDel.Node);
-                }
+				foreach (var parDel in parametersDelegates)
+				{
+					cancellation.ThrowIfCancellationRequested();
+					walker.Visit(parDel.Node);
+				}
 
-                var processDelegates = viewDel.ProcessDelegates.Where(d => d.Node != null);
+				var processDelegates = viewDel.ProcessDelegates.Where(d => d.Node != null);
 
-                foreach (var processDel in processDelegates)
-                {
-                    cancellation.ThrowIfCancellationRequested();
-                    walker.Visit(processDel.Node);
-                }
-            }
-        }
+				foreach (var processDel in processDelegates)
+				{
+					cancellation.ThrowIfCancellationRequested();
+					walker.Visit(processDel.Node);
+				}
+			}
+		}
 
-        private void CheckLongOperationStartDelegates(ISymbol symbol, WalkerForGraphAnalyzer walker, PXContext pxContext,
-                                                      CancellationToken cancellation)
-        {
-            cancellation.ThrowIfCancellationRequested();
+		private void CheckLongOperationStartDelegates(ISymbol symbol, WalkerForGraphAnalyzer walker, PXContext pxContext,
+													  CancellationToken cancellation)
+		{
+			cancellation.ThrowIfCancellationRequested();
 
-            var longOperationDelegates = GetLongOperationStartDelegates(symbol, pxContext, cancellation);
+			var longOperationDelegates = GetLongOperationStartDelegates(symbol, pxContext, cancellation);
 
-            foreach (var loDel in longOperationDelegates)
-            {
-                cancellation.ThrowIfCancellationRequested();
-                walker.Visit(loDel);
-            }
-        }
+			foreach (var loDel in longOperationDelegates)
+			{
+				cancellation.ThrowIfCancellationRequested();
+				walker.Visit(loDel);
+			}
+		}
 
-        private IEnumerable<SyntaxNode> GetLongOperationStartDelegates(ISymbol symbol, PXContext pxContext, CancellationToken cancellation)
-        {
-            cancellation.ThrowIfCancellationRequested();
+		private List<SyntaxNode> GetLongOperationStartDelegates(ISymbol symbol, PXContext pxContext, CancellationToken cancellation)
+		{
+			cancellation.ThrowIfCancellationRequested();
 
-            var loDelegateNodeList = new List<SyntaxNode>();
-            var declaringNodes = symbol.DeclaringSyntaxReferences
-                                 .Select(r => r.GetSyntax(cancellation));
+			var loDelegateNodeList = new List<SyntaxNode>();
+			var declaringNodes = symbol.DeclaringSyntaxReferences
+								 .Select(r => r.GetSyntax(cancellation));
 
-            foreach (var node in declaringNodes)
-            {
-                cancellation.ThrowIfCancellationRequested();
+			foreach (var node in declaringNodes)
+			{
+				cancellation.ThrowIfCancellationRequested();
 
-                var loStartWalker = new StartLongOperationDelegateWalker(pxContext, cancellation);
+				var loStartWalker = new StartLongOperationDelegateWalker(pxContext, cancellation);
 
-                loStartWalker.Visit(node);
-                loDelegateNodeList.AddRange(loStartWalker.Delegates);
-            }
+				loStartWalker.Visit(node);
+				loDelegateNodeList.AddRange(loStartWalker.Delegates);
+			}
 
-            return loDelegateNodeList;
-        }
-    }
+			return loDelegateNodeList;
+		}
+	}
 }

--- a/src/Acuminator/Acuminator.Runner.NetFramework/Properties/launchSettings.json
+++ b/src/Acuminator/Acuminator.Runner.NetFramework/Properties/launchSettings.json
@@ -30,7 +30,11 @@
     },
     "PXObjects": {
       "commandName": "Project",
-      "commandLineArgs": "D:\\Repos\\Acumatica2\\WebSites\\Pure\\PX.Objects\\PX.Objects.csproj -g D --enable-PX1007"
+      "commandLineArgs": "D:\\Repos\\Acumatica4\\WebSites\\Pure\\PX.Objects\\PX.Objects.csproj -g D --enable-PX1007"
+    },
+    "Pure": {
+      "commandName": "Project",
+      "commandLineArgs": "D:\\Repos\\Acumatica4\\WebSites\\Pure\\Pure.sln -g D --enable-PX1007"
     }
   }
 }

--- a/src/Acuminator/Acuminator.Tests/Acuminator.Tests.csproj
+++ b/src/Acuminator/Acuminator.Tests/Acuminator.Tests.csproj
@@ -456,8 +456,8 @@
     <EmbeddedResource Include="Tests\StaticAnalysis\PXOverride\Sources\BaseDelegateParameter\IncorrectParameter\PXOverrideWithIncorrectBaseDelegateParameter.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\PXOverride\Sources\BaseDelegateParameter\InvalidParameterName\PXOverrideWithIncorrectDelegateParameterName_Expected.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\PXOverride\Sources\BaseDelegateParameter\InvalidParameterName\PXOverrideWithIncorrectDelegateParameterName.cs" />
-    <EmbeddedResource Include="Tests\StaticAnalysis\PXOverride\Sources\XmlComment\PXOverrideWithoutXmlComment.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\PXOverride\Sources\XmlComment\PXOverrideWithoutXmlComment_Expected.cs" />
+    <EmbeddedResource Include="Tests\StaticAnalysis\PXOverride\Sources\XmlComment\PXOverrideWithoutXmlComment.cs" />
     <Compile Include="Tests\StaticAnalysis\StaticFieldOrPropertyInGraph\StaticFieldOrPropertyInGraphTests.cs" />
     <Compile Include="Tests\StaticAnalysis\SuppressionDiagnostics\MultipleSuppressionCodeFixTests.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\SuppressionDiagnostics\Sources\Dac\SuppressMuiltipleDiagnostics_One.cs" />

--- a/src/Acuminator/Acuminator.Tests/Acuminator.Tests.csproj
+++ b/src/Acuminator/Acuminator.Tests/Acuminator.Tests.csproj
@@ -399,6 +399,7 @@
     <EmbeddedResource Include="Tests\StaticAnalysis\PropertyAndBqlFieldTypesMismatch\Sources\DacExtensionWithInconsistentTypes.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\PropertyAndBqlFieldTypesMismatch\Sources\DerivedDacWithInconsistentTypes_Expected.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\PropertyAndBqlFieldTypesMismatch\Sources\DerivedDacWithInconsistentTypes.cs" />
+    <Compile Include="Tests\StaticAnalysis\PXOverride\PXOverrideWithoutXmlCommentTests.cs" />
     <Compile Include="Tests\StaticAnalysis\PXOverride\PXOverrideWithIncorrectDelegateParameterNameTests.cs" />
     <Compile Include="Tests\StaticAnalysis\PXOverride\PXOverrideWithIncorrectBaseDelegateParameterTests.cs" />
     <Compile Include="Tests\StaticAnalysis\PXOverride\PXOverrideWithoutBaseDelegateParameterTests.cs" />
@@ -455,6 +456,8 @@
     <EmbeddedResource Include="Tests\StaticAnalysis\PXOverride\Sources\BaseDelegateParameter\IncorrectParameter\PXOverrideWithIncorrectBaseDelegateParameter.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\PXOverride\Sources\BaseDelegateParameter\InvalidParameterName\PXOverrideWithIncorrectDelegateParameterName_Expected.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\PXOverride\Sources\BaseDelegateParameter\InvalidParameterName\PXOverrideWithIncorrectDelegateParameterName.cs" />
+    <EmbeddedResource Include="Tests\StaticAnalysis\PXOverride\Sources\XmlComment\PXOverrideWithoutXmlComment.cs" />
+    <EmbeddedResource Include="Tests\StaticAnalysis\PXOverride\Sources\XmlComment\PXOverrideWithoutXmlComment_Expected.cs" />
     <Compile Include="Tests\StaticAnalysis\StaticFieldOrPropertyInGraph\StaticFieldOrPropertyInGraphTests.cs" />
     <Compile Include="Tests\StaticAnalysis\SuppressionDiagnostics\MultipleSuppressionCodeFixTests.cs" />
     <EmbeddedResource Include="Tests\StaticAnalysis\SuppressionDiagnostics\Sources\Dac\SuppressMuiltipleDiagnostics_One.cs" />

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXOverride/PXOverrideMismatchTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXOverride/PXOverrideMismatchTests.cs
@@ -194,6 +194,10 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.PXOverride
 			protected override void CheckPatchMethodBaseDelegateParameter(SymbolAnalysisContext context, PXContext pxContext,
 																		  PXOverrideInfo pxOverrideInfo)
 			{ }
+
+			protected override void CheckPatchMethodForXmlDocComment(SymbolAnalysisContext context, PXContext pxContext, 
+																	 PXOverrideInfo pxOverrideInfo)
+			{ }
 		}
 	}
 }

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXOverride/PXOverrideWithIncorrectBaseDelegateParameterTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXOverride/PXOverrideWithIncorrectBaseDelegateParameterTests.cs
@@ -9,6 +9,7 @@ using Acuminator.Tests.Helpers;
 using Acuminator.Tests.Verification;
 using Acuminator.Utilities;
 using Acuminator.Utilities.Roslyn.Semantic;
+using Acuminator.Utilities.Roslyn.Semantic.PXGraph;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
@@ -64,6 +65,10 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.PXOverride
 
 			protected override void CheckPatchMethodIsPublicNonVirtual(SymbolAnalysisContext context, PXContext pxContext, 
 																		IMethodSymbol patchMethodWithPXOverride)
+			{ }
+
+			protected override void CheckPatchMethodForXmlDocComment(SymbolAnalysisContext context, PXContext pxContext, 
+																	 PXOverrideInfo pxOverrideInfo)
 			{ }
 		}
 	}

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXOverride/PXOverrideWithIncorrectDelegateParameterNameTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXOverride/PXOverrideWithIncorrectDelegateParameterNameTests.cs
@@ -9,6 +9,7 @@ using Acuminator.Tests.Helpers;
 using Acuminator.Tests.Verification;
 using Acuminator.Utilities;
 using Acuminator.Utilities.Roslyn.Semantic;
+using Acuminator.Utilities.Roslyn.Semantic.PXGraph;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
@@ -64,6 +65,10 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.PXOverride
 
 			protected override void CheckPatchMethodIsPublicNonVirtual(SymbolAnalysisContext context, PXContext pxContext, 
 																		IMethodSymbol patchMethodWithPXOverride)
+			{ }
+
+			protected override void CheckPatchMethodForXmlDocComment(SymbolAnalysisContext context, PXContext pxContext, 
+																	 PXOverrideInfo pxOverrideInfo)
 			{ }
 		}
 	}

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXOverride/PXOverrideWithoutBaseDelegateParameterTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXOverride/PXOverrideWithoutBaseDelegateParameterTests.cs
@@ -1,4 +1,5 @@
 ﻿#nullable enable
+using System.Collections.Immutable;
 using System.Threading.Tasks;
 
 using Acuminator.Analyzers.StaticAnalysis;
@@ -7,7 +8,10 @@ using Acuminator.Analyzers.StaticAnalysis.PXOverride;
 using Acuminator.Tests.Helpers;
 using Acuminator.Tests.Verification;
 using Acuminator.Utilities;
+using Acuminator.Utilities.Roslyn.Semantic;
+using Acuminator.Utilities.Roslyn.Semantic.PXGraph;
 
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Diagnostics;
 
@@ -22,7 +26,7 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.PXOverride
 									.WithRecursiveAnalysisEnabled()
 									.WithStaticAnalysisEnabled()
 									.WithSuppressionMechanismDisabled(),
-				new PXOverrideAnalyzer());
+				new PXOverrideAnalyzerForNoDelegateParameterTests());
 
 		protected override CodeFixProvider GetCSharpCodeFixProvider() => new AddOrReplaceOrRenameBaseDelegateParameterFix();
 
@@ -50,5 +54,26 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.PXOverride
 						  @"BaseDelegateParameter\WithoutParameter\PXOverrideWithoutBaseDelegateParameter_Expected.cs")]
 		public Task PXOverrides_Without_BaseDelegate_Parameter_CodeFix(string actual, string expected) => 
 			VerifyCSharpFixAsync(actual, expected);
+
+		private sealed class PXOverrideAnalyzerForNoDelegateParameterTests : PXOverrideAnalyzer
+		{
+			public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
+				ImmutableArray.Create
+				(
+					Descriptors.PX1079_PXOverrideWithoutDelegateParameter
+				);
+
+			protected override void CheckPatchMethodIsPublicNonVirtual(SymbolAnalysisContext context, PXContext pxContext,
+																	   IMethodSymbol patchMethodWithPXOverride)
+			{ }
+
+			protected override void ReportPatchMethodWithIncompatibleSignature(SymbolAnalysisContext context, PXContext pxContext,
+																				IMethodSymbol patchMethodWithPXOverride)
+			{ }
+
+			protected override void CheckPatchMethodForXmlDocComment(SymbolAnalysisContext context, PXContext pxContext,
+																	 PXOverrideInfo pxOverrideInfo)
+			{ }
+		}
 	}
 }

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXOverride/PXOverrideWithoutXmlCommentTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXOverride/PXOverrideWithoutXmlCommentTests.cs
@@ -34,10 +34,12 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.PXOverride
 		[EmbeddedFileData(@"XmlComment\PXOverrideWithoutXmlComment.cs")]
 		public Task PXOverrides_WithoutXmlDocComment(string source) =>
 			VerifyCSharpDiagnosticAsync(source,
-				Descriptors.PX1098_PXOverrideMethodWithoutXmlDocComment.CreateFor(13, 17),
-				Descriptors.PX1098_PXOverrideMethodWithoutXmlDocComment.CreateFor(19, 15),
-				Descriptors.PX1098_PXOverrideMethodWithoutXmlDocComment.CreateFor(25, 27),
-				Descriptors.PX1098_PXOverrideMethodWithoutXmlDocComment.CreateFor(32, 15));
+				Descriptors.PX1098_PXOverrideMethodWithoutXmlDocComment.CreateFor(23, 17),
+				Descriptors.PX1098_PXOverrideMethodWithoutXmlDocComment.CreateFor(29, 15),
+				Descriptors.PX1098_PXOverrideMethodWithoutXmlDocComment.CreateFor(35, 27),
+				Descriptors.PX1098_PXOverrideMethodWithoutXmlDocComment.CreateFor(43, 15),
+				Descriptors.PX1098_PXOverrideMethodWithoutXmlDocComment.CreateFor(50, 14),
+				Descriptors.PX1098_PXOverrideMethodWithoutXmlDocComment.CreateFor(62, 15));
 
 		[Theory]
 		[EmbeddedFileData(@"XmlComment\PXOverrideWithoutXmlComment_Expected.cs")]

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXOverride/PXOverrideWithoutXmlCommentTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXOverride/PXOverrideWithoutXmlCommentTests.cs
@@ -1,0 +1,74 @@
+﻿#nullable enable
+using System.Collections.Immutable;
+using System.Threading.Tasks;
+
+using Acuminator.Analyzers.StaticAnalysis;
+using Acuminator.Analyzers.StaticAnalysis.PXGraph;
+using Acuminator.Analyzers.StaticAnalysis.PXOverride;
+using Acuminator.Tests.Helpers;
+using Acuminator.Tests.Verification;
+using Acuminator.Utilities;
+using Acuminator.Utilities.Roslyn.Semantic;
+using Acuminator.Utilities.Roslyn.Semantic.PXGraph;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using Xunit;
+
+namespace Acuminator.Tests.Tests.StaticAnalysis.PXOverride
+{
+	public class PXOverrideWithoutXmlCommentTests : CodeFixVerifier
+	{
+		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer() => new PXGraphAnalyzer(
+				CodeAnalysisSettings.Default
+									.WithRecursiveAnalysisEnabled()
+									.WithStaticAnalysisEnabled()
+									.WithSuppressionMechanismDisabled(),
+				new PXOverrideAnalyzerForMissingXmlCommentTests());
+
+		protected override CodeFixProvider GetCSharpCodeFixProvider() => new AddXmlDocCommentWithReferenceToBaseMethodFix();
+
+		[Theory]
+		[EmbeddedFileData(@"XmlComment\PXOverrideWithoutXmlComment.cs")]
+		public Task PXOverrides_WithoutXmlDocComment(string source) =>
+			VerifyCSharpDiagnosticAsync(source,
+				Descriptors.PX1098_PXOverrideMethodWithoutXmlDocComment.CreateFor(13, 17),
+				Descriptors.PX1098_PXOverrideMethodWithoutXmlDocComment.CreateFor(19, 15),
+				Descriptors.PX1098_PXOverrideMethodWithoutXmlDocComment.CreateFor(25, 27),
+				Descriptors.PX1098_PXOverrideMethodWithoutXmlDocComment.CreateFor(32, 15));
+
+		[Theory]
+		[EmbeddedFileData(@"XmlComment\PXOverrideWithoutXmlComment_Expected.cs")]
+		public Task PXOverrides_WithoutXmlDocComment_AfterCodeFix(string source) =>
+			VerifyCSharpDiagnosticAsync(source);
+
+		[Theory]
+		[EmbeddedFileData(@"XmlComment\PXOverrideWithoutXmlComment.cs",
+						  @"XmlComment\PXOverrideWithoutXmlComment_Expected.cs")]
+		public Task PXOverrides_WithoutXmlDocComment_CodeFix(string actual, string expected) =>
+			VerifyCSharpFixAsync(actual, expected);
+
+		private sealed class PXOverrideAnalyzerForMissingXmlCommentTests : PXOverrideAnalyzer
+		{
+			public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
+				ImmutableArray.Create
+				(
+					Descriptors.PX1098_PXOverrideMethodWithoutXmlDocComment
+				);
+
+			protected override void ReportPatchMethodWithIncompatibleSignature(SymbolAnalysisContext context, PXContext pxContext,
+																			   IMethodSymbol patchMethodWithPXOverride)
+			{ }
+
+			protected override void CheckPatchMethodIsPublicNonVirtual(SymbolAnalysisContext context, PXContext pxContext,
+																		IMethodSymbol patchMethodWithPXOverride)
+			{ }
+
+			protected override void CheckPatchMethodBaseDelegateParameter(SymbolAnalysisContext context, PXContext pxContext,
+																			PXOverrideInfo pxOverrideInfo)
+			{ }
+		}
+	}
+}

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXOverride/PublicNonVirtualPXOverrideTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXOverride/PublicNonVirtualPXOverrideTests.cs
@@ -76,6 +76,10 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.PXOverride
 			protected override void CheckPatchMethodBaseDelegateParameter(SymbolAnalysisContext context, PXContext pxContext, 
 																		  PXOverrideInfo pxOverrideInfo) 
 			{ }
+
+			protected override void CheckPatchMethodForXmlDocComment(SymbolAnalysisContext context, PXContext pxContext,
+																	 PXOverrideInfo pxOverrideInfo)
+			{ }
 		}
 	}
 }

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXOverride/Sources/XmlComment/PXOverrideWithoutXmlComment.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXOverride/Sources/XmlComment/PXOverrideWithoutXmlComment.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using PX.Data;
+
+namespace Acuminator.Tests.Sources
+{
+	// Acuminator disable once PX1016 ExtensionDoesNotDeclareIsActiveMethod extension should be constantly active
+	public class DerivedExtension : PXGraphExtension<BaseExtension, MyGraph>
+	{
+		[PXOverride]
+		public object TestMethod1(int x, bool drilldown, double y, Func<int, bool, double, object> base_TestMethod1)
+		{
+			return base_TestMethod1(x, drilldown, y);
+		}
+
+		[PXOverride]
+		public void TestMethod2(int x, Action<int> base_TestMethod2)
+		{
+			base_TestMethod2(x);
+		}
+
+		[PXOverride]
+		public IEnumerable<int> TestMethod3(List<Func<int>> providers, 
+											Func<List<Func<int>>, IEnumerable<int>> base_TestMethod3)
+		{
+			return base_TestMethod3(providers);
+		}
+
+		[PXOverride]
+		public void TestMethod4(Action base_TestMethod4)
+		{
+			base_TestMethod4();
+		}
+	}
+
+	// Acuminator disable once PX1016 ExtensionDoesNotDeclareIsActiveMethod extension should be constantly active
+	public class BaseExtension : PXGraphExtension<MyGraph>
+	{
+		public virtual object TestMethod1(int x, bool drilldown, double y)
+		{
+			return new object();
+		}
+	}
+
+	public class MyGraph : PXGraph<MyGraph>
+	{
+		protected internal virtual void TestMethod2(int x)
+		{
+		}
+
+		protected virtual IEnumerable<int> TestMethod3(List<Func<int>> providers) =>
+			providers.Select(f => f()).ToList();
+
+		public virtual void TestMethod4()
+		{
+		}
+	}
+}

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXOverride/Sources/XmlComment/PXOverrideWithoutXmlComment.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXOverride/Sources/XmlComment/PXOverrideWithoutXmlComment.cs
@@ -9,6 +9,16 @@ namespace Acuminator.Tests.Sources
 	// Acuminator disable once PX1016 ExtensionDoesNotDeclareIsActiveMethod extension should be constantly active
 	public class DerivedExtension : PXGraphExtension<BaseExtension, MyGraph>
 	{
+		/// <summary>
+		/// Tests method 1 override.
+		/// </summary>
+		/// <param name="x">The x coordinate.</param>
+		/// <param name="drilldown">True to drilldown.</param>
+		/// <param name="y">The y coordinate.</param>
+		/// <param name="base_TestMethod1">The first base test method.</param>
+		/// <returns>
+		/// An object.
+		/// </returns>
 		[PXOverride]
 		public object TestMethod1(int x, bool drilldown, double y, Func<int, bool, double, object> base_TestMethod1)
 		{
@@ -28,11 +38,32 @@ namespace Acuminator.Tests.Sources
 			return base_TestMethod3(providers);
 		}
 
+		/// <inheritdoc cref="MyGraph.TestMethod4"/>
 		[PXOverride]
 		public void TestMethod4(Action base_TestMethod4)
 		{
 			base_TestMethod4();
 		}
+
+		#region Test Method 5
+		[PXOverride]
+		public int TestMethod5(object obj, Func<object, int> base_TestMethod5)
+		{
+			return base_TestMethod5(obj);
+		}
+		#endregion
+
+		#region Test Method 6
+		/// <summary>
+		/// Tests method 6.
+		/// </summary>
+		/// <param name="s">The string.</param>
+		[PXOverride]
+		public void TestMethod6(string s, Action<string> base_TestMethod6)
+		{
+			base_TestMethod6(s);
+		}
+		#endregion
 	}
 
 	// Acuminator disable once PX1016 ExtensionDoesNotDeclareIsActiveMethod extension should be constantly active
@@ -53,7 +84,19 @@ namespace Acuminator.Tests.Sources
 		protected virtual IEnumerable<int> TestMethod3(List<Func<int>> providers) =>
 			providers.Select(f => f()).ToList();
 
+		/// <summary>
+		/// Tests method 4.
+		/// </summary>
 		public virtual void TestMethod4()
+		{
+		}
+
+		public virtual int TestMethod5(object obj)
+		{
+			return 1;
+		}
+
+		public virtual void TestMethod6(string s)
 		{
 		}
 	}

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXOverride/Sources/XmlComment/PXOverrideWithoutXmlComment_Expected.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXOverride/Sources/XmlComment/PXOverrideWithoutXmlComment_Expected.cs
@@ -9,7 +9,16 @@ namespace Acuminator.Tests.Sources
 	// Acuminator disable once PX1016 ExtensionDoesNotDeclareIsActiveMethod extension should be constantly active
 	public class DerivedExtension : PXGraphExtension<BaseExtension, MyGraph>
 	{
-
+		/// <summary>
+		/// Tests method 1 override.
+		/// </summary>
+		/// <param name="x">The x coordinate.</param>
+		/// <param name="drilldown">True to drilldown.</param>
+		/// <param name="y">The y coordinate.</param>
+		/// <param name="base_TestMethod1">The first base test method.</param>
+		/// <returns>
+		/// An object.
+		/// </returns>
 		/// Overrides <seealso cref="BaseExtension.TestMethod1(int, bool, double)"/>
 		[PXOverride]
 		public object TestMethod1(int x, bool drilldown, double y, Func<int, bool, double, object> base_TestMethod1)
@@ -32,12 +41,35 @@ namespace Acuminator.Tests.Sources
 			return base_TestMethod3(providers);
 		}
 
+		/// <inheritdoc cref="MyGraph.TestMethod4"/>
 		/// Overrides <seealso cref="MyGraph.TestMethod4"/>
 		[PXOverride]
 		public void TestMethod4(Action base_TestMethod4)
 		{
 			base_TestMethod4();
 		}
+
+		#region Test Method 5
+		/// Overrides <seealso cref="MyGraph.TestMethod5(object)"/>
+		[PXOverride]
+		public int TestMethod5(object obj, Func<object, int> base_TestMethod5)
+		{
+			return base_TestMethod5(obj);
+		}
+		#endregion
+
+		#region Test Method 6
+		/// <summary>
+		/// Tests method 6.
+		/// </summary>
+		/// <param name="s">The string.</param>
+		/// Overrides <seealso cref="MyGraph.TestMethod6(string)"/>
+		[PXOverride]
+		public void TestMethod6(string s, Action<string> base_TestMethod6)
+		{
+			base_TestMethod6(s);
+		}
+		#endregion
 	}
 
 	// Acuminator disable once PX1016 ExtensionDoesNotDeclareIsActiveMethod extension should be constantly active
@@ -58,7 +90,19 @@ namespace Acuminator.Tests.Sources
 		protected virtual IEnumerable<int> TestMethod3(List<Func<int>> providers) =>
 			providers.Select(f => f()).ToList();
 
+		/// <summary>
+		/// Tests method 4.
+		/// </summary>
 		public virtual void TestMethod4()
+		{
+		}
+
+		public virtual int TestMethod5(object obj)
+		{
+			return 1;
+		}
+
+		public virtual void TestMethod6(string s)
 		{
 		}
 	}

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXOverride/Sources/XmlComment/PXOverrideWithoutXmlComment_Expected.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXOverride/Sources/XmlComment/PXOverrideWithoutXmlComment_Expected.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using PX.Data;
+
+namespace Acuminator.Tests.Sources
+{
+	// Acuminator disable once PX1016 ExtensionDoesNotDeclareIsActiveMethod extension should be constantly active
+	public class DerivedExtension : PXGraphExtension<BaseExtension, MyGraph>
+	{
+
+		/// Overrides <seealso cref="BaseExtension.TestMethod1(int, bool, double)"/>
+		[PXOverride]
+		public object TestMethod1(int x, bool drilldown, double y, Func<int, bool, double, object> base_TestMethod1)
+		{
+			return base_TestMethod1(x, drilldown, y);
+		}
+
+		/// Overrides <seealso cref="MyGraph.TestMethod2(int)"/>
+		[PXOverride]
+		public void TestMethod2(int x, Action<int> base_TestMethod2)
+		{
+			base_TestMethod2(x);
+		}
+
+		/// Overrides <seealso cref="MyGraph.TestMethod3(List{Func{int}})"/>
+		[PXOverride]
+		public IEnumerable<int> TestMethod3(List<Func<int>> providers, 
+											Func<List<Func<int>>, IEnumerable<int>> base_TestMethod3)
+		{
+			return base_TestMethod3(providers);
+		}
+
+		/// Overrides <seealso cref="MyGraph.TestMethod4"/>
+		[PXOverride]
+		public void TestMethod4(Action base_TestMethod4)
+		{
+			base_TestMethod4();
+		}
+	}
+
+	// Acuminator disable once PX1016 ExtensionDoesNotDeclareIsActiveMethod extension should be constantly active
+	public class BaseExtension : PXGraphExtension<MyGraph>
+	{
+		public virtual object TestMethod1(int x, bool drilldown, double y)
+		{
+			return new object();
+		}
+	}
+
+	public class MyGraph : PXGraph<MyGraph>
+	{
+		protected internal virtual void TestMethod2(int x)
+		{
+		}
+
+		protected virtual IEnumerable<int> TestMethod3(List<Func<int>> providers) =>
+			providers.Select(f => f()).ToList();
+
+		public virtual void TestMethod4()
+		{
+		}
+	}
+}

--- a/src/Acuminator/Acuminator.Utilities/Common/StructCollectionsNoBoxingExtensions.cs
+++ b/src/Acuminator/Acuminator.Utilities/Common/StructCollectionsNoBoxingExtensions.cs
@@ -12,6 +12,52 @@ namespace Acuminator.Utilities.Common
 	public static class StructCollectionsNoBoxingExtensions
 	{
 		/// <summary>
+		/// Prepends struct collection <paramref name="source"/> with an <paramref name="itemToAdd"/>.<br/>
+		/// This methods prevents additional boxing on convertation of a <typeparamref name="TStructCollection"/> collection to <see cref="IEnumerable{T}"/>.
+		/// </summary>
+		/// <typeparam name="TStructCollection">Type of the structure collection.</typeparam>
+		/// <typeparam name="TItem">Type of the item.</typeparam>
+		/// <param name="source">The struct collection to act on.</param>
+		/// <param name="itemToAdd">The item to add.</param>
+		/// <returns>
+		/// An <see cref="IEnumerable{TItem}"/> that contains the <paramref name="itemToAdd"/> followed by the items in <paramref name="source"/>.
+		/// </returns>
+		[DebuggerStepThrough]
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static IEnumerable<TItem> PrependItem<TStructCollection, TItem>(this TStructCollection source, TItem itemToAdd)
+		where TStructCollection : struct, IEnumerable<TItem> =>
+			source.PrependOrAppend(itemToAdd, isAppending: false);
+
+		/// <summary>
+		/// Appends struct collection <paramref name="source"/> with an <paramref name="item"/>.<br/>
+		/// This methods prevents additional boxing on convertation of a <typeparamref name="TStructCollection"/> collection to <see cref="IEnumerable{T}"/>.
+		/// </summary>
+		/// <typeparam name="TItem">Type of the item.</typeparam>
+		/// <param name="source">The struct collection to act on.</param>
+		/// <param name="itemToAdd">The item to add.</param>
+		/// <returns>
+		/// An <see cref="IEnumerable{TItem}"/> that contains the items in <paramref name="source"/> followed by the <paramref name="itemToAdd"/>.
+		/// </returns>
+		[DebuggerStepThrough]
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static IEnumerable<TItem> AppendItem<TStructCollection, TItem>(this TStructCollection source, TItem itemToAdd)
+		where TStructCollection : struct, IReadOnlyCollection<TItem> =>
+			source.PrependOrAppend(itemToAdd, isAppending: true);
+
+		[DebuggerStepThrough]
+		private static IEnumerable<TItem> PrependOrAppend<TStructCollection, TItem>(this TStructCollection source, TItem itemToAdd, bool isAppending)
+		where TStructCollection : struct, IEnumerable<TItem>
+		{
+			if (!isAppending)
+				yield return itemToAdd;
+
+			foreach (var item in source)
+				yield return item;
+
+			if (isAppending)
+				yield return itemToAdd;
+		}
+		/// <summary>
 		/// Concatenate structure list to this collection. This is an optimization method which allows to avoid boxing for collections implemented as structs.
 		/// </summary>
 		/// <typeparam name="TItem">Type of the item.</typeparam>

--- a/src/Acuminator/Acuminator.Utilities/Common/StructCollectionsNoBoxingExtensions.cs
+++ b/src/Acuminator/Acuminator.Utilities/Common/StructCollectionsNoBoxingExtensions.cs
@@ -282,6 +282,34 @@ namespace Acuminator.Utilities.Common
 		}
 
 		/// <summary>
+		/// Skip method for <see cref="SyntaxTriviaList"/>. This is an optimization method which allows to avoid boxing and allocations in many cases.
+		/// </summary>
+		/// <param name="triviaList">The trivia list to act on.</param>
+		/// <param name="countToSkip">The count of elements to skip.</param>
+		/// <returns/>
+		[DebuggerStepThrough]
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static SyntaxTriviaList Skip(this in SyntaxTriviaList triviaList, int countToSkip)
+		{
+			if (countToSkip >= triviaList.Count)
+				return SyntaxTriviaList.Empty;
+			else if (countToSkip <= 0)
+				return triviaList;
+			else if (countToSkip == triviaList.Count - 1)		// Hot path to avoid some allocations
+				return new SyntaxTriviaList(triviaList[^1]);
+			else
+			{
+				int countOfElementsToTake = triviaList.Count - countToSkip;
+				var slice = new SyntaxTrivia[countOfElementsToTake];
+
+				for (int i = 0; i < slice.Length; i++)
+					slice[i] = triviaList[i + countToSkip];
+
+				return new SyntaxTriviaList(slice);
+			}
+		}
+
+		/// <summary>
 		/// TakeWhile method for <see cref="SyntaxTriviaList"/>. This is an optimization method which allows to avoid boxing.
 		/// </summary>
 		/// <param name="triviaList">The trivia list to act on.</param>

--- a/src/Acuminator/Acuminator.Utilities/Common/StructCollectionsNoBoxingExtensions.cs
+++ b/src/Acuminator/Acuminator.Utilities/Common/StructCollectionsNoBoxingExtensions.cs
@@ -11,6 +11,10 @@ namespace Acuminator.Utilities.Common
 {
 	public static class StructCollectionsNoBoxingExtensions
 	{
+		public delegate bool PredicateWithInputByReadOnlyRef<TItem>(in TItem item);
+		public delegate TResult FuncWithInputByReadOnlyRef<TItem, TResult>(in TItem item);
+		public delegate void ActionWithInputByReadOnlyRef<TItem>(in TItem item);
+
 		/// <summary>
 		/// Prepends struct collection <paramref name="source"/> with an <paramref name="itemToAdd"/>.<br/>
 		/// This methods prevents additional boxing on convertation of a <typeparamref name="TStructCollection"/> collection to <see cref="IEnumerable{T}"/>.
@@ -57,6 +61,7 @@ namespace Acuminator.Utilities.Common
 			if (isAppending)
 				yield return itemToAdd;
 		}
+
 		/// <summary>
 		/// Concatenate structure list to this collection. This is an optimization method which allows to avoid boxing for collections implemented as structs.
 		/// </summary>
@@ -114,7 +119,7 @@ namespace Acuminator.Utilities.Common
 		/// <returns/>
 		[DebuggerStepThrough]
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static IEnumerable<SyntaxToken> Where(this SyntaxTokenList source, Func<SyntaxToken, bool> predicate)
+		public static IEnumerable<SyntaxToken> Where(this SyntaxTokenList source, PredicateWithInputByReadOnlyRef<SyntaxToken> predicate)
 		{
 			predicate.ThrowOnNull();
 			return WhereForSyntaxTokenListImplementation();
@@ -141,7 +146,7 @@ namespace Acuminator.Utilities.Common
 		/// <returns/>
 		[DebuggerStepThrough]
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static SyntaxToken FirstOrDefault(this SyntaxTokenList source, Func<SyntaxToken, bool> predicate)
+		public static SyntaxToken FirstOrDefault(this SyntaxTokenList source, PredicateWithInputByReadOnlyRef<SyntaxToken> predicate)
 		{
 			predicate.ThrowOnNull();
 
@@ -189,12 +194,12 @@ namespace Acuminator.Utilities.Common
 		/// Select method for <see cref="SyntaxTriviaList"/>. This is an optimization method which allows to avoid boxing.
 		/// </summary>
 		/// <typeparam name="TResult">Type of the result.</typeparam>
-		/// <param name="triviaList">The triviaList to act on.</param>
+		/// <param name="triviaList">The trivia list to act on.</param>
 		/// <param name="selector">The selector.</param>
 		/// <returns/>
 		[DebuggerStepThrough]
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static IEnumerable<TResult> Select<TResult>(this SyntaxTriviaList triviaList, Func<SyntaxTrivia, TResult> selector)
+		public static IEnumerable<TResult> Select<TResult>(this SyntaxTriviaList triviaList, FuncWithInputByReadOnlyRef<SyntaxTrivia, TResult> selector)
 		{
 			selector.ThrowOnNull();
 			return SelectForStructListImplementation();
@@ -205,6 +210,86 @@ namespace Acuminator.Utilities.Common
 				{
 					yield return selector(triviaList[i]);
 				}
+			}
+		}
+
+		/// <summary>
+		/// Where method for <see cref="SyntaxTriviaList"/>. 
+		/// This is an optimization method which allows to avoid boxing.
+		/// </summary>
+		/// <param name="triviaList">The trivia list to act on.</param>
+		/// <param name="predicate">The selector.</param>
+		/// <returns/>
+		[DebuggerStepThrough]
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static IEnumerable<SyntaxTrivia> Where(this SyntaxTriviaList triviaList,
+													  PredicateWithInputByReadOnlyRef<SyntaxTrivia> predicate) =>
+			WhereImplementation(triviaList, predicate.CheckIfNull());
+
+		/// <summary>
+		/// Where method for <see cref="SyntaxTriviaList.Reversed"/>.
+		/// This is an optimization method which allows to avoid boxing.
+		/// </summary>
+		/// <param name="reversedTrivia">The reversedTrivia to act on.</param>
+		/// <param name="predicate">The selector.</param>
+		/// <returns/>
+		[DebuggerStepThrough]
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static IEnumerable<SyntaxTrivia> Where(this SyntaxTriviaList.Reversed reversedTrivia,
+													  PredicateWithInputByReadOnlyRef<SyntaxTrivia> predicate) =>
+			WhereImplementation(reversedTrivia, predicate.CheckIfNull());
+
+		private static IEnumerable<SyntaxTrivia> WhereImplementation<TStructCollection>(TStructCollection source,
+																						PredicateWithInputByReadOnlyRef<SyntaxTrivia> predicate)
+		where TStructCollection : struct, IEnumerable<SyntaxTrivia>
+		{
+			foreach (SyntaxTrivia item in source)
+			{
+				if (predicate(item))
+					yield return item;
+			}
+		}
+
+		/// <summary>
+		/// TakeWhile method for <see cref="SyntaxTriviaList"/>. This is an optimization method which allows to avoid boxing.
+		/// </summary>
+		/// <param name="triviaList">The trivia list to act on.</param>
+		/// <param name="predicate">The selector.</param>
+		/// <returns/>
+		[DebuggerStepThrough]
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static IEnumerable<SyntaxTrivia> TakeWhile(this SyntaxTriviaList triviaList,
+														  PredicateWithInputByReadOnlyRef<SyntaxTrivia> predicate)
+		{
+			predicate.ThrowOnNull();
+			return TakeWhileImplementation(triviaList, predicate);
+		}
+
+		/// <summary>
+		/// TakeWhile method for <see cref="SyntaxTriviaList.Reversed"/>. This is an optimization method which allows to avoid boxing.
+		/// </summary>
+		/// <param name="reversedTrivia">The reversedTrivia to act on.</param>
+		/// <param name="predicate">The selector.</param>
+		/// <returns/>
+		[DebuggerStepThrough]
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static IEnumerable<SyntaxTrivia> TakeWhile(this SyntaxTriviaList.Reversed reversedTrivia,
+														  PredicateWithInputByReadOnlyRef<SyntaxTrivia> predicate)
+		{
+			predicate.ThrowOnNull();
+			return TakeWhileImplementation(reversedTrivia, predicate);			
+		}
+
+		private static IEnumerable<SyntaxTrivia> TakeWhileImplementation<TStructCollection>(TStructCollection source,
+																							PredicateWithInputByReadOnlyRef<SyntaxTrivia> predicate)
+		where TStructCollection : struct, IEnumerable<SyntaxTrivia>
+		{
+			foreach (SyntaxTrivia item in source)
+			{
+				if (predicate(item))
+					yield return item;
+				else
+					yield break;
 			}
 		}
 

--- a/src/Acuminator/Acuminator.Utilities/Common/StructCollectionsNoBoxingExtensions.cs
+++ b/src/Acuminator/Acuminator.Utilities/Common/StructCollectionsNoBoxingExtensions.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Linq;
 using System.Runtime.CompilerServices;
 
 using Microsoft.CodeAnalysis;
@@ -377,6 +378,58 @@ namespace Acuminator.Utilities.Common
 				for (int i = 0; i < triviasToAdd.Count; i++)
 					yield return triviasToAdd[i];
 			}
+		}
+
+		/// <summary>
+		/// Concat method that appends trivias collection to <see cref="SyntaxTriviaList"/> without boxing.<br/>
+		/// This is an optimization method which allows to avoid boxing.
+		/// </summary>
+		/// <param name="triviaList">The trivia list to act on.</param>
+		/// <param name="triviasToAdd">The collection of trivias to add.</param>
+		/// <returns/>
+		public static IEnumerable<SyntaxTrivia> Concat(this in SyntaxTriviaList triviaList, IEnumerable<SyntaxTrivia>? triviasToAdd)
+		{
+			if (triviaList.Count == 0)
+				return triviasToAdd ?? [];
+			else if (triviasToAdd == null)
+				return triviaList;
+
+			return ConcatImpl(triviaList, triviasToAdd);
+
+			//------------------------------------Local Function-----------------------------------------
+			static IEnumerable<SyntaxTrivia> ConcatImpl(SyntaxTriviaList triviaList, IEnumerable<SyntaxTrivia> triviasToAdd)
+			{
+				for (int i = 0; i < triviaList.Count; i++)
+					yield return triviaList[i];
+
+				foreach (SyntaxTrivia trivia in triviasToAdd)
+					yield return trivia;
+			}
+		}
+
+		/// <summary>
+		/// Concat method that appends <see cref="SyntaxTriviaList"/> collection without boxing.<br/>
+		/// This is an optimization method which allows to avoid boxing.
+		/// </summary>
+		/// <param name="triviaList">The trivia list to act on.</param>
+		/// <param name="triviasToAdd">The <see cref="SyntaxTriviaList"/> trivias to add.</param>
+		/// <returns/>
+		public static SyntaxTriviaList Concat(this in SyntaxTriviaList triviaList, in SyntaxTriviaList triviasToAdd)
+		{
+			if (triviaList.Count == 0)
+				return triviasToAdd;
+			else if (triviasToAdd.Count == 0)
+				return triviaList;
+
+			var unitedTrivia = new SyntaxTrivia[triviaList.Count + triviasToAdd.Count];
+
+			for (int i = 0; i < triviaList.Count; i++)
+				unitedTrivia[i] = triviaList[i];
+
+			for (int i = 0; i < triviasToAdd.Count; i++)
+				unitedTrivia[triviaList.Count + i] = triviasToAdd[i];
+
+			return new SyntaxTriviaList(unitedTrivia);
 		}
 
 		/// <summary>

--- a/src/Acuminator/Acuminator.Utilities/Common/StructCollectionsNoBoxingExtensions.cs
+++ b/src/Acuminator/Acuminator.Utilities/Common/StructCollectionsNoBoxingExtensions.cs
@@ -1,10 +1,9 @@
-﻿#nullable enable
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+
 using Microsoft.CodeAnalysis;
 
 namespace Acuminator.Utilities.Common
@@ -250,6 +249,35 @@ namespace Acuminator.Utilities.Common
 			{
 				if (predicate(item))
 					yield return item;
+			}
+		}
+
+		/// <summary>
+		/// Take method for <see cref="SyntaxTriviaList"/>. This is an optimization method which allows to avoid boxing and allocations in some cases.
+		/// </summary>
+		/// <param name="triviaList">The trivia list to act on.</param>
+		/// <param name="countToTake">The count of elements to take.</param>
+		/// <returns/>
+		[DebuggerStepThrough]
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static SyntaxTriviaList Take(this in SyntaxTriviaList triviaList, int countToTake)
+		{
+			if (countToTake >= triviaList.Count)
+				return triviaList;
+
+			switch (countToTake)
+			{
+				case <= 0:
+					return SyntaxTriviaList.Empty;
+				case 1:
+					return new SyntaxTriviaList(triviaList[0]);     // Hot path to avoid some allocations
+				default:
+					var slice = new SyntaxTrivia[countToTake];
+
+					for (int i = 0; i < countToTake; i++)
+						slice[i] = triviaList[i];
+
+					return new SyntaxTriviaList(slice);
 			}
 		}
 

--- a/src/Acuminator/Acuminator.Utilities/Common/StructCollectionsNoBoxingExtensions.cs
+++ b/src/Acuminator/Acuminator.Utilities/Common/StructCollectionsNoBoxingExtensions.cs
@@ -119,12 +119,13 @@ namespace Acuminator.Utilities.Common
 		/// <returns/>
 		[DebuggerStepThrough]
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static IEnumerable<SyntaxToken> Where(this SyntaxTokenList source, PredicateWithInputByReadOnlyRef<SyntaxToken> predicate)
+		public static IEnumerable<SyntaxToken> Where(this in SyntaxTokenList source, PredicateWithInputByReadOnlyRef<SyntaxToken> predicate)
 		{
 			predicate.ThrowOnNull();
-			return WhereForSyntaxTokenListImplementation();
+			return WhereForSyntaxTokenListImplementation(source, predicate);
 
-			IEnumerable<SyntaxToken> WhereForSyntaxTokenListImplementation()
+			static IEnumerable<SyntaxToken> WhereForSyntaxTokenListImplementation(SyntaxTokenList source, 
+																				  PredicateWithInputByReadOnlyRef<SyntaxToken> predicate)
 			{
 				for (int i = 0; i < source.Count; i++)
 				{
@@ -146,7 +147,7 @@ namespace Acuminator.Utilities.Common
 		/// <returns/>
 		[DebuggerStepThrough]
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static SyntaxToken FirstOrDefault(this SyntaxTokenList source, PredicateWithInputByReadOnlyRef<SyntaxToken> predicate)
+		public static SyntaxToken FirstOrDefault(this in SyntaxTokenList source, PredicateWithInputByReadOnlyRef<SyntaxToken> predicate)
 		{
 			predicate.ThrowOnNull();
 
@@ -199,12 +200,14 @@ namespace Acuminator.Utilities.Common
 		/// <returns/>
 		[DebuggerStepThrough]
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static IEnumerable<TResult> Select<TResult>(this SyntaxTriviaList triviaList, FuncWithInputByReadOnlyRef<SyntaxTrivia, TResult> selector)
+		public static IEnumerable<TResult> Select<TResult>(this in SyntaxTriviaList triviaList, 
+														  FuncWithInputByReadOnlyRef<SyntaxTrivia, TResult> selector)
 		{
 			selector.ThrowOnNull();
-			return SelectForStructListImplementation();
+			return SelectForStructListImplementation(triviaList, selector);
 
-			IEnumerable<TResult> SelectForStructListImplementation()
+			static IEnumerable<TResult> SelectForStructListImplementation(SyntaxTriviaList triviaList, 
+																		  FuncWithInputByReadOnlyRef<SyntaxTrivia, TResult> selector)
 			{
 				for (int i = 0; i < triviaList.Count; i++)
 				{
@@ -222,7 +225,7 @@ namespace Acuminator.Utilities.Common
 		/// <returns/>
 		[DebuggerStepThrough]
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static IEnumerable<SyntaxTrivia> Where(this SyntaxTriviaList triviaList,
+		public static IEnumerable<SyntaxTrivia> Where(this in SyntaxTriviaList triviaList,
 													  PredicateWithInputByReadOnlyRef<SyntaxTrivia> predicate) =>
 			WhereImplementation(triviaList, predicate.CheckIfNull());
 
@@ -235,7 +238,7 @@ namespace Acuminator.Utilities.Common
 		/// <returns/>
 		[DebuggerStepThrough]
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static IEnumerable<SyntaxTrivia> Where(this SyntaxTriviaList.Reversed reversedTrivia,
+		public static IEnumerable<SyntaxTrivia> Where(this in SyntaxTriviaList.Reversed reversedTrivia,
 													  PredicateWithInputByReadOnlyRef<SyntaxTrivia> predicate) =>
 			WhereImplementation(reversedTrivia, predicate.CheckIfNull());
 
@@ -258,7 +261,7 @@ namespace Acuminator.Utilities.Common
 		/// <returns/>
 		[DebuggerStepThrough]
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static IEnumerable<SyntaxTrivia> TakeWhile(this SyntaxTriviaList triviaList,
+		public static IEnumerable<SyntaxTrivia> TakeWhile(this in SyntaxTriviaList triviaList,
 														  PredicateWithInputByReadOnlyRef<SyntaxTrivia> predicate)
 		{
 			predicate.ThrowOnNull();
@@ -273,7 +276,7 @@ namespace Acuminator.Utilities.Common
 		/// <returns/>
 		[DebuggerStepThrough]
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static IEnumerable<SyntaxTrivia> TakeWhile(this SyntaxTriviaList.Reversed reversedTrivia,
+		public static IEnumerable<SyntaxTrivia> TakeWhile(this in SyntaxTriviaList.Reversed reversedTrivia,
 														  PredicateWithInputByReadOnlyRef<SyntaxTrivia> predicate)
 		{
 			predicate.ThrowOnNull();
@@ -290,6 +293,33 @@ namespace Acuminator.Utilities.Common
 					yield return item;
 				else
 					yield break;
+			}
+		}
+
+		/// <summary>
+		/// Concat method that appends <see cref="SyntaxTriviaList"/> collection without boxing.<br/>
+		/// This is an optimization method which allows to avoid boxing.
+		/// </summary>
+		/// <param name="source">The source collection to act on.</param>
+		/// <param name="triviasToAdd">The <see cref="SyntaxTriviaList"/> trivias to add.</param>
+		/// <returns/>
+		public static IEnumerable<SyntaxTrivia> Concat(this IEnumerable<SyntaxTrivia>? source, in SyntaxTriviaList triviasToAdd)
+		{
+			if (source == null)
+				return triviasToAdd;
+			else if (triviasToAdd.Count == 0)
+				return source;
+
+			return ConcatImpl(source, triviasToAdd);
+
+			//------------------------------------Local Function-----------------------------------------
+			static IEnumerable<SyntaxTrivia> ConcatImpl(IEnumerable<SyntaxTrivia> source, SyntaxTriviaList triviasToAdd)
+			{
+				foreach (SyntaxTrivia trivia in source)
+					yield return trivia;
+
+				for (int i = 0; i < triviasToAdd.Count; i++)
+					yield return triviasToAdd[i];
 			}
 		}
 
@@ -375,7 +405,7 @@ namespace Acuminator.Utilities.Common
 
 		[DebuggerStepThrough]
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static int FindIndex<TNode>(this SeparatedSyntaxList<TNode> source, Func<TNode, bool> condition)
+		public static int FindIndex<TNode>(this in SeparatedSyntaxList<TNode> source, Func<TNode, bool> condition)
 		where TNode : SyntaxNode
 		{
 			return FindIndex(source, startInclusive: 0, endExclusive: source.Count, condition);
@@ -383,14 +413,15 @@ namespace Acuminator.Utilities.Common
 
 		[DebuggerStepThrough]
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static int FindIndex<TNode>(this SeparatedSyntaxList<TNode> source, int startInclusive, Func<TNode, bool> condition)
+		public static int FindIndex<TNode>(this in SeparatedSyntaxList<TNode> source, int startInclusive, Func<TNode, bool> condition)
 		where TNode : SyntaxNode
 		{
 			return FindIndex(source, startInclusive, endExclusive: source.Count, condition);
 		}
 
 		[DebuggerStepThrough]
-		public static int FindIndex<TNode>(this SeparatedSyntaxList<TNode> source, int startInclusive, int endExclusive, Func<TNode, bool> condition)
+		public static int FindIndex<TNode>(this in SeparatedSyntaxList<TNode> source, int startInclusive, int endExclusive, 
+										   Func<TNode, bool> condition)
 		where TNode : SyntaxNode
 		{
 			condition.ThrowOnNull();
@@ -410,7 +441,7 @@ namespace Acuminator.Utilities.Common
 		}
 
 		[DebuggerStepThrough]
-		public static bool All<TNode>(this SeparatedSyntaxList<TNode> source, Func<TNode, bool> condition)
+		public static bool All<TNode>(this in SeparatedSyntaxList<TNode> source, Func<TNode, bool> condition)
 		where TNode : SyntaxNode
 		{
 			condition.ThrowOnNull();
@@ -425,7 +456,7 @@ namespace Acuminator.Utilities.Common
 		}
 
 		[DebuggerStepThrough]
-		public static bool Any<TNode>(this SeparatedSyntaxList<TNode> source, Func<TNode, bool> condition)
+		public static bool Any<TNode>(this in SeparatedSyntaxList<TNode> source, Func<TNode, bool> condition)
 		where TNode : SyntaxNode
 		{
 			condition.ThrowOnNull();
@@ -440,7 +471,7 @@ namespace Acuminator.Utilities.Common
 		}
 
 		[DebuggerStepThrough]
-		public static bool Contains<TNode>(this SyntaxList<TNode> source, TNode node)
+		public static bool Contains<TNode>(this in SyntaxList<TNode> source, TNode node)
 		where TNode : SyntaxNode
 		{
 			for (int i = 0; i < source.Count; i++)

--- a/src/Acuminator/Acuminator.Utilities/DiagnosticSuppression/SuppressionManager.cs
+++ b/src/Acuminator/Acuminator.Utilities/DiagnosticSuppression/SuppressionManager.cs
@@ -363,7 +363,7 @@ namespace Acuminator.Utilities.DiagnosticSuppression
 			if (trivias.Count == 0)
 				return false;
 
-			var successfulMatch = trivias.Where(x => x.IsKind(SyntaxKind.SingleLineCommentTrivia))
+			var successfulMatch = trivias.Where((in SyntaxTrivia x) => x.IsKind(SyntaxKind.SingleLineCommentTrivia))
 										 .Select(trivia => _suppressPattern.Match(trivia.ToString()))
 										 .FirstOrDefault(match => match.Success && diagnostic.Id == match.Groups[1].Value &&
 																  (diagnosticShortName == null || diagnosticShortName == match.Groups[2].Value));

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/CodeGeneration/TypeMemberModifiersRewriterBase.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/CodeGeneration/TypeMemberModifiersRewriterBase.cs
@@ -148,7 +148,7 @@ namespace Acuminator.Utilities.Roslyn.CodeGeneration
 		private IEnumerable<SyntaxToken> FilterModifiers(in SyntaxTokenList modifiers, bool includeFirstModifier)
 		{
 			if (includeFirstModifier)
-				return modifiers.Where(m => !ShouldModifierBeRemoved(m));
+				return modifiers.Where((in SyntaxToken m) => !ShouldModifierBeRemoved(m));
 
 			switch (modifiers.Count)
 			{

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Syntax/RoslynSyntaxUtils.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Syntax/RoslynSyntaxUtils.cs
@@ -373,6 +373,19 @@ namespace Acuminator.Utilities.Roslyn.Syntax
 			return regionTrivias;
 		}
 
+		/// <summary>
+		/// Check if <paramref name="trivia"/> represents a comment.
+		/// </summary>
+		/// <param name="trivia">The trivia to act on.</param>
+		/// <returns>
+		/// <see langword="true"/> if trivia is a comment, <see langword="false"/> if not.
+		/// </returns>
+		public static bool IsCommentTrivia(this in SyntaxTrivia trivia) =>
+			trivia.Kind() is SyntaxKind.SingleLineDocumentationCommentTrivia or 
+							 SyntaxKind.MultiLineDocumentationCommentTrivia or
+							 SyntaxKind.SingleLineCommentTrivia or 
+							 SyntaxKind.MultiLineCommentTrivia;
+
 		public static IEnumerable<SingleVariableDesignationSyntax> GetAllVariableDesignations(this PatternSyntax? pattern)
 		{
 			switch (pattern)

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Syntax/RoslynSyntaxUtils.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Syntax/RoslynSyntaxUtils.cs
@@ -329,8 +329,8 @@ namespace Acuminator.Utilities.Roslyn.Syntax
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static string? GetDocTagName(this XmlNodeSyntax docTagNode) => docTagNode switch
 		{
-			XmlElementSyntax docTagWithContent	 => docTagWithContent.StartTag?.Name?.ToString(),
-			XmlEmptyElementSyntax oneLinerDocTag => oneLinerDocTag.Name?.ToString(),
+			XmlElementSyntax docTagWithContent	 => docTagWithContent.StartTag?.Name?.LocalName.ToString(),
+			XmlEmptyElementSyntax oneLinerDocTag => oneLinerDocTag.Name?.LocalName.ToString(),
 			_									 => null
 		};
 

--- a/src/Samples/PX.Objects.HackathonDemo/PX.Objects.HackathonDemo/Graph/OverrideTest/PXOverridesExample.cs
+++ b/src/Samples/PX.Objects.HackathonDemo/PX.Objects.HackathonDemo/Graph/OverrideTest/PXOverridesExample.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Collections.Generic;
+
+using PX.Data;
+
+namespace PX.Objects.HackathonDemo.OverrideTest
+{
+	// Acuminator disable once PX1016 ExtensionDoesNotDeclareIsActiveMethod extension should be constantly active
+	public class ChainedExtension : PXGraphExtension<DerivedExtension, MyGraph>
+	{
+		public delegate string CustomDelegateType(string input);
+
+		[PXOverride]
+		public MyDac TestMethod1(MyDac x, bool drilldown, double y, Func<MyDac, bool, double, MyDac> base_TestMethod1) => base_TestMethod1(x, drilldown, y);
+
+		[PXOverride]
+		public void TestMethod2(Func<string> func, IEnumerable<List<string>> itemsLists, Action<Func<string>, IEnumerable<List<string>>> base_TestMethod2)
+		{
+			base_TestMethod2(func, itemsLists);
+		}
+
+		[PXOverride]
+		public object TestMethod3(Func<string> func, int x, IEnumerable<List<string>> itemsLists, Func<Func<string>, int, IEnumerable<List<string>>, object> base_TestMethod3)
+		{
+			return base_TestMethod3?.Invoke(func, x, itemsLists);
+		}
+
+		[PXOverride]
+		public string TestMethod4(string x, CustomDelegateType base_TestMethod4)
+		{
+			if (base_TestMethod4 != null)
+				return base_TestMethod4(x);
+			else
+				return string.Empty;
+		}
+	}
+
+	// Acuminator disable once PX1016 ExtensionDoesNotDeclareIsActiveMethod extension should be constantly active
+	public class DerivedExtension : BaseExtension<MyDac> { }
+
+	// Acuminator disable once PX1016 ExtensionDoesNotDeclareIsActiveMethod extension should be constantly active
+	public abstract class BaseExtension<TDac> : PXGraphExtension<MyGraph>
+	where TDac : IBqlTable
+	{
+		public virtual TDac TestMethod1(TDac x, bool drilldown, double y)
+		{
+			return x;
+		}
+	}
+
+
+	public class MyGraph : PXGraph<MyGraph>
+	{
+		public virtual void TestMethod2(Func<string> func, IEnumerable<List<string>> itemsLists)
+		{
+		}
+
+		protected internal virtual object TestMethod3(Func<string> func, int x, IEnumerable<List<string>> itemsLists)
+		{
+			return new();
+		}
+
+		protected virtual string TestMethod4(string x)
+		{
+			return string.Empty;
+		}
+	}
+
+	[PXHidden]
+	public class MyDac : IBqlTable
+	{
+	}
+}

--- a/src/Samples/PX.Objects.HackathonDemo/PX.Objects.HackathonDemo/PX.Objects.HackathonDemo.csproj
+++ b/src/Samples/PX.Objects.HackathonDemo/PX.Objects.HackathonDemo/PX.Objects.HackathonDemo.csproj
@@ -15,6 +15,7 @@
     <AssemblyName>PX.Objects.HackathonDemo</AssemblyName>
     <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -136,6 +137,7 @@
     <Compile Include="CallsToInternalAPI\GraphUsingInternalApi.cs" />
     <Compile Include="Graph\Graph with workflow\SOInvoiceEntry_Workflow.cs" />
     <Compile Include="Graph\OverrideTest\GraphExtensionsWithOverrides.cs" />
+    <Compile Include="Graph\OverrideTest\PXOverridesExample.cs" />
     <Compile Include="Graph\Start row reset for paging\LEPMaint.cs" />
     <Compile Include="Graph\Static fields and properties in graph\POCustomOrderEntry.cs" />
     <Compile Include="Graph\View Order\DAC\ARTran.cs" />


### PR DESCRIPTION
Implementation of diagnostic PX1098 that checks for XML comment with reference to the base method on `PXOverride`

**Changes Overview:**

**PX1098 Diagnostic**
- Implemented PX1098 diagnostic
- Implemented PX1098 code fix
- Implemented unit tests for PX1098 and updated unit tests for other  `PXOverride`  diagnostics
- Wrote documentation for PX1098 and updated documentation for other diagnostics for `PXOverride` methods
- Added example to the demo solution

**Utilities**
- Added extension methods that work with trivia list struct collection without boxing
- Added utils for syntax trivias 

**Other**
- Replaced conditional compilation in the base aggregator analyzer with a check whether a debugger is attached to support parallel analysis execution on debug builds
- Added small optimizations to other analyzers