### PR TITLE
Bugfix/atr 798 dev suppression comment not working in chained constructor calls

### DIFF
--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/SuppressDiagnosticFixBase.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/SuppressDiagnosticFixBase.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -63,7 +64,7 @@ namespace Acuminator.Analyzers.StaticAnalysis
 			{
 				RegisterCodeActionForDiagnostic(diagnostic, context);
 			}
-				
+
 			return Task.CompletedTask;
 		}
 
@@ -75,7 +76,7 @@ namespace Acuminator.Analyzers.StaticAnalysis
 			if (groupCodeAction != null)
 			{
 				context.RegisterCodeFix(groupCodeAction, diagnostic);
-			}	
+			}
 		}
 
 		protected virtual CodeAction? GetCodeActionToRegister(Diagnostic diagnostic, CodeFixContext context)
@@ -104,7 +105,7 @@ namespace Acuminator.Analyzers.StaticAnalysis
 
 			// Use reflection based factory to create group code action with nested actions and custom priority.
 			// Setting code action priority is impossible via Roslyn public API.
-			var groupCodeAction = 
+			var groupCodeAction =
 				CodeActionWithNestedActionsFabric.CreateCodeActionWithNestedActions(groupCodeActionName, suppressionCodeActions.ToImmutable()) ??
 				CodeAction.Create(groupCodeActionName, suppressionCodeActions.ToImmutable(), isInlinable: false);
 
@@ -134,10 +135,10 @@ namespace Acuminator.Analyzers.StaticAnalysis
 		{
 			string suppressionFileCodeActionName = nameof(Resources.SuppressDiagnosticInSuppressionFileCodeActionTitle).GetLocalized().ToString();
 			return new SuppressWithSuppressionFileCodeAction(context, diagnostic, suppressionFileCodeActionName,
-															 equivalenceKey: suppressionFileCodeActionName + diagnostic.Id); 
+															 equivalenceKey: suppressionFileCodeActionName + diagnostic.Id);
 		}
 
-		protected virtual async Task<Document> AddSuppressionCommentAsync(CodeFixContext context, Diagnostic diagnostic, 
+		protected virtual async Task<Document> AddSuppressionCommentAsync(CodeFixContext context, Diagnostic diagnostic,
 																		  CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
@@ -149,6 +150,11 @@ namespace Acuminator.Analyzers.StaticAnalysis
 			if (diagnostic == null || reportedNode == null)
 				return document;
 
+			SyntaxNode? nodeToPlaceComment = GetNodeToPlaceComment(reportedNode);
+
+			if (nodeToPlaceComment == null)
+				return document;
+
 			cancellationToken.ThrowIfCancellationRequested();
 
 			var (diagnosticShortName, diagnosticJustification) = GetDiagnosticShortNameAndJustification(diagnostic);
@@ -157,36 +163,67 @@ namespace Acuminator.Analyzers.StaticAnalysis
 				return document;
 
 			string suppressionComment = string.Format(SuppressionCommentFormat, diagnostic.Id, diagnosticShortName, diagnosticJustification);
+			bool isInsideList = nodeToPlaceComment.Parent is BaseArgumentListSyntax or TypeArgumentListSyntax;
+
+			var modifiedRoot = isInsideList
+				? GetNewRootWithSuppressionCommentForArgumentNodeInList(root!, nodeToPlaceComment, suppressionComment)
+				: GetNewRootWithSuppressionCommentForNonListNode(root!, nodeToPlaceComment, suppressionComment);
+
+			return document.WithSyntaxRoot(modifiedRoot);
+		}
+
+		protected virtual SyntaxNode GetNewRootWithSuppressionCommentForArgumentNodeInList(SyntaxNode root, SyntaxNode nodeToPlaceComment,
+																							string suppressionComment)
+		{
+			var suppressionCommentTrivias = new SyntaxTriviaList
+			(
+				SyntaxFactory.SyntaxTrivia(SyntaxKind.SingleLineCommentTrivia, suppressionComment),
+				SyntaxFactory.CarriageReturnLineFeed
+			);
+
+			SyntaxTriviaList oldLeadingTrivia = nodeToPlaceComment.GetLeadingTrivia();
+			SyntaxTriviaList newLeadingTrivia;
+
+			if (oldLeadingTrivia.Count > 0)
+			{
+				var whiteSpaceIndentationTrivia = oldLeadingTrivia.TakeWhile((in SyntaxTrivia t) => !t.IsKind(SyntaxKind.EndOfLineTrivia))
+																  .Where(t => !t.IsDirective && t.IsKind(SyntaxKind.WhitespaceTrivia));
+				var mutableTriviaList = whiteSpaceIndentationTrivia.ToList(capacity: oldLeadingTrivia.Count);
+				mutableTriviaList.AddRange(suppressionCommentTrivias);
+				mutableTriviaList.AddRange(oldLeadingTrivia);
+
+				newLeadingTrivia = new SyntaxTriviaList(mutableTriviaList);
+			}
+			else
+				newLeadingTrivia = suppressionCommentTrivias;
+
+			var nodeWithSuppressionComment = nodeToPlaceComment.WithLeadingTrivia(newLeadingTrivia);
+			var modifiedRoot = root.ReplaceNode(nodeToPlaceComment, nodeWithSuppressionComment);
+
+			return modifiedRoot;
+		}
+
+		protected virtual SyntaxNode GetNewRootWithSuppressionCommentForNonListNode(SyntaxNode root, SyntaxNode nodeToPlaceComment,
+																					string suppressionComment)
+		{
 			var suppressionCommentTrivias = new SyntaxTrivia[]
 			{
 				SyntaxFactory.SyntaxTrivia(SyntaxKind.SingleLineCommentTrivia, suppressionComment),
-				SyntaxFactory.ElasticEndOfLine("")
+				SyntaxFactory.ElasticEndOfLine(string.Empty)
 			};
-
-			SyntaxNode? nodeToPlaceComment = reportedNode;
-
-			while (nodeToPlaceComment is not (StatementSyntax or MemberDeclarationSyntax or UsingDirectiveSyntax or null))
-			{
-				nodeToPlaceComment = nodeToPlaceComment.Parent;
-			}
-
-			if (nodeToPlaceComment == null)
-				return document;
 
 			SyntaxTriviaList leadingTrivia = nodeToPlaceComment.GetLeadingTrivia();
 			SyntaxNode? modifiedRoot;
 
 			if (leadingTrivia.Count > 0)
-				modifiedRoot = root!.InsertTriviaAfter(leadingTrivia.Last(), suppressionCommentTrivias);
+				modifiedRoot = root.InsertTriviaAfter(leadingTrivia.Last(), suppressionCommentTrivias);
 			else
 			{
 				var nodeWithSuppressionComment = nodeToPlaceComment.WithLeadingTrivia(suppressionCommentTrivias);
-				modifiedRoot = root!.ReplaceNode(nodeToPlaceComment, nodeWithSuppressionComment);
+				modifiedRoot = root.ReplaceNode(nodeToPlaceComment, nodeWithSuppressionComment);
 			}
 
-			return modifiedRoot != null
-				? document.WithSyntaxRoot(modifiedRoot)
-				: document;
+			return modifiedRoot;
 		}
 
 		protected (string? DiagnosticShortName, string? DiagnosticJustification) GetDiagnosticShortNameAndJustification(Diagnostic diagnostic)
@@ -203,5 +240,20 @@ namespace Acuminator.Analyzers.StaticAnalysis
 
 			return (diagnosticShortName, diagnosticJustification);
 		}
+
+		protected SyntaxNode? GetNodeToPlaceComment(SyntaxNode reportedNode)
+		{
+			SyntaxNode? nodeToPlaceComment = reportedNode;
+			while (nodeToPlaceComment != null && !CanPlaceCommentAboveNode(nodeToPlaceComment))
+			{
+				nodeToPlaceComment = nodeToPlaceComment.Parent;
+			}
+
+			return nodeToPlaceComment;
+		}
+
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		protected bool CanPlaceCommentAboveNode(SyntaxNode node) =>
+			node is StatementSyntax or ArgumentSyntax or MemberDeclarationSyntax or UsingDirectiveSyntax;
 	}
 }

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/SuppressDiagnosticFixBase.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/SuppressDiagnosticFixBase.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -12,6 +11,7 @@ using Acuminator.Utilities.Common;
 using Acuminator.Utilities.DiagnosticSuppression;
 using Acuminator.Utilities.DiagnosticSuppression.CodeActions;
 using Acuminator.Utilities.Roslyn.CodeActions;
+using Acuminator.Utilities.Roslyn.Syntax;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
@@ -163,7 +163,7 @@ namespace Acuminator.Analyzers.StaticAnalysis
 				return document;
 
 			string suppressionComment = string.Format(SuppressionCommentFormat, diagnostic.Id, diagnosticShortName, diagnosticJustification);
-			bool isInsideList = nodeToPlaceComment.Parent is BaseArgumentListSyntax or TypeArgumentListSyntax;
+			bool isInsideList = nodeToPlaceComment.Parent is BaseArgumentListSyntax or TypeArgumentListSyntax or BaseParameterListSyntax;
 
 			var modifiedRoot = isInsideList
 				? GetNewRootWithSuppressionCommentForArgumentNodeInList(root!, nodeToPlaceComment, suppressionComment)
@@ -172,39 +172,8 @@ namespace Acuminator.Analyzers.StaticAnalysis
 			return document.WithSyntaxRoot(modifiedRoot);
 		}
 
-		protected virtual SyntaxNode GetNewRootWithSuppressionCommentForArgumentNodeInList(SyntaxNode root, SyntaxNode nodeToPlaceComment,
-																							string suppressionComment)
-		{
-			var suppressionCommentTrivias = new SyntaxTriviaList
-			(
-				SyntaxFactory.SyntaxTrivia(SyntaxKind.SingleLineCommentTrivia, suppressionComment),
-				SyntaxFactory.CarriageReturnLineFeed
-			);
-
-			SyntaxTriviaList oldLeadingTrivia = nodeToPlaceComment.GetLeadingTrivia();
-			SyntaxTriviaList newLeadingTrivia;
-
-			if (oldLeadingTrivia.Count > 0)
-			{
-				var whiteSpaceIndentationTrivia = oldLeadingTrivia.TakeWhile((in SyntaxTrivia t) => !t.IsKind(SyntaxKind.EndOfLineTrivia))
-																  .Where(t => !t.IsDirective && t.IsKind(SyntaxKind.WhitespaceTrivia));
-				var mutableTriviaList = whiteSpaceIndentationTrivia.ToList(capacity: oldLeadingTrivia.Count);
-				mutableTriviaList.AddRange(suppressionCommentTrivias);
-				mutableTriviaList.AddRange(oldLeadingTrivia);
-
-				newLeadingTrivia = new SyntaxTriviaList(mutableTriviaList);
-			}
-			else
-				newLeadingTrivia = suppressionCommentTrivias;
-
-			var nodeWithSuppressionComment = nodeToPlaceComment.WithLeadingTrivia(newLeadingTrivia);
-			var modifiedRoot = root.ReplaceNode(nodeToPlaceComment, nodeWithSuppressionComment);
-
-			return modifiedRoot;
-		}
-
-		protected virtual SyntaxNode GetNewRootWithSuppressionCommentForNonListNode(SyntaxNode root, SyntaxNode nodeToPlaceComment,
-																					string suppressionComment)
+		protected SyntaxNode GetNewRootWithSuppressionCommentForNonListNode(SyntaxNode root, SyntaxNode nodeToPlaceComment,
+																			string suppressionComment)
 		{
 			var suppressionCommentTrivias = new SyntaxTrivia[]
 			{
@@ -224,6 +193,91 @@ namespace Acuminator.Analyzers.StaticAnalysis
 			}
 
 			return modifiedRoot;
+		}
+
+		protected SyntaxNode GetNewRootWithSuppressionCommentForArgumentNodeInList(SyntaxNode root, SyntaxNode nodeToPlaceComment,
+																					string suppressionComment)
+		{
+			bool shouldAddNewLineBeforeComment = ShouldAddNewLineBeforeComment(nodeToPlaceComment);
+
+			SyntaxTriviaList oldLeadingTrivia  = nodeToPlaceComment.GetLeadingTrivia();
+			var whiteSpaceIndentationTrivia	   = GetWhiteSpaceTrivia(oldLeadingTrivia);
+
+			var parentLeadingTrivia 				  = GetParentTrivia(nodeToPlaceComment);
+			var whiteSpaceIndentationParentTrivia = GetWhiteSpaceTrivia(parentLeadingTrivia);
+
+			bool oldTriviaStartsWithNewLine = 
+				!shouldAddNewLineBeforeComment && oldLeadingTrivia.Count > 0 && oldLeadingTrivia[0].IsKind(SyntaxKind.EndOfLineTrivia);
+			var suppressionCommentTriviasMutableList = new List<SyntaxTrivia>(capacity: 16);
+
+			if (shouldAddNewLineBeforeComment || oldTriviaStartsWithNewLine)
+			{
+				suppressionCommentTriviasMutableList.Add(SyntaxFactory.CarriageReturnLineFeed);
+
+				if (shouldAddNewLineBeforeComment)
+				{
+					suppressionCommentTriviasMutableList.AddRange(whiteSpaceIndentationParentTrivia);
+					suppressionCommentTriviasMutableList.Add(SyntaxFactory.Tab);
+					suppressionCommentTriviasMutableList.Add(SyntaxFactory.Tab);
+				}
+			}
+
+			suppressionCommentTriviasMutableList.AddRange(whiteSpaceIndentationTrivia);
+			suppressionCommentTriviasMutableList.Add(SyntaxFactory.SyntaxTrivia(SyntaxKind.SingleLineCommentTrivia, suppressionComment));
+
+			if (!oldTriviaStartsWithNewLine)
+			{
+				suppressionCommentTriviasMutableList.Add(SyntaxFactory.CarriageReturnLineFeed);
+
+				if (shouldAddNewLineBeforeComment)
+				{
+					suppressionCommentTriviasMutableList.AddRange(whiteSpaceIndentationParentTrivia);
+					suppressionCommentTriviasMutableList.Add(SyntaxFactory.Tab);
+					suppressionCommentTriviasMutableList.Add(SyntaxFactory.Tab);
+				}
+			}
+
+			suppressionCommentTriviasMutableList.AddRange(oldLeadingTrivia);
+
+			var newLeadingTrivia = new SyntaxTriviaList(suppressionCommentTriviasMutableList);
+			var nodeWithSuppressionComment = nodeToPlaceComment.WithLeadingTrivia(newLeadingTrivia);
+			var modifiedRoot = root.ReplaceNode(nodeToPlaceComment, nodeWithSuppressionComment);
+
+			return modifiedRoot;
+		}
+
+		private bool ShouldAddNewLineBeforeComment(SyntaxNode nodeToPlaceComment)
+		{
+			if (nodeToPlaceComment.Parent == null)  // in all uncertain cases add new line for safety
+				return true;
+
+			var nodeLocation  = nodeToPlaceComment.GetLocation();
+			var nodeLineSpan  = nodeLocation.GetLineSpan();
+
+			var parentLocation = nodeToPlaceComment.Parent.GetLocation();
+			var parentLineSpan = parentLocation.GetLineSpan();
+
+			// Node with a comment is on the same line as the parent list => need to add new line
+			if (parentLineSpan.StartLinePosition.Line == nodeLineSpan.StartLinePosition.Line)
+				return true;
+
+			var arguments = GetArguments(nodeToPlaceComment.Parent);
+
+			if (arguments?.Count is null or 0)
+				return true;
+
+			int nodeToPlaceCommentIndex = arguments.FindIndex(argNode => argNode.Equals(nodeToPlaceComment));
+
+			// Node with a comment is first in the list and on a different line than the parent => no need to add new line
+			if (nodeToPlaceCommentIndex <= 0)	
+				return false;
+
+			var previousArgument = arguments[nodeToPlaceCommentIndex - 1];
+			var previousArgumentLocation = previousArgument.GetLocation();
+			var previousArgumentLineSpan = previousArgumentLocation.GetLineSpan();
+
+			// Node with a comment is on the same line as the previous argument => need to add new line
+			return previousArgumentLineSpan.EndLinePosition.Line == nodeLineSpan.StartLinePosition.Line;
 		}
 
 		protected (string? DiagnosticShortName, string? DiagnosticJustification) GetDiagnosticShortNameAndJustification(Diagnostic diagnostic)
@@ -250,6 +304,39 @@ namespace Acuminator.Analyzers.StaticAnalysis
 			}
 
 			return nodeToPlaceComment;
+		}
+
+		private static IReadOnlyList<SyntaxNode>? GetArguments(SyntaxNode listNode) =>
+			listNode switch
+			{
+				BaseArgumentListSyntax baseArgList		  => baseArgList.Arguments,
+				BaseParameterListSyntax baseParameterList => baseParameterList.Parameters,
+				TypeArgumentListSyntax typeArgumentList	  => typeArgumentList.Arguments,
+				_ 										  => null
+			};
+
+		private static SyntaxTriviaList? GetParentTrivia(SyntaxNode nodeToPlaceComment)
+		{
+			SyntaxNode? nodeToGetTrivia = nodeToPlaceComment;
+
+			while (nodeToGetTrivia != null && !SuppressionExtensions.ShouldStopSearchForSuppressionComment(nodeToGetTrivia))
+			{
+				nodeToGetTrivia = nodeToGetTrivia.Parent;
+			}
+
+			return nodeToGetTrivia?.GetLeadingTrivia();
+		}
+
+		private static List<SyntaxTrivia> GetWhiteSpaceTrivia(in SyntaxTriviaList? trivia)
+		{
+			if (trivia?.Count is null or 0)
+				return [];
+
+			return trivia.Value.Reverse()
+							   .TakeWhile((in SyntaxTrivia t) => !t.IsKind(SyntaxKind.EndOfLineTrivia))
+							   .Where(t => !t.IsDirective && t.IsKind(SyntaxKind.WhitespaceTrivia))
+							   .Reverse()
+							   .ToList(trivia.Value.Count);
 		}
 	}
 }

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/SuppressDiagnosticFixBase.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/SuppressDiagnosticFixBase.cs
@@ -244,16 +244,12 @@ namespace Acuminator.Analyzers.StaticAnalysis
 		protected SyntaxNode? GetNodeToPlaceComment(SyntaxNode reportedNode)
 		{
 			SyntaxNode? nodeToPlaceComment = reportedNode;
-			while (nodeToPlaceComment != null && !CanPlaceCommentAboveNode(nodeToPlaceComment))
+			while (nodeToPlaceComment != null && !SuppressionExtensions.CanNodeContainSuppressionComment(nodeToPlaceComment))
 			{
 				nodeToPlaceComment = nodeToPlaceComment.Parent;
 			}
 
 			return nodeToPlaceComment;
 		}
-
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		protected bool CanPlaceCommentAboveNode(SyntaxNode node) =>
-			node is StatementSyntax or ArgumentSyntax or MemberDeclarationSyntax or UsingDirectiveSyntax;
 	}
 }

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/SuppressionDiagnostics/Sources/Exceptions/PXCustomException.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/SuppressionDiagnostics/Sources/Exceptions/PXCustomException.cs
@@ -1,0 +1,55 @@
+#nullable disable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
+
+using PX.Common;
+using PX.Data;
+
+namespace PX.Objects.HackathonDemo
+{
+	public class PXCustomException : PXSetPropertyException
+	{
+		private const string ErrorFieldProcessing = "Error";
+		private const string ErrorFieldProcessingWithDescriptor = "Error with descriptor";
+
+		public readonly string FieldName;
+
+		protected PXCustomException(string fieldName, Exception inner, PXErrorLevel errorLevel, string format, params object[] args)
+			: base(inner, errorLevel, format, args)
+		{
+			FieldName = fieldName;
+		}
+
+		public PXCustomException(string fieldName, Exception inner, PXErrorLevel errorLevel, params object[] args)
+			: this(fieldName, inner, errorLevel, ErrorMessages.ErrorFieldProcessing, args)
+		{
+		}
+
+		public PXCustomException(string fieldName, bool isWithDescriptor, Exception inner, PXErrorLevel errorLevel,
+										  string fieldNameInErrorMessage, string errorText)
+			: this(fieldName, inner, errorLevel,
+				   format: GetExceptionMessageFormat(isWithDescriptor),
+				   args: new[] { fieldNameInErrorMessage, errorText })
+		{
+		}
+
+		public PXCustomException(SerializationInfo info, StreamingContext context)
+			: base(info, context)
+		{
+			PXReflectionSerializer.RestoreObjectProps(this, info);
+		}
+
+		public override void GetObjectData(SerializationInfo info, StreamingContext context)
+		{
+			PXReflectionSerializer.GetObjectData(this, info);
+			base.GetObjectData(info, context);
+		}
+
+		private static string GetExceptionMessageFormat(bool isWithDescriptor) =>
+			isWithDescriptor
+				? ErrorFieldProcessingWithDescriptor
+				: ErrorFieldProcessing;
+	}
+}

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/SuppressionDiagnostics/Sources/Exceptions/PXCustomExceptionDifferentFormat.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/SuppressionDiagnostics/Sources/Exceptions/PXCustomExceptionDifferentFormat.cs
@@ -1,0 +1,54 @@
+#nullable disable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
+
+using PX.Common;
+using PX.Data;
+
+namespace PX.Objects.HackathonDemo
+{
+	public class PXCustomException : PXSetPropertyException
+	{
+		private const string ErrorFieldProcessing = "Error";
+		private const string ErrorFieldProcessingWithDescriptor = "Error with descriptor";
+
+		public readonly string FieldName;
+
+		protected PXCustomException(string fieldName, Exception inner, PXErrorLevel errorLevel, string format, params object[] args)
+			: base(inner, errorLevel, format, args)
+		{
+			FieldName = fieldName;
+		}
+
+		public PXCustomException(string fieldName, Exception inner, PXErrorLevel errorLevel, params object[] args)
+			: this(fieldName, inner, errorLevel, ErrorMessages.ErrorFieldProcessing, args)
+		{
+		}
+
+		public PXCustomException(string fieldName, bool isWithDescriptor, Exception inner, PXErrorLevel errorLevel,
+										  string fieldNameInErrorMessage, string errorText)
+			: this(fieldName, inner, errorLevel, format: GetExceptionMessageFormat(isWithDescriptor),
+				   args: new[] { fieldNameInErrorMessage, errorText })
+		{
+		}
+
+		public PXCustomException(SerializationInfo info, StreamingContext context)
+			: base(info, context)
+		{
+			PXReflectionSerializer.RestoreObjectProps(this, info);
+		}
+
+		public override void GetObjectData(SerializationInfo info, StreamingContext context)
+		{
+			PXReflectionSerializer.GetObjectData(this, info);
+			base.GetObjectData(info, context);
+		}
+
+		private static string GetExceptionMessageFormat(bool isWithDescriptor) =>
+			isWithDescriptor
+				? ErrorFieldProcessingWithDescriptor
+				: ErrorFieldProcessing;
+	}
+}

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/SuppressionDiagnostics/Sources/Exceptions/PXCustomExceptionDifferentFormat_Expected.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/SuppressionDiagnostics/Sources/Exceptions/PXCustomExceptionDifferentFormat_Expected.cs
@@ -1,0 +1,57 @@
+#nullable disable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
+
+using PX.Common;
+using PX.Data;
+
+namespace PX.Objects.HackathonDemo
+{
+	public class PXCustomException : PXSetPropertyException
+	{
+		private const string ErrorFieldProcessing = "Error";
+		private const string ErrorFieldProcessingWithDescriptor = "Error with descriptor";
+
+		public readonly string FieldName;
+
+		protected PXCustomException(string fieldName, Exception inner, PXErrorLevel errorLevel, string format, params object[] args)
+			: base(inner, errorLevel, format, args)
+		{
+			FieldName = fieldName;
+		}
+
+		public PXCustomException(string fieldName, Exception inner, PXErrorLevel errorLevel, params object[] args)
+			: this(fieldName, inner, errorLevel, ErrorMessages.ErrorFieldProcessing, args)
+		{
+		}
+
+		public PXCustomException(string fieldName, bool isWithDescriptor, Exception inner, PXErrorLevel errorLevel,
+										  string fieldNameInErrorMessage, string errorText)
+			: this(fieldName, inner, errorLevel, 
+				// Acuminator disable once PX1050 HardcodedStringInLocalizationMethod [Justification]
+				// Acuminator disable once PX1051 NonLocalizableString [Justification]
+				format: GetExceptionMessageFormat(isWithDescriptor),
+				   args: new[] { fieldNameInErrorMessage, errorText })
+		{
+		}
+
+		public PXCustomException(SerializationInfo info, StreamingContext context)
+			: base(info, context)
+		{
+			PXReflectionSerializer.RestoreObjectProps(this, info);
+		}
+
+		public override void GetObjectData(SerializationInfo info, StreamingContext context)
+		{
+			PXReflectionSerializer.GetObjectData(this, info);
+			base.GetObjectData(info, context);
+		}
+
+		private static string GetExceptionMessageFormat(bool isWithDescriptor) =>
+			isWithDescriptor
+				? ErrorFieldProcessingWithDescriptor
+				: ErrorFieldProcessing;
+	}
+}

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/SuppressionDiagnostics/Sources/Exceptions/PXCustomException_Expected.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/SuppressionDiagnostics/Sources/Exceptions/PXCustomException_Expected.cs
@@ -1,0 +1,57 @@
+#nullable disable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
+
+using PX.Common;
+using PX.Data;
+
+namespace PX.Objects.HackathonDemo
+{
+	public class PXCustomException : PXSetPropertyException
+	{
+		private const string ErrorFieldProcessing = "Error";
+		private const string ErrorFieldProcessingWithDescriptor = "Error with descriptor";
+
+		public readonly string FieldName;
+
+		protected PXCustomException(string fieldName, Exception inner, PXErrorLevel errorLevel, string format, params object[] args)
+			: base(inner, errorLevel, format, args)
+		{
+			FieldName = fieldName;
+		}
+
+		public PXCustomException(string fieldName, Exception inner, PXErrorLevel errorLevel, params object[] args)
+			: this(fieldName, inner, errorLevel, ErrorMessages.ErrorFieldProcessing, args)
+		{
+		}
+
+		public PXCustomException(string fieldName, bool isWithDescriptor, Exception inner, PXErrorLevel errorLevel,
+										  string fieldNameInErrorMessage, string errorText)
+			: this(fieldName, inner, errorLevel,
+				   // Acuminator disable once PX1050 HardcodedStringInLocalizationMethod [Justification]
+				   // Acuminator disable once PX1051 NonLocalizableString [Justification]
+				   format: GetExceptionMessageFormat(isWithDescriptor),
+				   args: new[] { fieldNameInErrorMessage, errorText })
+		{
+		}
+
+		public PXCustomException(SerializationInfo info, StreamingContext context)
+			: base(info, context)
+		{
+			PXReflectionSerializer.RestoreObjectProps(this, info);
+		}
+
+		public override void GetObjectData(SerializationInfo info, StreamingContext context)
+		{
+			PXReflectionSerializer.GetObjectData(this, info);
+			base.GetObjectData(info, context);
+		}
+
+		private static string GetExceptionMessageFormat(bool isWithDescriptor) =>
+			isWithDescriptor
+				? ErrorFieldProcessingWithDescriptor
+				: ErrorFieldProcessing;
+	}
+}

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/SuppressionDiagnostics/SuppressDiagnosticTestCodeFix.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/SuppressionDiagnostics/SuppressDiagnosticTestCodeFix.cs
@@ -14,7 +14,7 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.SuppressionDiagnostics
 	{
 		public override ImmutableArray<string> FixableDiagnosticIds => AllCollectedFixableDiagnosticIds;
 
-		public override FixAllProvider GetFixAllProvider() => null;
+		public override FixAllProvider GetFixAllProvider() => null!;
 
 		/// <summary>
 		/// Gets code action to register. OVerrides the default method that returns code action with nested code actions. 

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/SuppressionDiagnostics/SuppressionOnExceptionCodeFixTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/SuppressionDiagnostics/SuppressionOnExceptionCodeFixTests.cs
@@ -1,0 +1,37 @@
+﻿using System.Threading.Tasks;
+
+using Acuminator.Analyzers.StaticAnalysis;
+using Acuminator.Analyzers.StaticAnalysis.Localization;
+using Acuminator.Tests.Helpers;
+using Acuminator.Tests.Verification;
+using Acuminator.Utilities;
+
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using Xunit;
+
+namespace Acuminator.Tests.Tests.StaticAnalysis.SuppressionDiagnostics
+{
+	public class SuppressionOnExceptionCodeFixTests : CodeFixVerifier
+	{
+		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer() =>
+			new LocalizationPXExceptionAndPXExceptionInfoAnalyzer(
+				CodeAnalysisSettings.Default
+									.WithStaticAnalysisEnabled()
+									.WithSuppressionMechanismEnabled()
+									.WithRecursiveAnalysisEnabled());
+
+		protected override CodeFixProvider GetCSharpCodeFixProvider() => new SuppressDiagnosticTestCodeFix();
+
+		[Theory]
+		[EmbeddedFileData(@"Exceptions\PXCustomException_Expected.cs")]
+		public virtual Task CustomException_Alert_ChainedConstructorCall_Suppressed(string source) =>
+			VerifyCSharpDiagnosticAsync(source);
+
+		[Theory]
+		[EmbeddedFileData(@"Exceptions\PXCustomException.cs", @"Exceptions\PXCustomException_Expected.cs")]
+		public virtual Task CustomException_Alert_ChainedConstructorCall_SuppressComment_CodeFix(string actual, string expected) =>
+			VerifyCSharpFixAsync(actual, expected);
+	}
+}

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/SuppressionDiagnostics/SuppressionOnExceptionCodeFixTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/SuppressionDiagnostics/SuppressionOnExceptionCodeFixTests.cs
@@ -26,12 +26,22 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.SuppressionDiagnostics
 
 		[Theory]
 		[EmbeddedFileData(@"Exceptions\PXCustomException_Expected.cs")]
-		public virtual Task CustomException_Alert_ChainedConstructorCall_Suppressed(string source) =>
+		public virtual Task CustomException_Alert_InChainedConstructorCall_Suppressed(string source) =>
+			VerifyCSharpDiagnosticAsync(source);
+
+		[Theory]
+		[EmbeddedFileData(@"Exceptions\PXCustomExceptionDifferentFormat_Expected.cs")]
+		public virtual Task CustomException_DifferentFormat_Alert_InChainedConstructorCall_Suppressed(string source) =>
 			VerifyCSharpDiagnosticAsync(source);
 
 		[Theory]
 		[EmbeddedFileData(@"Exceptions\PXCustomException.cs", @"Exceptions\PXCustomException_Expected.cs")]
-		public virtual Task CustomException_Alert_ChainedConstructorCall_SuppressComment_CodeFix(string actual, string expected) =>
+		public virtual Task CustomException_Alert_InChainedConstructorCall_SuppressComment_CodeFix(string actual, string expected) =>
+			VerifyCSharpFixAsync(actual, expected);
+
+		[Theory]
+		[EmbeddedFileData(@"Exceptions\PXCustomExceptionDifferentFormat.cs", @"Exceptions\PXCustomExceptionDifferentFormat_Expected.cs")]
+		public virtual Task CustomException_DifferentFormat_Alert_InChainedConstructorCall_SuppressComment_CodeFix(string actual, string expected) =>
 			VerifyCSharpFixAsync(actual, expected);
 	}
 }

--- a/src/Acuminator/Acuminator.Utilities/Common/EnumerableExtensions.cs
+++ b/src/Acuminator/Acuminator.Utilities/Common/EnumerableExtensions.cs
@@ -226,5 +226,28 @@ namespace Acuminator.Utilities.Common
 
 			return false;
 		}
+
+		/// <summary>
+		/// Finds the index of the first item matching the <paramref name="predicate"/>.
+		/// </summary>
+		/// <typeparam name="T">Generic type parameter.</typeparam>
+		/// <param name="source">The source to act on.</param>
+		/// <param name="predicate">The predicate.</param>
+		/// <returns>
+		/// The found index.
+		/// </returns>
+		public static int FindIndex<T>(this IReadOnlyList<T> source, Func<T, bool> predicate)
+		{
+			source.ThrowOnNull();
+			predicate.ThrowOnNull();
+
+			for (int i = 0; i < source.Count; i++)
+			{
+				if (predicate(source[i]))
+					return i;
+			}
+
+			return -1;
+		}
 	}
 }

--- a/src/Acuminator/Acuminator.Utilities/DiagnosticSuppression/SuppressionManager.cs
+++ b/src/Acuminator/Acuminator.Utilities/DiagnosticSuppression/SuppressionManager.cs
@@ -345,7 +345,7 @@ namespace Acuminator.Utilities.DiagnosticSuppression
 			{
 				containsComment = CheckSuppressionCommentOnNode(diagnostic, shortName, node, cancellation);
 
-				if (node is (StatementSyntax or MemberDeclarationSyntax or UsingDirectiveSyntax) || containsComment)
+				if (SuppressionExtensions.ShouldStopSearchForSuppressionComment(node) || containsComment)
 					break;
 
 				node = node.Parent;

--- a/src/Acuminator/Acuminator.Utilities/DiagnosticSuppression/Utils/SuppressionExtensions.cs
+++ b/src/Acuminator/Acuminator.Utilities/DiagnosticSuppression/Utils/SuppressionExtensions.cs
@@ -20,7 +20,7 @@ namespace Acuminator.Utilities.DiagnosticSuppression
 			node is StatementSyntax or MemberDeclarationSyntax or UsingDirectiveSyntax or ArgumentSyntax or ParameterSyntax;
 
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		internal static bool ShouldStopSearchForSuppressionComment(SyntaxNode node) =>
+		public static bool ShouldStopSearchForSuppressionComment(SyntaxNode node) =>
 			node is StatementSyntax or MemberDeclarationSyntax or UsingDirectiveSyntax;
 
 		public static void ReportDiagnosticWithSuppressionCheck(this SymbolAnalysisContext context, Diagnostic diagnostic,

--- a/src/Acuminator/Acuminator.Utilities/DiagnosticSuppression/Utils/SuppressionExtensions.cs
+++ b/src/Acuminator/Acuminator.Utilities/DiagnosticSuppression/Utils/SuppressionExtensions.cs
@@ -1,18 +1,28 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Xml.Linq;
 
 using Acuminator.Utilities.Common;
 
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Acuminator.Utilities.DiagnosticSuppression
 {
 	public static class SuppressionExtensions
 	{
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static bool CanNodeContainSuppressionComment(SyntaxNode node) =>
+			node is StatementSyntax or MemberDeclarationSyntax or UsingDirectiveSyntax or ArgumentSyntax or ParameterSyntax;
+
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		internal static bool ShouldStopSearchForSuppressionComment(SyntaxNode node) =>
+			node is StatementSyntax or MemberDeclarationSyntax or UsingDirectiveSyntax;
+
 		public static void ReportDiagnosticWithSuppressionCheck(this SymbolAnalysisContext context, Diagnostic diagnostic,
 																CodeAnalysisSettings settings)
 		{


### PR DESCRIPTION
**Changes Overview**
- Added `FindIndex` `IReadOnlyList` util
- Significantly reworked suppression comment generation to generate suppression comments in argument list nodes 
- Added unit tests for generation of suppression comment in argument list nodes 