### PR TITLE
Feature/atr 507 dev do not require audit fieds and tstamp from projection da cs

### DIFF
--- a/docs/diagnostics/PX1069.md
+++ b/docs/diagnostics/PX1069.md
@@ -28,6 +28,11 @@ There are some exceptions to the PX069 diagnostic when the mandatory fields are 
 
 - The DAC has the `PXAccumulator` attribute or an attribute derived from the `PXAccumulator` attribute. Such DACs are used for special scenarios that involve accumulation of data. 
   These scenarios are handled differently by the Acumatica Framework. Thus, DACs with the `PXAccumulator` attribute do not require audit or timestamp fields.
+- The DAC has the `PXProjection` attribute or an attribute derived from the `PXProjection` attribute. These DACs (also called _projection DACs_) usually represent readonly database views or complex queries 
+  rather than direct table mappings. Such readonly projection DACs do not require audit or timestamp fields.
+
+  However, Acumatica also supports writable projection DACs (also called [_persistent projection DACs_](https://help.acumatica.com/Help?ScreenId=ShowWiki&pageid=e8f097ea-69a0-496d-84d1-807f21b072b4)). 
+  **Such DACs also must declare audit and timestamp fields!** Unfortunately, currently PX1069 diagnostic does not report them.
 - The DAC is fully unbound from the database, meaning there are no tables in the database that correspond to it. Such DACs are also known as **virtual DACs**. They do not require audit or timestamp fields because they do not interact with the database directly and do not persist any audit data.
 - The DAC does not declare any DAC fields. Empty DACs are considered to be the same as virtual DACs in this context.
 
@@ -147,6 +152,7 @@ public class IncompleteDac : PXBqlTable, IBqlTable
 
  - [Audit Fields](https://help.acumatica.com/Help?ScreenId=ShowWiki&pageid=9dd06906-0b2f-498c-a333-cfd641bfbd9e)
  - [Concurrent Update Control (TStamp)](https://help.acumatica.com/Help?ScreenId=ShowWiki&pageid=8d904e5f-2b8c-4d82-a8f5-bc863f8ffc8f)
+ - [Persistent Projection DACs](https://help.acumatica.com/Help?ScreenId=ShowWiki&pageid=e8f097ea-69a0-496d-84d1-807f21b072b4) 
  - [Data Access Classes in Fluent BQL](https://help.acumatica.com/Help?ScreenId=ShowWiki&pageid=957f950d-22cd-4b2f-81ca-77464d0c9eff)
  - [Data Access Classes in Traditional BQL](https://help.acumatica.com/Help?ScreenId=ShowWiki&pageid=a47ddb36-eb85-486f-9d6b-49beac42fc80)
  - [Data Field](https://help.acumatica.com/Help?ScreenId=ShowWiki&pageid=b3d24079-bda4-4f82-9fbd-c444a8bcb733)

--- a/docs/diagnostics/PX1069.md
+++ b/docs/diagnostics/PX1069.md
@@ -32,7 +32,7 @@ There are some exceptions to the PX069 diagnostic when the mandatory fields are 
   rather than direct table mappings. Such readonly projection DACs do not require audit or timestamp fields.
 
   However, Acumatica also supports writable projection DACs (also called [_persistent projection DACs_](https://help.acumatica.com/Help?ScreenId=ShowWiki&pageid=e8f097ea-69a0-496d-84d1-807f21b072b4)). 
-  **Such DACs also must declare audit and timestamp fields!** Unfortunately, currently PX1069 diagnostic does not report them.
+  **Such DACs also must declare audit and timestamp fields!** Currently, the PX1069 diagnostic does not report the absense of these fields in projection DACs.
 - The DAC is fully unbound from the database, meaning there are no tables in the database that correspond to it. Such DACs are also known as **virtual DACs**. They do not require audit or timestamp fields because they do not interact with the database directly and do not persist any audit data.
 - The DAC does not declare any DAC fields. Empty DACs are considered to be the same as virtual DACs in this context.
 

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/MissingMandatoryDacFields/MissingMandatoryDacFieldsAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/MissingMandatoryDacFields/MissingMandatoryDacFieldsAnalyzer.cs
@@ -33,11 +33,14 @@ public class MissingMandatoryDacFieldsAnalyzer : DacAggregatedAnalyzerBase
 
 	public override void Analyze(SymbolAnalysisContext symbolContext, PXContext pxContext, DacSemanticModel dac)
 	{
-		var missingMandatoryDacFieldKinds = GetMissingMandatoryDacFieldsInfos(dac, symbolContext.CancellationToken);
-
-		if (missingMandatoryDacFieldKinds.Count > 0)
+		if (!dac.IsProjectionDac)
 		{
-			ReportMissingMandatoryTimestampAndAuditDacFields(symbolContext, pxContext, dac, missingMandatoryDacFieldKinds);
+			var missingMandatoryDacFieldKinds = GetMissingMandatoryDacFieldsInfos(dac, symbolContext.CancellationToken);
+
+			if (missingMandatoryDacFieldKinds.Count > 0)
+			{
+				ReportMissingMandatoryTimestampAndAuditDacFields(symbolContext, pxContext, dac, missingMandatoryDacFieldKinds);
+			}
 		}
 
 		var missingNoteIdFieldInfo = GetMissingNoteIdFieldInfo(dac, pxContext);

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/MissingMandatoryDacFields/MissingMandatoryDacFieldsTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/MissingMandatoryDacFields/MissingMandatoryDacFieldsTests.cs
@@ -65,6 +65,11 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.MissingMandatoryDacFields
 			await VerifyCSharpDiagnosticAsync(source);
 
 		[Theory]
+		[EmbeddedFileData("ProjectionDac.cs", "ProjectionDac.BaseDac.cs")]
+		public async Task ProjectionDac_NoDiagnostic(string source, string baseDacSource) =>
+			await VerifyCSharpDiagnosticAsync(source, baseDacSource);
+
+		[Theory]
 		[EmbeddedFileData(@"PX1069CodeFix\SealedDacWithoutAnyMandatoryField_Expected.cs")]
 		public async Task SealedDac_WithoutAnyMandatoryField_AfterCodeFix_NoDiagnostic(string source) =>
 			await VerifyCSharpDiagnosticAsync(source);

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/MissingMandatoryDacFields/Sources/ProjectionDac.BaseDac.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/MissingMandatoryDacFields/Sources/ProjectionDac.BaseDac.cs
@@ -1,0 +1,25 @@
+using System;
+
+using PX.Data;
+using PX.Data.BQL;
+
+namespace Acuminator.Tests.Sources
+{
+	// Acuminator disable once PX1069 MissingMandatoryDacFields This DAC should not be reported, the goal of test is to check the projection DAC
+	/// <exclude/>
+	[PXCacheName("Base DAC")]
+	public class BaseDac : IBqlTable
+	{
+		#region ID
+		[PXDBIdentity(IsKey = true)]
+		public int? ID { get; set; }
+		public abstract class iD : BqlInt.Field<iD> { }
+		#endregion
+
+		#region Description
+		[PXDBString(255)]
+		public string? Description { get; set; }
+		public abstract class description : BqlString.Field<description> { }
+		#endregion
+	}
+}

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/MissingMandatoryDacFields/Sources/ProjectionDac.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/MissingMandatoryDacFields/Sources/ProjectionDac.cs
@@ -1,0 +1,47 @@
+using System;
+
+using PX.Data;
+using PX.Data.BQL;
+
+namespace Acuminator.Tests.Sources
+{
+	/// <exclude/>
+	[PXProjection(typeof(Select<BaseDac>))]
+	[PXCacheName("Projection DAC")]
+	public class ProjectionDac : IBqlTable
+	{
+		#region ID
+		public abstract class iD : BqlInt.Field<iD> { }
+
+		[PXDBIdentity(IsKey = true, BqlField = typeof(BaseDac.iD))]
+		public virtual int? ID { get; set; }
+		#endregion
+
+		#region Description
+		public abstract class description : BqlString.Field<description> { }
+
+		[PXDBString(255)]
+		public virtual string? Description { get; set; }
+		#endregion
+	}
+
+	/// <exclude/>
+	[PXProjection(typeof(Select<BaseDac>), Persistent = true)]
+	[PXCacheName("Projection DAC")]
+	public class PersistentProjectionDac : IBqlTable
+	{
+		#region ID
+		public abstract class iD : BqlInt.Field<iD> { }
+
+		[PXDBIdentity(IsKey = true, BqlField = typeof(BaseDac.iD))]
+		public virtual int? ID { get; set; }
+		#endregion
+
+		#region Description
+		public abstract class description : BqlString.Field<description> { }
+
+		[PXDBString(255)]
+		public virtual string? Description { get; set; }
+		#endregion
+	}
+}


### PR DESCRIPTION
Enhanced the PX1069 diagnostic to not require audit and tstamp DAC fields from projection DACs.

**Changes Overview**
- Updated the PX1069 diagnostic analyzer to not report all projection DACs. 
The persistent projection DACs won't be reported too due to the complications in the analysis required to check if the DAC is a persistent projection DAC. The follow-up CR ATR-916 was created to support persistent projection DACs correctly in the future.
- Added unit test case to verify that projection DACs do not trigger PX1069.  
- Updated documentation for PX1069 to clarify behavior for projection DACs and persistent projection DACs.