### PR TITLE
Feature/atr 777 dev graphs and graph extensions not sealed

### DIFF
--- a/docs/Summary.md
+++ b/docs/Summary.md
@@ -113,4 +113,4 @@ Acuminator does not perform static analysis of projects whose names contain `Tes
 | [PX1110](diagnostics/PX1110.md) | The DAC has a DAC field with the `PXDBLocalizableString` attribute. Therefore, this DAC must declare a `NoteID` DAC field. | Error | Available |
 | [PX1111](diagnostics/PX1111.md) | The primary DAC of a processing view must contain the `NoteID` field. | Error | Unavailable |
 | [PX1112](diagnostics/PX1112.md) | Graphs and graph extensions with generic type parameters must be abstract. | Error | Available |
-| [PX1113](diagnostics/PX1113.md) | Graphs and graph extensions cannot be `sealed` types. | Error | Available |
+| [PX1113](diagnostics/PX1113.md) | Graphs and graph extensions should not be `sealed` types. | Warning | Available |

--- a/docs/Summary.md
+++ b/docs/Summary.md
@@ -113,3 +113,4 @@ Acuminator does not perform static analysis of projects whose names contain `Tes
 | [PX1110](diagnostics/PX1110.md) | The DAC has a DAC field with the `PXDBLocalizableString` attribute. Therefore, this DAC must declare a `NoteID` DAC field. | Error | Available |
 | [PX1111](diagnostics/PX1111.md) | The primary DAC of a processing view must contain the `NoteID` field. | Error | Unavailable |
 | [PX1112](diagnostics/PX1112.md) | Graphs and graph extensions with generic type parameters must be abstract. | Error | Available |
+| [PX1113](diagnostics/PX1113.md) | Graphs and graph extensions cannot be `sealed` types. | Error | Available |

--- a/docs/diagnostics/PX1113.md
+++ b/docs/diagnostics/PX1113.md
@@ -1,0 +1,58 @@
+# PX1113
+This document describes the PX1113 diagnostic.
+
+## Summary
+
+| Code   | Short Description                                     | Type  | Code Fix  | 
+| ------ | ----------------------------------------------------- | ----- | --------- | 
+| PX1113 | Graphs and graph extensions cannot be `sealed` types. | Error | Available |
+
+## Diagnostic Description
+
+The PX1113 diagnostic detects graphs and graph extensions that are incorrectly marked with the `sealed` modifier.
+
+Graphs and graph extensions in Acumatica Framework must not be `sealed` types because the framework's customization mechanism depends on the ability to inherit from and extend existing business logic components. 
+When the `PXGraph.CreateInstance` factory method creates a graph instance, the Acumatica runtime dynamically generates derived types from the instantiated graph and its associated graph extensions. 
+Within these dynamically generated types, the runtime applies and combines logic from applicable graph extensions. Declaring graphs or graph extensions as `sealed` prevents this dynamic type generation, 
+making customization impossible and causing runtime errors when attempting to extend such types.
+
+## Code Fix Behavior
+
+The PX1113 code fix automatically removes the `sealed` modifier from the graph or graph extension declaration.
+
+## Example of Incorrect Code
+
+```C#
+using PX.Data;
+
+namespace Examples
+{
+	// Sealed graph - reports PX1113
+	public sealed class OrderGraph<TOrderDac> : PXGraph<GenericOrderGraph<TOrderDac>>
+	where TOrderDac : PXBqlTable, IBqlTable, new()
+	{
+		// Business logic
+	}
+}
+```
+
+## Example of Correct Code after Code Fix
+
+```C#
+using PX.Data;
+
+namespace Examples
+{
+	public class OrderGraph<TOrderDac> : PXGraph<GenericOrderGraph<TOrderDac>>
+	where TOrderDac : PXBqlTable, IBqlTable, new()
+	{
+		// Business logic
+	}
+}
+```
+
+## Related Articles
+
+ - [Business Logic Implementation](https://help.acumatica.com/Help?ScreenId=ShowWiki&pageid=b02bd27f-3e86-4210-9e0f-c0df7aa701d9)
+ - [Use of Generic Graph Extensions by the System](https://help.acumatica.com/Help?ScreenId=ShowWiki&pageid=eece8358-f6ea-47e8-899a-d466eccbc14e)
+ - [Reusing Business Logic](https://help.acumatica.com/Help?ScreenId=ShowWiki&pageid=76b8c160-89bd-4501-9f9f-1dabc648d417)

--- a/docs/diagnostics/PX1113.md
+++ b/docs/diagnostics/PX1113.md
@@ -3,18 +3,22 @@ This document describes the PX1113 diagnostic.
 
 ## Summary
 
-| Code   | Short Description                                     | Type  | Code Fix  | 
-| ------ | ----------------------------------------------------- | ----- | --------- | 
-| PX1113 | Graphs and graph extensions cannot be `sealed` types. | Error | Available |
+| Code   | Short Description                                         |  Type   | Code Fix  |
+| ------ | --------------------------------------------------------- | ------- | --------- |
+| PX1113 | Graphs and graph extensions should not be `sealed` types. | Warning | Available |
 
 ## Diagnostic Description
 
-The PX1113 diagnostic detects graphs and graph extensions that are incorrectly marked with the `sealed` modifier.
+The PX1113 diagnostic detects graphs and graph extensions marked with the `sealed` modifier.
 
 Graphs and graph extensions in Acumatica Framework must not be `sealed` types because the framework's customization mechanism depends on the ability to inherit from and extend existing business logic components. 
 When the `PXGraph.CreateInstance` factory method creates a graph instance, the Acumatica runtime dynamically generates derived types from the instantiated graph and its associated graph extensions. 
-Within these dynamically generated types, the runtime applies and combines logic from applicable graph extensions. Declaring graphs or graph extensions as `sealed` prevents this dynamic type generation, 
-making customization impossible and causing runtime errors when attempting to extend such types.
+Within these dynamically generated types, the runtime applies and combines logic from applicable graph extensions. 
+
+Declaring graphs or graph extensions as `sealed` prevents this dynamic type generation, making customization impossible and causing runtime errors when attempting to extend such types.
+This goes against Acumatica Framework design best practices which promote extensibility and reusability of business logic. Thus, the diagnostic PX1113 issues a warning for any graph or graph extension declared as `sealed`.
+
+In a rare scenario when the `sealed` modifier is intentionally used to prevent the extension of the business logic, developers should suppress the alert from PX1113 diagnostic with Acuminator suppression comment.
 
 ## Code Fix Behavior
 

--- a/src/Acuminator/Acuminator.Analyzers/DiagnosticsShortName.Designer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/DiagnosticsShortName.Designer.cs
@@ -1103,5 +1103,14 @@ namespace Acuminator.Analyzers {
                 return ResourceManager.GetString("PX1112", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to SealedGraphOrGraphExtension.
+        /// </summary>
+        public static string PX1113 {
+            get {
+                return ResourceManager.GetString("PX1113", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Acuminator/Acuminator.Analyzers/DiagnosticsShortName.resx
+++ b/src/Acuminator/Acuminator.Analyzers/DiagnosticsShortName.resx
@@ -465,4 +465,7 @@
   <data name="PX1112" xml:space="preserve">
     <value>GenericNonAbstractGraphOrGraphExtension</value>
   </data>
+  <data name="PX1113" xml:space="preserve">
+    <value>SealedGraphOrGraphExtension</value>
+  </data>
 </root>

--- a/src/Acuminator/Acuminator.Analyzers/Resources.Designer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/Resources.Designer.cs
@@ -2313,6 +2313,24 @@ namespace Acuminator.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Remove &quot;sealed&quot; modifier from the type.
+        /// </summary>
+        public static string PX1113Fix {
+            get {
+                return ResourceManager.GetString("PX1113Fix", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Graphs and graph extensions cannot be sealed types.
+        /// </summary>
+        public static string PX1113Title {
+            get {
+                return ResourceManager.GetString("PX1113Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Suppress the {0} diagnostic with Acuminator.
         /// </summary>
         public static string SuppressDiagnosticGroupCodeActionTitle {

--- a/src/Acuminator/Acuminator.Analyzers/Resources.Designer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/Resources.Designer.cs
@@ -2322,7 +2322,7 @@ namespace Acuminator.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Graphs and graph extensions cannot be sealed types.
+        ///   Looks up a localized string similar to Graphs and graph extensions should not be sealed types.
         /// </summary>
         public static string PX1113Title {
             get {

--- a/src/Acuminator/Acuminator.Analyzers/Resources.resx
+++ b/src/Acuminator/Acuminator.Analyzers/Resources.resx
@@ -879,7 +879,7 @@ Reason: {2}</value>
     <value>Remove "sealed" modifier from the type</value>
   </data>
   <data name="PX1113Title" xml:space="preserve">
-    <value>Graphs and graph extensions cannot be sealed types</value>
+    <value>Graphs and graph extensions should not be sealed types</value>
   </data>
   <data name="SuppressDiagnosticGroupCodeActionTitle" xml:space="preserve">
     <value>Suppress the {0} diagnostic with Acuminator</value>

--- a/src/Acuminator/Acuminator.Analyzers/Resources.resx
+++ b/src/Acuminator/Acuminator.Analyzers/Resources.resx
@@ -875,6 +875,12 @@ Reason: {2}</value>
   <data name="PX1112Title" xml:space="preserve">
     <value>Graphs and graph extensions with generic type parameters must be abstract</value>
   </data>
+  <data name="PX1113Fix" xml:space="preserve">
+    <value>Remove "sealed" modifier from the type</value>
+  </data>
+  <data name="PX1113Title" xml:space="preserve">
+    <value>Graphs and graph extensions cannot be sealed types</value>
+  </data>
   <data name="SuppressDiagnosticGroupCodeActionTitle" xml:space="preserve">
     <value>Suppress the {0} diagnostic with Acuminator</value>
   </data>

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/DeclarationAnalysisGraphAndDac/GraphAndGraphExtensionDeclarationAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/DeclarationAnalysisGraphAndDac/GraphAndGraphExtensionDeclarationAnalyzer.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using System.Threading;
 
 using Acuminator.Analyzers.StaticAnalysis.PXGraph;
 using Acuminator.Utilities.Common;
@@ -22,29 +22,50 @@ namespace Acuminator.Analyzers.StaticAnalysis.DeclarationAnalysisGraphAndDac
 		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
 			ImmutableArray.Create
 			(
-				Descriptors.PX1112_GenericGraphsAndGraphExtensionsMustBeAbstract
+				Descriptors.PX1112_GenericGraphsAndGraphExtensionsMustBeAbstract,
+				Descriptors.PX1113_SealedGraphsAndGraphExtensions
 			);
 
 		public override void Analyze(SymbolAnalysisContext context, PXContext pxContext, PXGraphEventSemanticModel graphOrGraphExt)
 		{
 			context.CancellationToken.ThrowIfCancellationRequested();
-
 			CheckIfGraphOrGraphExtensionIsGenericNonAbstract(context, pxContext, graphOrGraphExt);
+
+			context.CancellationToken.ThrowIfCancellationRequested();
+			CheckIfGraphOrGraphExtensionIsSealed(context, pxContext, graphOrGraphExt);
 		}
 
 		protected virtual void CheckIfGraphOrGraphExtensionIsGenericNonAbstract(SymbolAnalysisContext context, PXContext pxContext,
 																				PXGraphEventSemanticModel graphOrGraphExt)
 		{
 			if (graphOrGraphExt.Symbol.IsAbstract || !graphOrGraphExt.Symbol.IsGenericType ||
-				graphOrGraphExt.Symbol.TypeParameters.IsDefaultOrEmpty || graphOrGraphExt.Node == null)
+				graphOrGraphExt.Symbol.TypeParameters.IsDefaultOrEmpty)
 			{
 				return;
 			}
 			
-			var location = graphOrGraphExt.Node.Identifier.GetLocation().NullIfLocationKindIsNone() ??
+			var location = graphOrGraphExt.Node!.Identifier.GetLocation().NullIfLocationKindIsNone() ??
 						   graphOrGraphExt.Node.GetLocation();
 			var diagnostic = Diagnostic.Create(Descriptors.PX1112_GenericGraphsAndGraphExtensionsMustBeAbstract, location,
 												graphOrGraphExt.Symbol.Name);
+
+			context.ReportDiagnosticWithSuppressionCheck(diagnostic, pxContext.CodeAnalysisSettings);
+		}
+
+		protected virtual void CheckIfGraphOrGraphExtensionIsSealed(SymbolAnalysisContext context, PXContext pxContext,
+																	PXGraphEventSemanticModel graphOrGraphExt)
+		{
+			if (!graphOrGraphExt.Symbol.IsSealed)
+				return;
+
+			var sealedToken = graphOrGraphExt.Node!.Modifiers.FirstOrDefault(m => m.IsKind(SyntaxKind.SealedKeyword));
+			var location = sealedToken != default
+				? sealedToken.GetLocation().NullIfLocationKindIsNone()
+				: null;
+
+			location ??= graphOrGraphExt.Node.Identifier.GetLocation().NullIfLocationKindIsNone() ??
+						 graphOrGraphExt.Node.GetLocation();
+			var diagnostic = Diagnostic.Create(Descriptors.PX1113_SealedGraphsAndGraphExtensions, location, graphOrGraphExt.Symbol.Name);
 
 			context.ReportDiagnosticWithSuppressionCheck(diagnostic, pxContext.CodeAnalysisSettings);
 		}

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/DeclarationAnalysisGraphAndDac/TypeModifiersFix.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/DeclarationAnalysisGraphAndDac/TypeModifiersFix.cs
@@ -28,36 +28,38 @@ namespace Acuminator.Analyzers.StaticAnalysis.DeclarationAnalysisGraphAndDac
 			new HashSet<string>
 			{
 				Descriptors.PX1112_GenericGraphsAndGraphExtensionsMustBeAbstract.Id,
+				Descriptors.PX1113_SealedGraphsAndGraphExtensions.Id
 			}
 			.ToImmutableArray();
 
 		protected override Task RegisterCodeFixesForDiagnosticAsync(CodeFixContext context, Diagnostic diagnostic)
 		{
-			bool removeSealedModifier, addAbstractModifier;
+			bool addAbstractModifier;
 			string codeActionName;
 
 			if (diagnostic.Id == Descriptors.PX1112_GenericGraphsAndGraphExtensionsMustBeAbstract.Id)
 			{
-				addAbstractModifier  = true;
-				removeSealedModifier = true;
-				codeActionName 		 = nameof(Resources.PX1112Fix).GetLocalized().ToString();
+				addAbstractModifier = true;
+				codeActionName 		= nameof(Resources.PX1112Fix).GetLocalized().ToString();
+			}
+			else if (diagnostic.Id == Descriptors.PX1113_SealedGraphsAndGraphExtensions.Id)
+			{
+				addAbstractModifier = false;
+				codeActionName 		= nameof(Resources.PX1113Fix).GetLocalized().ToString();
 			}
 			else
-			{
 				return Task.CompletedTask;
-			}
 
 			context.CancellationToken.ThrowIfCancellationRequested();
 
 			var codeAction = CodeAction.Create(codeActionName,
-											   cToken => UpdateTypeModifiers(context.Document, context.Span, removeSealedModifier, 
-																			 addAbstractModifier, cToken),
+											   cToken => UpdateTypeModifiers(context.Document, context.Span, addAbstractModifier, cToken),
 											   equivalenceKey: codeActionName);
 			context.RegisterCodeFix(codeAction, diagnostic);
 			return Task.CompletedTask;
 		}
 
-		private async Task<Solution> UpdateTypeModifiers(Document document, TextSpan span, bool removeSealedModifier, bool addAbstractModifier,
+		private async Task<Solution> UpdateTypeModifiers(Document document, TextSpan span, bool addAbstractModifier,
 														 CancellationToken cancellationToken)
 		{
 			Solution originalSolution = document.Project.Solution;
@@ -84,22 +86,22 @@ namespace Acuminator.Analyzers.StaticAnalysis.DeclarationAnalysisGraphAndDac
 			if (typeDeclarations.Length <= 1)
 			{
 				var changedSolutionForNonPartialType = UpdateTypeNodeModifiersForNonPartialType(document, root, graphOrDacOrExtensionToMakePublicNode,
-																								removeSealedModifier, addAbstractModifier);
+																								addAbstractModifier);
 				return changedSolutionForNonPartialType;
 			}
 			else
 			{
 				var changedSolutionForPartialType = await UpdateTypeNodeModifiersForPartialType(document.Project.Solution, typeDeclarations,
-																						removeSealedModifier, addAbstractModifier, cancellationToken)
+																								addAbstractModifier, cancellationToken)
 														.ConfigureAwait(false);
 				return changedSolutionForPartialType;
 			}	
 		}
 
 		private Solution UpdateTypeNodeModifiersForNonPartialType(Document document, SyntaxNode root, ClassDeclarationSyntax graphOrGraphExtTypeNode, 
-																  bool removeSealedModifier, bool addAbstractModifier)
+																  bool addAbstractModifier)
 		{
-			var modifiedGraphOrGraphExtTypeNode = UpdateTypeNodeModifiers(graphOrGraphExtTypeNode, removeSealedModifier, addAbstractModifier);
+			var modifiedGraphOrGraphExtTypeNode = UpdateTypeNodeModifiers(graphOrGraphExtTypeNode, addAbstractModifier);
 
 			if (ReferenceEquals(modifiedGraphOrGraphExtTypeNode, graphOrGraphExtTypeNode))
 				return document.Project.Solution;
@@ -111,8 +113,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.DeclarationAnalysisGraphAndDac
 		}
 
 		private async Task<Solution> UpdateTypeNodeModifiersForPartialType(Solution originalSolution, ImmutableArray<SyntaxReference> graphOrGraphExtDeclarations,
-																		   bool removeSealedModifier, bool addAbstractModifier, 
-																		   CancellationToken cancellation)
+																		   bool addAbstractModifier, CancellationToken cancellation)
 		{
 			var solutionEditor = new SolutionEditor(originalSolution);
 			var documentEditors = await GetAllDocumentEditorsAsync(solutionEditor, graphOrGraphExtDeclarations, cancellation).ConfigureAwait(false);
@@ -129,7 +130,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.DeclarationAnalysisGraphAndDac
 
 				foreach (var graphOrGraphExtTypeNode in graphOrGraphExtTypeNodesInDocument)
 				{
-					var modifiedGraphOrGraphExtTypeNode = UpdateTypeNodeModifiers(graphOrGraphExtTypeNode, removeSealedModifier, addAbstractModifier);
+					var modifiedGraphOrGraphExtTypeNode = UpdateTypeNodeModifiers(graphOrGraphExtTypeNode, addAbstractModifier);
 
 					if (ReferenceEquals(modifiedGraphOrGraphExtTypeNode, graphOrGraphExtTypeNode))
 						continue;
@@ -178,14 +179,13 @@ namespace Acuminator.Analyzers.StaticAnalysis.DeclarationAnalysisGraphAndDac
 				   .OfType<ClassDeclarationSyntax>();
 		}
 
-		private ClassDeclarationSyntax UpdateTypeNodeModifiers(ClassDeclarationSyntax graphOrGraphExtensionNode,
-																bool removeSealedModifier, bool addAbstractModifier)
+		private ClassDeclarationSyntax UpdateTypeNodeModifiers(ClassDeclarationSyntax graphOrGraphExtensionNode, bool addAbstractModifier)
 		{
 			var oldModifiers = graphOrGraphExtensionNode.Modifiers;
 			SyntaxTokenList newModifiers = oldModifiers;
 			bool modifiedAny = false;
 
-			if (removeSealedModifier && oldModifiers.Count > 0)
+			if (oldModifiers.Count > 0)
 			{
 				int sealedIndex = newModifiers.IndexOf(SyntaxKind.SealedKeyword);
 				if (sealedIndex >= 0 && sealedIndex < newModifiers.Count)

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/Descriptors.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/Descriptors.cs
@@ -541,5 +541,8 @@ namespace Acuminator.Analyzers.StaticAnalysis
 
 		public static DiagnosticDescriptor PX1112_GenericGraphsAndGraphExtensionsMustBeAbstract { get; } =
 			Rule("PX1112", nameof(Resources.PX1112Title).GetLocalized(), Category.Acuminator, DiagnosticSeverity.Error, DiagnosticsShortName.PX1112);
+
+		public static DiagnosticDescriptor PX1113_SealedGraphsAndGraphExtensions { get; } =
+			Rule("PX1113", nameof(Resources.PX1113Title).GetLocalized(), Category.Acuminator, DiagnosticSeverity.Error, DiagnosticsShortName.PX1113);
 	}
 }

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/Descriptors.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/Descriptors.cs
@@ -543,6 +543,6 @@ namespace Acuminator.Analyzers.StaticAnalysis
 			Rule("PX1112", nameof(Resources.PX1112Title).GetLocalized(), Category.Acuminator, DiagnosticSeverity.Error, DiagnosticsShortName.PX1112);
 
 		public static DiagnosticDescriptor PX1113_SealedGraphsAndGraphExtensions { get; } =
-			Rule("PX1113", nameof(Resources.PX1113Title).GetLocalized(), Category.Acuminator, DiagnosticSeverity.Error, DiagnosticsShortName.PX1113);
+			Rule("PX1113", nameof(Resources.PX1113Title).GetLocalized(), Category.Acuminator, DiagnosticSeverity.Warning, DiagnosticsShortName.PX1113);
 	}
 }

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/DeclarationAnalysisGraphAndDac/GenericNonAbstractGraphsAndGraphExtensionsTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/DeclarationAnalysisGraphAndDac/GenericNonAbstractGraphsAndGraphExtensionsTests.cs
@@ -15,6 +15,8 @@ using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Diagnostics;
 
 using Xunit;
+using Acuminator.Utilities.Roslyn.Semantic;
+using Acuminator.Utilities.Roslyn.Semantic.PXGraph;
 
 namespace Acuminator.Tests.Tests.StaticAnalysis.DeclarationAnalysisGraphAndDac
 {
@@ -91,6 +93,10 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.DeclarationAnalysisGraphAndDac
 				(
 					Descriptors.PX1112_GenericGraphsAndGraphExtensionsMustBeAbstract
 				);
+
+			protected override void CheckIfGraphOrGraphExtensionIsSealed(SymbolAnalysisContext context, PXContext pxContext, 
+																		 PXGraphEventSemanticModel graphOrGraphExt)
+			{ }
 		}
 	}
 }

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/DeclarationAnalysisGraphAndDac/SealedGraphsAndGraphExtensionsTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/DeclarationAnalysisGraphAndDac/SealedGraphsAndGraphExtensionsTests.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Collections.Immutable;
+using System.Threading.Tasks;
+
+using Acuminator.Analyzers.StaticAnalysis;
+using Acuminator.Analyzers.StaticAnalysis.PXGraph;
+using Acuminator.Analyzers.StaticAnalysis.DeclarationAnalysisGraphAndDac;
+using Acuminator.Tests.Helpers;
+using Acuminator.Tests.Verification;
+using Acuminator.Utilities;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using Xunit;
+using Acuminator.Utilities.Roslyn.Semantic;
+using Acuminator.Utilities.Roslyn.Semantic.PXGraph;
+
+namespace Acuminator.Tests.Tests.StaticAnalysis.DeclarationAnalysisGraphAndDac
+{
+	public class SealedGraphsAndGraphExtensionsTests : CodeFixVerifier
+	{
+		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer() =>
+			new PXGraphAnalyzer(
+				CodeAnalysisSettings.Default.WithStaticAnalysisEnabled()
+											.WithSuppressionMechanismDisabled(),
+				new GraphAndGraphExtensionDeclarationAnalyzerForPX1113Tests());
+
+		protected override CodeFixProvider GetCSharpCodeFixProvider() => 
+			new TypeModifiersFix();
+
+		[Theory]
+		[EmbeddedFileData(@"SealedGraphsAndGraphExtensions\SealedGraph.cs")]
+		public async Task SealedGraph(string source) =>
+			await VerifyCSharpDiagnosticAsync(source,
+				Descriptors.PX1113_SealedGraphsAndGraphExtensions.CreateFor(5, 9),
+				Descriptors.PX1113_SealedGraphsAndGraphExtensions.CreateFor(9, 9),
+				Descriptors.PX1113_SealedGraphsAndGraphExtensions.CreateFor(15, 9),
+				Descriptors.PX1113_SealedGraphsAndGraphExtensions.CreateFor(19, 9),
+				Descriptors.PX1113_SealedGraphsAndGraphExtensions.CreateFor(23, 9));
+
+		[Theory]
+		[EmbeddedFileData(@"SealedGraphsAndGraphExtensions\SealedGraphExtension.cs")]
+		public async Task SealedGraphExtension(string source) =>
+			await VerifyCSharpDiagnosticAsync(source,
+				Descriptors.PX1113_SealedGraphsAndGraphExtensions.CreateFor(6, 9),
+				Descriptors.PX1113_SealedGraphsAndGraphExtensions.CreateFor(11, 9));
+
+		[Theory]
+		[EmbeddedFileData(@"SealedGraphsAndGraphExtensions\RegularGraphAndGraphExtension.cs")]
+		public async Task Regular_GraphsAndGraphExtensions_NoDiagnostic(string source) =>
+			await VerifyCSharpDiagnosticAsync(source);
+
+		[Theory]
+		[EmbeddedFileData(@"SealedGraphsAndGraphExtensions\SealedGraph_Expected.cs")]
+		public async Task SealedGraph_AfterCodeFix_NoDiagnostic(string source) =>
+			await VerifyCSharpDiagnosticAsync(source);
+
+		[Theory]
+		[EmbeddedFileData(@"SealedGraphsAndGraphExtensions\SealedGraphExtension_Expected.cs")]
+		public async Task SealedGraphExtension_AfterCodeFix_NoDiagnostic(string source) =>
+			await VerifyCSharpDiagnosticAsync(source);
+
+		#region Code Fix Tests
+		[Theory]
+		[EmbeddedFileData(@"SealedGraphsAndGraphExtensions\SealedGraph.cs", 
+						  @"SealedGraphsAndGraphExtensions\SealedGraph_Expected.cs")]
+		public async Task Sealed_Graph_CodeFix_RemoveSealed(string source, string expected) =>
+			await VerifyCSharpFixAsync(source, expected);
+
+		[Theory]
+		[EmbeddedFileData(@"SealedGraphsAndGraphExtensions\SealedGraphExtension.cs", 
+						  @"SealedGraphsAndGraphExtensions\SealedGraphExtension_Expected.cs")]
+		public async Task Sealed_GraphExtension_CodeFix_RemoveSealed(string source, string expected) =>
+			await VerifyCSharpFixAsync(source, expected);
+		#endregion
+
+		private sealed class GraphAndGraphExtensionDeclarationAnalyzerForPX1113Tests : GraphAndGraphExtensionDeclarationAnalyzer
+		{
+			public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+				ImmutableArray.Create
+				(
+					Descriptors.PX1113_SealedGraphsAndGraphExtensions
+				);
+
+			protected override void CheckIfGraphOrGraphExtensionIsGenericNonAbstract(SymbolAnalysisContext context, PXContext pxContext,
+																					 PXGraphEventSemanticModel graphOrGraphExt)
+			{
+			}
+		}
+	}
+}

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/DeclarationAnalysisGraphAndDac/Sources/SealedGraphsAndGraphExtensions/RegularGraphAndGraphExtension.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/DeclarationAnalysisGraphAndDac/Sources/SealedGraphsAndGraphExtensions/RegularGraphAndGraphExtension.cs
@@ -1,0 +1,32 @@
+using PX.Data;
+
+namespace PX.Objects
+{
+	public class SomeGraph : PXGraph<SomeGraph>
+	{
+	}
+
+	public abstract class SomeGenericGraph<T> : PXGraph<SomeGenericGraph<T>>
+	{
+	}
+
+	public partial class SomePartialGraph : PXGraph<SomePartialGraph> { }
+
+	public partial class SomePartialGraph : PXGraph<SomePartialGraph> { }
+
+
+	// Acuminator disable once PX1016 ExtensionDoesNotDeclareIsActiveMethod extension should be constantly active
+	public class SomeGraphExtension : PXGraphExtension<SomeGraph>
+	{
+	}
+
+	public abstract class SomeGraphExtension<TGraph> : PXGraphExtension<TGraph>
+	where TGraph : PXGraph
+	{
+	}
+
+	// Acuminator disable once PX1016 ExtensionDoesNotDeclareIsActiveMethod extension should be constantly active
+	public partial class PartialGenericGraphExtension : PXGraphExtension<SomeGraph> { }
+
+	public partial class PartialGenericGraphExtension : PXGraphExtension<SomeGraph> { }
+}

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/DeclarationAnalysisGraphAndDac/Sources/SealedGraphsAndGraphExtensions/SealedGraph.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/DeclarationAnalysisGraphAndDac/Sources/SealedGraphsAndGraphExtensions/SealedGraph.cs
@@ -1,0 +1,26 @@
+using PX.Data;
+
+namespace Acuminator.Tests.Tests.StaticAnalysis.DeclarationAnalysisGraphAndDac.Sources
+{
+	public sealed class SealedGraph<TDac> : PXGraph<SealedGraph<TDac>>
+	{
+	}
+
+	public sealed class SealedGraphWithConstraints<TDac> : PXGraph<SealedGraphWithConstraints<TDac>>
+	where TDac : class, IBqlTable, new()
+	{
+		public PXSelect<TDac> Documents = null!;
+	}
+
+	public sealed class SealedGraphWithModifiers<TDac> : PXGraph<SealedGraphWithModifiers<TDac>>
+	{
+	}
+
+	public sealed class SealedGraphWithMultipleTypeParameters<T1, T2> : PXGraph<SealedGraphWithMultipleTypeParameters<T1, T2>>
+	{
+	}
+
+	public sealed partial class SealedPartialGraph : PXGraph<SealedPartialGraph> { }
+
+	public sealed partial class SealedPartialGraph : PXGraph<SealedPartialGraph> { }
+}

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/DeclarationAnalysisGraphAndDac/Sources/SealedGraphsAndGraphExtensions/SealedGraphExtension.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/DeclarationAnalysisGraphAndDac/Sources/SealedGraphsAndGraphExtensions/SealedGraphExtension.cs
@@ -1,0 +1,18 @@
+using PX.Data;
+
+namespace PX.Objects
+{
+	// Acuminator disable once PX1016 ExtensionDoesNotDeclareIsActiveMethod extension should be constantly active
+	public sealed class SealedGraphExtension : PXGraphExtension<MyGraph>
+	{
+	}
+
+	// Acuminator disable once PX1016 ExtensionDoesNotDeclareIsActiveMethod extension should be constantly active
+	public sealed partial class SealedPartialGraphExtension : PXGraphExtension<MyGraph> { }
+
+	public sealed partial class SealedPartialGraphExtension : PXGraphExtension<MyGraph> { }
+
+	public class MyGraph : PXGraph<MyGraph>
+	{
+	}
+}

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/DeclarationAnalysisGraphAndDac/Sources/SealedGraphsAndGraphExtensions/SealedGraphExtension_Expected.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/DeclarationAnalysisGraphAndDac/Sources/SealedGraphsAndGraphExtensions/SealedGraphExtension_Expected.cs
@@ -1,0 +1,18 @@
+using PX.Data;
+
+namespace PX.Objects
+{
+	// Acuminator disable once PX1016 ExtensionDoesNotDeclareIsActiveMethod extension should be constantly active
+	public class SealedGraphExtension : PXGraphExtension<MyGraph>
+	{
+	}
+
+	// Acuminator disable once PX1016 ExtensionDoesNotDeclareIsActiveMethod extension should be constantly active
+	public partial class SealedPartialGraphExtension : PXGraphExtension<MyGraph> { }
+
+	public partial class SealedPartialGraphExtension : PXGraphExtension<MyGraph> { }
+
+	public class MyGraph : PXGraph<MyGraph>
+	{
+	}
+}

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/DeclarationAnalysisGraphAndDac/Sources/SealedGraphsAndGraphExtensions/SealedGraph_Expected.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/DeclarationAnalysisGraphAndDac/Sources/SealedGraphsAndGraphExtensions/SealedGraph_Expected.cs
@@ -1,0 +1,26 @@
+using PX.Data;
+
+namespace Acuminator.Tests.Tests.StaticAnalysis.DeclarationAnalysisGraphAndDac.Sources
+{
+	public class SealedGraph<TDac> : PXGraph<SealedGraph<TDac>>
+	{
+	}
+
+	public class SealedGraphWithConstraints<TDac> : PXGraph<SealedGraphWithConstraints<TDac>>
+	where TDac : class, IBqlTable, new()
+	{
+		public PXSelect<TDac> Documents = null!;
+	}
+
+	public class SealedGraphWithModifiers<TDac> : PXGraph<SealedGraphWithModifiers<TDac>>
+	{
+	}
+
+	public class SealedGraphWithMultipleTypeParameters<T1, T2> : PXGraph<SealedGraphWithMultipleTypeParameters<T1, T2>>
+	{
+	}
+
+	public partial class SealedPartialGraph : PXGraph<SealedPartialGraph> { }
+
+	public partial class SealedPartialGraph : PXGraph<SealedPartialGraph> { }
+}


### PR DESCRIPTION
**MERGE INTO `dev` BRANCH AFTER https://github.com/Acumatica/Acuminator/pull/621** 

Implemented PX1113 diagnostic to report sealed graphs and graph extensions.

**Changes Overview**
- Implemented PX1113 diagnostic as part of the analyzer for graph and graph extension declaration
- Implemented code fix for PX1113 diagnostic to remove `sealed` modifier
- Added unit tests for PX1113 diagnostic and fixed tests for PX1112 diagnostic.
- Added documentation for PX1113 diagnostic