### PR TITLE
Feature/atr 778 dev derive from non abstract non generic graph ext

### DIFF
--- a/.github/prompts/UnitTests.prompt.md
+++ b/.github/prompts/UnitTests.prompt.md
@@ -1,0 +1,76 @@
+# Generate Unit Tests for Acuminator Diagnostic
+
+## TASK
+Generate comprehensive unit tests for the `{DIAGNOSTIC_ID}` diagnostic (e.g., PX1114, PX1112, PX1113).
+
+## REQUIREMENTS
+- Place tests in the current test class.
+- Generate 4-5 unit tests covering key scenarios
+- Use existing unit tests in the project as examples for structure and naming
+- Use the existing analyzer `{AnalyzerClassName}` for the specified diagnostic. By convetion, analyzer classes have word "Analyzer" in their names.
+- Use the existing code fix `{CodeFixClassName}` for the specified diagnostic. By convention, code fix classes have word "Fix" in their names.
+- **DO NOT** generate code fix tests if no code fix exists for the diagnostic.
+- No code fix exists if the base class of the test class is `DiagnosticVerifier` class instead of `CodeFixVerifier`.
+- Follow Acuminator naming conventions exactly
+
+## NAMING CONVENTIONS FOR UNIT TESTS
+- Use `NoDiagnostic` suffix for tests that should NOT report the diagnostic
+- **DO NOT** use `ShouldNotReportDiagnostic` suffix
+- **DO NOT** add `ShouldReportDiagnostic` suffix for positive test cases
+- Use descriptive names that clearly indicate the scenario being tested
+- Examples:
+  - `GraphExtension_InheritingFromAbstractExtension_NoDiagnostic`
+  - `GraphExtension_InheritingFromNonAbstractExtension`
+  - `RegularGraph_InheritanceScenarios_NoDiagnostic` 
+
+## NAMING CONVENTIONS FOR TESTS SOURCES
+- Place test source files in the `Sources` subfolder and its subfolders
+- Name test source files descriptively based on the scenario being tested
+- Examples:
+  - `SealedGraphExtension.cs`
+  - `NonSealedGraph.cs`
+  - `AbstractGraphExtension.cs`
+- Code fix tests use two test source files:
+  - `{TestSourceFileName}.cs` for the code before the code fix
+  - `{TestSourceFileName}_Expected.cs` for the code expected after the code fix
+
+## TEST STRUCTURE
+Each test should:
+- Generate C# test source files in the `Sources` subfolder and its subfolders
+- Use `[Theory]` and `[EmbeddedFileData(@"FolderName\FileName.cs")]` attributes. The path to the test source file specified in the `EmbeddedFileData` attribute should be relative to the `Sources` folder.
+- The path to the test source file specified in the `EmbeddedFileData` attribute should use Windows path separators (`\`).
+- The C# string with to the test source file specified in the `EmbeddedFileData` attribute should be C# verbatim string literal (use `@` before the opening quote) if the file is located in a subfolder of the `Sources` folder.
+- Be `async Task` methods
+- Call `await VerifyCSharpDiagnosticAsync(source)` for no-diagnostic cases
+- Call `await VerifyCSharpDiagnosticAsync(source, Descriptors.{DIAGNOSTIC_ID}.CreateFor(line, column))` for positive cases
+- Use correct line and column numbers for diagnostic expectations. The correct line and columns are the starting position of the location of the reported diagnostic. 
+
+## TEST CATEGORIES TO INCLUDE
+1. **Positive cases** - scenarios that SHOULD trigger the diagnostic
+2. **Negative cases** - scenarios that should NOT trigger the diagnostic  
+3. **Edge cases** - boundary conditions, inheritance chains, generic types
+
+## ANALYZER SETUP
+- The analyzer should be prepared in the unit test file by the user in advance.
+The setup code depends on the base class of the test class:
+- For analyzers derived from `PXGraphAggregatedAnalyzerBase` Use the following analyzer pattern:
+```csharp
+protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer() => 
+	new PXGraphAnalyzer(
+		CodeAnalysisSettings.Default.WithStaticAnalysisEnabled()
+									.WithSuppressionMechanismDisabled(), 
+		new {AnalyzerClassName}());
+```
+- For analyzers derived from `DacAggregatedAnalyzerBase` Use the following analyzer pattern:
+```csharp
+protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer() => 
+	new DacAnalyzersAggregator(
+		CodeAnalysisSettings.Default.WithStaticAnalysisEnabled()
+									.WithSuppressionMechanismDisabled(), 
+		new {AnalyzerClassName}());
+```
+- For analyzers derived from `PXDiagnosticAnalyzer` Use the following analyzer pattern:
+```csharp
+protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer() => 
+	new {AnalyzerClassName}();
+```

--- a/.github/prompts/UnitTests.prompt.md
+++ b/.github/prompts/UnitTests.prompt.md
@@ -26,6 +26,7 @@ Generate comprehensive unit tests for the `{DIAGNOSTIC_ID}` diagnostic (e.g., PX
 ## NAMING CONVENTIONS FOR TESTS SOURCES
 - Place test source files in the `Sources` subfolder and its subfolders
 - Name test source files descriptively based on the scenario being tested
+- For the test sources use the subnamespace `Source` of the test class namespace
 - Examples:
   - `SealedGraphExtension.cs`
   - `NonSealedGraph.cs`

--- a/docs/Summary.md
+++ b/docs/Summary.md
@@ -114,3 +114,4 @@ Acuminator does not perform static analysis of projects whose names contain `Tes
 | [PX1111](diagnostics/PX1111.md) | The primary DAC of a processing view must contain the `NoteID` field. | Error | Unavailable |
 | [PX1112](diagnostics/PX1112.md) | Graphs and graph extensions with generic type parameters must be abstract. | Error | Available |
 | [PX1113](diagnostics/PX1113.md) | Graphs and graph extensions should not be `sealed` types. | Warning | Available |
+| [PX1114](diagnostics/PX1114.md) | Graph extension should not inherit from a terminal graph extension. | Warning | Unavailable |

--- a/docs/diagnostics/PX1110.md
+++ b/docs/diagnostics/PX1110.md
@@ -38,9 +38,6 @@ The PX1110 code fix automatically adds the missing `NoteID` field to the DAC wit
 ## Example of Incorrect Code
 
 ```C#
-using System;
-using PX.Data;
-
 [PXCacheName("Some DAC")]
 public class SomeDac : PXBqlTable, IBqlTable
 {
@@ -65,10 +62,6 @@ public class SomeDac : PXBqlTable, IBqlTable
 ## Example of Code Fix
 
 ```C#
-using System;
-using PX.Data;
-using PX.Data.BQL;
-
 [PXCacheName("Some DAC")]
 public class SomeDac : PXBqlTable, IBqlTable
 {

--- a/docs/diagnostics/PX1111.md
+++ b/docs/diagnostics/PX1111.md
@@ -16,10 +16,6 @@ The PX1111 diagnostic detects and reports processing graph views where the main 
 ## Example of Incorrect Code
 
 ```C#
-using System;
-using PX.Data;
-using PX.Data.BQL;
-
 public class OrderProcessingGraph : PXGraph<OrderProcessingGraph>
 {
 	// Processing view with DAC that lacks NoteID field
@@ -60,10 +56,6 @@ public class OrderDac : PXBqlTable, IBqlTable
 ## Example of Correct Code
 
 ```C#
-using System;
-using PX.Data;
-using PX.Data.BQL;
-
 public class OrderProcessingGraph : PXGraph<OrderProcessingGraph>
 {
 	// Processing view with DAC that has required NoteID field

--- a/docs/diagnostics/PX1112.md
+++ b/docs/diagnostics/PX1112.md
@@ -24,35 +24,25 @@ If the class has a `sealed` modifier, it is automatically removed (since `abstra
 ## Example of Incorrect Code
 
 ```C#
-using PX.Data;
-
-namespace Examples
+// Generic graph without abstract modifier - reports PX1112
+public class GenericOrderGraph<TOrderDac> : PXGraph<GenericOrderGraph<TOrderDac>>
+where TOrderDac : PXBqlTable, IBqlTable, new()
 {
-	// Generic graph without abstract modifier - reports PX1112
-	public class GenericOrderGraph<TOrderDac> : PXGraph<GenericOrderGraph<TOrderDac>>
-	where TOrderDac : PXBqlTable, IBqlTable, new()
-	{
-		public PXSelect<TOrderDac> Orders = null!;
+	public PXSelect<TOrderDac> Orders = null!;
 		
-		// Business logic
-	}
+	// Business logic
 }
 ```
 
 ## Example of Correct Code after Code Fix
 
 ```C#
-using PX.Data;
-
-namespace Examples
+public abstract class GenericOrderGraph<TOrderDac> : PXGraph<GenericOrderGraph<TOrderDac>>
+where TOrderDac : PXBqlTable, IBqlTable, new()
 {
-	public abstract class GenericOrderGraph<TOrderDac> : PXGraph<GenericOrderGraph<TOrderDac>>
-	where TOrderDac : PXBqlTable, IBqlTable, new()
-	{
-		public PXSelect<TOrderDac> Orders = null!;
+	public PXSelect<TOrderDac> Orders = null!;
 		
-		// Business logic
-	}
+	// Business logic
 }
 ```
 

--- a/docs/diagnostics/PX1113.md
+++ b/docs/diagnostics/PX1113.md
@@ -27,31 +27,21 @@ The PX1113 code fix automatically removes the `sealed` modifier from the graph o
 ## Example of Incorrect Code
 
 ```C#
-using PX.Data;
-
-namespace Examples
+// Sealed graph - reports PX1113
+public sealed class OrderGraph<TOrderDac> : PXGraph<GenericOrderGraph<TOrderDac>>
+where TOrderDac : PXBqlTable, IBqlTable, new()
 {
-	// Sealed graph - reports PX1113
-	public sealed class OrderGraph<TOrderDac> : PXGraph<GenericOrderGraph<TOrderDac>>
-	where TOrderDac : PXBqlTable, IBqlTable, new()
-	{
-		// Business logic
-	}
+	// Business logic
 }
 ```
 
 ## Example of Correct Code after Code Fix
 
 ```C#
-using PX.Data;
-
-namespace Examples
+public class OrderGraph<TOrderDac> : PXGraph<GenericOrderGraph<TOrderDac>>
+where TOrderDac : PXBqlTable, IBqlTable, new()
 {
-	public class OrderGraph<TOrderDac> : PXGraph<GenericOrderGraph<TOrderDac>>
-	where TOrderDac : PXBqlTable, IBqlTable, new()
-	{
-		// Business logic
-	}
+	// Business logic
 }
 ```
 

--- a/docs/diagnostics/PX1114.md
+++ b/docs/diagnostics/PX1114.md
@@ -1,0 +1,123 @@
+# PX1114
+This document describes the PX1114 diagnostic.
+
+## Summary
+
+| Code   | Short Description                                                  |  Type   |  Code Fix   |
+| ------ | ------------------------------------------------------------------ | ------- | ----------- |
+| PX1114 | Graph extension should not inherit from terminal graph extensions. | Warning | Unavailable |
+
+## Diagnostic Description
+
+The PX1114 diagnostic identifies graph extensions that inherit from **terminal** graph extensions. A **terminal** graph extension is a graph extension that will be instantiated by Acumatica Framework at runtime 
+during the initialization of the corresponding graph.
+
+Currently, there are two types of terminal extensions:
+
+1. **Non-abstract and non-generic graph extension**: A concrete graph extension without generic type parameters.
+2. **Abstract graph extension with PXProtectedAccess attribute**: An abstract graph extension decorated with the `[PXProtectedAccess]` attribute.
+
+Having a terminal graph extension among graph extension's base classes may cause confusion and be undesired for developer since graph event handlers declared in the base terminal extension will be subscribed to Acumatica events twice - 
+once for the base terminal extension and once for the derived extension. This may lead to unexpected behavior, such as event handlers being executed twice. For this reason, inheriting from terminal graph extensions is discouraged and
+PX1114 diagnostic issues a warning for graph extensions derived from terminal extensions. For rare scenarios where such inheritance is intentional, you may suppress the warning with Acuminator suppression comment.
+
+## Example of Incorrect Code
+
+### Case 1: Inheriting from Non-Abstract Graph Extension
+
+```csharp
+public class SomeGraph : PXGraph<SomeGraph>
+{
+	// Business logic here
+}
+
+// Non-abstract graph extension - this is a terminal extension
+public class NonAbstractGraphExtension : PXGraphExtension<SomeGraph>
+{
+	// Extension logic here
+}
+
+// This graph extension inherits from a non-abstract extension - PX1114 violation
+public class DerivedGraphExtension : NonAbstractGraphExtension
+{
+	// Additional logic here
+}
+```
+
+### Case 2: Inheriting from Graph Extension with PXProtectedAccessAttribute
+
+```csharp
+public class SomeGraph : PXGraph<SomeGraph>
+{
+	// Business logic here
+}
+
+// Abstract graph extension with PXProtectedAccess - still considered terminal
+[PXProtectedAccess]
+public abstract class PXProtectedAccessExtension : PXGraphExtension<SomeGraph>
+{
+	// Extension logic here
+}
+
+// This graph extension inherits from PXProtectedAccess extension - PX1114 violation
+public class DerivedFromProtectedExtension : PXProtectedAccessExtension
+{
+	// Additional logic here
+}
+```
+
+## Example of Correct Code
+
+### Case 1: Inheriting from Abstract Graph Extension
+
+```csharp
+public class SomeGraph : PXGraph<SomeGraph>
+{
+	// Business logic here
+}
+
+public abstract class AbstractGraphExtension : PXGraphExtension<SomeGraph>
+{
+	// Extension logic here
+}
+
+// This graph extension inherits from an abstract graph extension - no error
+public class DerivedGraphExtension : AbstractGraphExtension
+{
+	// Additional logic here
+}
+```
+
+### Case 2: Inheriting from Abstract Graph Extension that use PXProtectedAccessAttribute to Access Protected Members
+
+```csharp
+public class SomeGraph : PXGraph<SomeGraph>
+{
+	protected void Foo(){ }
+}
+
+// Abstract graph extension without PXProtectedAccess on the extension class itself can still declare members with [PXProtectedAccess]
+// to access protected members of the base graph and its base graph extensions
+// Such graph extensions are not considered terminal, they won't be instantiated at runtime.
+public abstract class PXProtectedAccessExtension : PXGraphExtension<SomeGraph>
+{
+	[PXProtectedAccess]
+	protected abstract void Foo();
+}
+
+// This graph extension inherits from PXProtectedAccess extension which is not considered terminal - no error
+// Notice that DerivedFromProtectedExtension has to be abstract and declare [PXProtectedAccess] attribute as well since its base class accesses protected members of the base graph
+[PXProtectedAccess]
+public class DerivedFromProtectedExtension : PXProtectedAccessExtension
+{
+	// Additional logic here
+}
+```
+
+## Related Articles
+
+ - [Graph Extensions: General Information](https://help.acumatica.com/Help?ScreenId=ShowWiki&pageid=e220486e-32d1-439b-a858-7c10f44a9bac)
+ - [Use of Generic Graph Extensions by the System](https://help.acumatica.com/Help?ScreenId=ShowWiki&pageid=eece8358-f6ea-47e8-899a-d466eccbc14e)
+ - [PXProtectedAccessAttribute and Access to Protected Graph Members](https://help.acumatica.com/Help?ScreenId=ShowWiki&pageid=af86ebcf-0ea1-4c22-b624-99fc14c0b02c)
+ - [Reusing Business Logic](https://help.acumatica.com/Help?ScreenId=ShowWiki&pageid=76b8c160-89bd-4501-9f9f-1dabc648d417)
+ - [PX1112: Graphs and graph extensions with generic type parameters must be abstract](PX1112.md)

--- a/src/Acuminator/Acuminator.Analyzers/DiagnosticsShortName.Designer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/DiagnosticsShortName.Designer.cs
@@ -1112,5 +1112,14 @@ namespace Acuminator.Analyzers {
                 return ResourceManager.GetString("PX1113", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to GraphExtensionInheritFromNonAbstractGraphExtension.
+        /// </summary>
+        public static string PX1114 {
+            get {
+                return ResourceManager.GetString("PX1114", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Acuminator/Acuminator.Analyzers/DiagnosticsShortName.resx
+++ b/src/Acuminator/Acuminator.Analyzers/DiagnosticsShortName.resx
@@ -468,4 +468,7 @@
   <data name="PX1113" xml:space="preserve">
     <value>SealedGraphOrGraphExtension</value>
   </data>
+  <data name="PX1114" xml:space="preserve">
+    <value>GraphExtensionInheritFromNonAbstractGraphExtension</value>
+  </data>
 </root>

--- a/src/Acuminator/Acuminator.Analyzers/Resources.Designer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/Resources.Designer.cs
@@ -2331,7 +2331,7 @@ namespace Acuminator.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Graph extension should not inherit from non-abstract graph extensions.
+        ///   Looks up a localized string similar to Graph extension should not inherit from non-terminal graph extensions.
         /// </summary>
         public static string PX1114Title {
             get {

--- a/src/Acuminator/Acuminator.Analyzers/Resources.Designer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/Resources.Designer.cs
@@ -2331,6 +2331,15 @@ namespace Acuminator.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Graph extension should not inherit from non-abstract graph extensions.
+        /// </summary>
+        public static string PX1114Title {
+            get {
+                return ResourceManager.GetString("PX1114Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Suppress the {0} diagnostic with Acuminator.
         /// </summary>
         public static string SuppressDiagnosticGroupCodeActionTitle {

--- a/src/Acuminator/Acuminator.Analyzers/Resources.resx
+++ b/src/Acuminator/Acuminator.Analyzers/Resources.resx
@@ -882,7 +882,7 @@ Reason: {2}</value>
     <value>Graphs and graph extensions should not be sealed types</value>
   </data>
   <data name="PX1114Title" xml:space="preserve">
-    <value>Graph extension should not inherit from non-abstract graph extensions</value>
+    <value>Graph extension should not inherit from non-terminal graph extensions</value>
   </data>
   <data name="SuppressDiagnosticGroupCodeActionTitle" xml:space="preserve">
     <value>Suppress the {0} diagnostic with Acuminator</value>

--- a/src/Acuminator/Acuminator.Analyzers/Resources.resx
+++ b/src/Acuminator/Acuminator.Analyzers/Resources.resx
@@ -881,6 +881,9 @@ Reason: {2}</value>
   <data name="PX1113Title" xml:space="preserve">
     <value>Graphs and graph extensions should not be sealed types</value>
   </data>
+  <data name="PX1114Title" xml:space="preserve">
+    <value>Graph extension should not inherit from non-abstract graph extensions</value>
+  </data>
   <data name="SuppressDiagnosticGroupCodeActionTitle" xml:space="preserve">
     <value>Suppress the {0} diagnostic with Acuminator</value>
   </data>

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/DeclarationAnalysisGraphAndDac/GraphAndGraphExtensionDeclarationAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/DeclarationAnalysisGraphAndDac/GraphAndGraphExtensionDeclarationAnalyzer.cs
@@ -9,6 +9,7 @@ using Acuminator.Utilities.Common;
 using Acuminator.Utilities.DiagnosticSuppression;
 using Acuminator.Utilities.Roslyn.Semantic;
 using Acuminator.Utilities.Roslyn.Semantic.PXGraph;
+using Acuminator.Utilities.Roslyn.Syntax.PXGraph;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -23,7 +24,8 @@ namespace Acuminator.Analyzers.StaticAnalysis.DeclarationAnalysisGraphAndDac
 			ImmutableArray.Create
 			(
 				Descriptors.PX1112_GenericGraphsAndGraphExtensionsMustBeAbstract,
-				Descriptors.PX1113_SealedGraphsAndGraphExtensions
+				Descriptors.PX1113_SealedGraphsAndGraphExtensions,
+				Descriptors.PX1114_GraphExtensionInheritFromNonAbstractGraphExtension
 			);
 
 		public override void Analyze(SymbolAnalysisContext context, PXContext pxContext, PXGraphEventSemanticModel graphOrGraphExt)
@@ -33,6 +35,12 @@ namespace Acuminator.Analyzers.StaticAnalysis.DeclarationAnalysisGraphAndDac
 
 			context.CancellationToken.ThrowIfCancellationRequested();
 			CheckIfGraphOrGraphExtensionIsSealed(context, pxContext, graphOrGraphExt);
+
+			if (graphOrGraphExt.GraphType == GraphType.PXGraphExtension)
+			{
+				context.CancellationToken.ThrowIfCancellationRequested();
+				CheckIfGraphExtensionInheritsFromNonAbstractGraphExtension(context, pxContext, graphOrGraphExt);
+			}
 		}
 
 		protected virtual void CheckIfGraphOrGraphExtensionIsGenericNonAbstract(SymbolAnalysisContext context, PXContext pxContext,
@@ -69,6 +77,55 @@ namespace Acuminator.Analyzers.StaticAnalysis.DeclarationAnalysisGraphAndDac
 											Descriptors.PX1113_SealedGraphsAndGraphExtensions, location);
 
 			context.ReportDiagnosticWithSuppressionCheck(diagnostic, pxContext.CodeAnalysisSettings);
+		}
+
+		protected virtual void CheckIfGraphExtensionInheritsFromNonAbstractGraphExtension(SymbolAnalysisContext context, PXContext pxContext,
+																						  PXGraphEventSemanticModel graphExtension)
+		{
+			var pxProtectedAccessAttribute = pxContext.AttributeTypes.PXProtectedAccessAttribute;
+			bool isDerivedFromTerminalGraphExtension = 
+				graphExtension.Symbol.GetGraphExtensionBaseTypes()
+									 .OfType<INamedTypeSymbol>()
+									 .Any(baseExtension => IsTerminalGraphExtension(baseExtension, pxProtectedAccessAttribute));
+
+			if (!isDerivedFromTerminalGraphExtension)
+				return;
+
+			var location = GetDiagnosticLocation();
+			var diagnostic = Diagnostic.Create(
+											Descriptors.PX1114_GraphExtensionInheritFromNonAbstractGraphExtension, location);
+			context.ReportDiagnosticWithSuppressionCheck(diagnostic, pxContext.CodeAnalysisSettings);
+
+			//-----------------------------------------------Local Function------------------------------------------------
+			Location? GetDiagnosticLocation()
+			{
+				var semanticModel = context.Compilation.GetSemanticModel(graphExtension.Node!.SyntaxTree);
+
+				if (semanticModel == null)
+				{
+					return graphExtension.Node.Identifier.GetLocation().NullIfLocationKindIsNone() ??
+						   graphExtension.Node.GetLocation();
+				}
+
+				var baseGraphInfo = GraphSyntaxUtils.GetBaseGraphTypeInfo(semanticModel, pxContext, graphExtension.Node,
+																		  context.CancellationToken);
+				var location = baseGraphInfo?.TypeNode.GetLocation().NullIfLocationKindIsNone();
+				location ??= graphExtension.Node.Identifier.GetLocation().NullIfLocationKindIsNone() ??
+							 graphExtension.Node.GetLocation();
+				return location;
+			}
+		}
+
+		private static bool IsTerminalGraphExtension(INamedTypeSymbol graphExtension, INamedTypeSymbol? pxProtectedAccessAttribute)
+		{
+			if (!graphExtension.TypeParameters.IsDefaultOrEmpty)
+				return false;
+			else if (!graphExtension.IsAbstract)
+				return true;
+
+			return pxProtectedAccessAttribute != null 
+				? graphExtension.HasAttribute(pxProtectedAccessAttribute, checkOverrides: false)
+				: false;
 		}
 	}
 }

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/DeclarationAnalysisGraphAndDac/GraphAndGraphExtensionDeclarationAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/DeclarationAnalysisGraphAndDac/GraphAndGraphExtensionDeclarationAnalyzer.cs
@@ -13,7 +13,6 @@ using Acuminator.Utilities.Roslyn.Syntax.PXGraph;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Acuminator.Analyzers.StaticAnalysis.DeclarationAnalysisGraphAndDac
@@ -107,9 +106,9 @@ namespace Acuminator.Analyzers.StaticAnalysis.DeclarationAnalysisGraphAndDac
 						   graphExtension.Node.GetLocation();
 				}
 
-				var baseGraphInfo = GraphSyntaxUtils.GetBaseGraphTypeInfo(semanticModel, pxContext, graphExtension.Node,
-																		  context.CancellationToken);
-				var location = baseGraphInfo?.TypeNode.GetLocation().NullIfLocationKindIsNone();
+				var baseGraphExtensionInfo = GraphSyntaxUtils.GetBaseGraphExtensionTypeInfo(semanticModel, pxContext, graphExtension.Node,
+																							context.CancellationToken);
+				var location = baseGraphExtensionInfo?.TypeNode.GetLocation().NullIfLocationKindIsNone();
 				location ??= graphExtension.Node.Identifier.GetLocation().NullIfLocationKindIsNone() ??
 							 graphExtension.Node.GetLocation();
 				return location;

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/DeclarationAnalysisGraphAndDac/GraphAndGraphExtensionDeclarationAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/DeclarationAnalysisGraphAndDac/GraphAndGraphExtensionDeclarationAnalyzer.cs
@@ -46,8 +46,8 @@ namespace Acuminator.Analyzers.StaticAnalysis.DeclarationAnalysisGraphAndDac
 			
 			var location = graphOrGraphExt.Node!.Identifier.GetLocation().NullIfLocationKindIsNone() ??
 						   graphOrGraphExt.Node.GetLocation();
-			var diagnostic = Diagnostic.Create(Descriptors.PX1112_GenericGraphsAndGraphExtensionsMustBeAbstract, location,
-												graphOrGraphExt.Symbol.Name);
+			var diagnostic = Diagnostic.Create(
+											Descriptors.PX1112_GenericGraphsAndGraphExtensionsMustBeAbstract, location);
 
 			context.ReportDiagnosticWithSuppressionCheck(diagnostic, pxContext.CodeAnalysisSettings);
 		}
@@ -65,7 +65,8 @@ namespace Acuminator.Analyzers.StaticAnalysis.DeclarationAnalysisGraphAndDac
 
 			location ??= graphOrGraphExt.Node.Identifier.GetLocation().NullIfLocationKindIsNone() ??
 						 graphOrGraphExt.Node.GetLocation();
-			var diagnostic = Diagnostic.Create(Descriptors.PX1113_SealedGraphsAndGraphExtensions, location, graphOrGraphExt.Symbol.Name);
+			var diagnostic = Diagnostic.Create(
+											Descriptors.PX1113_SealedGraphsAndGraphExtensions, location);
 
 			context.ReportDiagnosticWithSuppressionCheck(diagnostic, pxContext.CodeAnalysisSettings);
 		}

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/Descriptors.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/Descriptors.cs
@@ -544,5 +544,8 @@ namespace Acuminator.Analyzers.StaticAnalysis
 
 		public static DiagnosticDescriptor PX1113_SealedGraphsAndGraphExtensions { get; } =
 			Rule("PX1113", nameof(Resources.PX1113Title).GetLocalized(), Category.Acuminator, DiagnosticSeverity.Warning, DiagnosticsShortName.PX1113);
+
+		public static DiagnosticDescriptor PX1114_GraphExtensionInheritFromNonAbstractGraphExtension { get; } =
+			Rule("PX1114", nameof(Resources.PX1114Title).GetLocalized(), Category.Acuminator, DiagnosticSeverity.Warning, DiagnosticsShortName.PX1114);
 	}
 }

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXGraphDeclarationTypeParameter/PXGraphDeclarationTypeParameterAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXGraphDeclarationTypeParameter/PXGraphDeclarationTypeParameterAnalyzer.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using Acuminator.Utilities;
 using Acuminator.Utilities.DiagnosticSuppression;
 using Acuminator.Utilities.Roslyn.Semantic;
+using Acuminator.Utilities.Roslyn.Syntax.PXGraph;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -45,12 +46,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXGraphDeclarationTypeParameter
 				return;
 			}
 
-			if (classDeclaration.BaseList == null)
-			{
-				return;
-			}
-
-			var graphArgumentNode = GetBaseGraphTypeNode(context, pxContext, classDeclaration.BaseList.Types);
+			var graphArgumentNode = GetBaseGraphTypeNode(context, pxContext, classDeclaration);
 			if (graphArgumentNode == null)
 			{
 				return;
@@ -75,39 +71,26 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXGraphDeclarationTypeParameter
 		}
 
 		private TypeSyntax? GetBaseGraphTypeNode(SyntaxNodeAnalysisContext context, PXContext pxContext,
-												 SeparatedSyntaxList<BaseTypeSyntax> baseTypes)
+												 ClassDeclarationSyntax graphNode)
 		{
-			foreach (var typeSyntax in baseTypes)
-			{
-				context.CancellationToken.ThrowIfCancellationRequested();
+			var baseGraphTypeInfo = GraphSyntaxUtils.GetBaseGraphTypeInfo(context.SemanticModel, pxContext, graphNode, 
+																		  context.CancellationToken);
+			if (baseGraphTypeInfo == null)
+				return null;
 
-				if (typeSyntax?.Type == null)
-				{
-					continue;
-				}
+			var (baseTypeSymbol, baseTypeNode) = baseGraphTypeInfo.Value;
+			var isGraphBaseType = baseTypeSymbol.ConstructedFrom.Equals(pxContext.PXGraph.GenericTypeGraph, SymbolEqualityComparer.Default) ||
+								  baseTypeSymbol.ConstructedFrom.Equals(pxContext.PXGraph.GenericTypeGraphDac, SymbolEqualityComparer.Default) ||
+								  baseTypeSymbol.ConstructedFrom.Equals(pxContext.PXGraph.GenericTypeGraphDacField, SymbolEqualityComparer.Default);
 
-				if (context.SemanticModel.GetTypeInfo(typeSyntax.Type).Type is not INamedTypeSymbol baseTypeSymbol)
-				{
-					continue;
-				}
+			if (!isGraphBaseType)
+				return null;
 
-				var isGraphBaseType = baseTypeSymbol.ConstructedFrom.Equals(pxContext.PXGraph.GenericTypeGraph, SymbolEqualityComparer.Default) ||
-									  baseTypeSymbol.ConstructedFrom.Equals(pxContext.PXGraph.GenericTypeGraphDac, SymbolEqualityComparer.Default) ||
-									  baseTypeSymbol.ConstructedFrom.Equals(pxContext.PXGraph.GenericTypeGraphDacField, SymbolEqualityComparer.Default);
+			var typeArgumentsListNode = baseTypeNode.DescendantNodes()
+													.OfType<TypeArgumentListSyntax>()
+													.FirstOrDefault();
 
-				if (!isGraphBaseType)
-				{
-					continue;
-				}
-
-				var typeArgumentsListNode = typeSyntax.DescendantNodes()
-													  .OfType<TypeArgumentListSyntax>()
-													  .FirstOrDefault();
-
-				return typeArgumentsListNode?.Arguments.FirstOrDefault();
-			}
-
-			return null;
+			return typeArgumentsListNode?.Arguments.FirstOrDefault();
 		}
 	}
 }

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/DeclarationAnalysisGraphAndDac/GenericNonAbstractGraphsAndGraphExtensionsTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/DeclarationAnalysisGraphAndDac/GenericNonAbstractGraphsAndGraphExtensionsTests.cs
@@ -97,6 +97,10 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.DeclarationAnalysisGraphAndDac
 			protected override void CheckIfGraphOrGraphExtensionIsSealed(SymbolAnalysisContext context, PXContext pxContext, 
 																		 PXGraphEventSemanticModel graphOrGraphExt)
 			{ }
+
+			protected override void CheckIfGraphExtensionInheritsFromNonAbstractGraphExtension(SymbolAnalysisContext context, PXContext pxContext, 
+																								PXGraphEventSemanticModel graphExtension)
+			{ }
 		}
 	}
 }

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/DeclarationAnalysisGraphAndDac/InheritingFromTerminalGraphExtensionsTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/DeclarationAnalysisGraphAndDac/InheritingFromTerminalGraphExtensionsTests.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Immutable;
+using System.Threading.Tasks;
+
+using Acuminator.Analyzers.StaticAnalysis;
+using Acuminator.Analyzers.StaticAnalysis.PXGraph;
+using Acuminator.Analyzers.StaticAnalysis.DeclarationAnalysisGraphAndDac;
+using Acuminator.Tests.Helpers;
+using Acuminator.Tests.Verification;
+using Acuminator.Utilities;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using Xunit;
+using Acuminator.Utilities.Roslyn.Semantic;
+using Acuminator.Utilities.Roslyn.Semantic.PXGraph;
+
+namespace Acuminator.Tests.Tests.StaticAnalysis.DeclarationAnalysisGraphAndDac
+{
+	public class InheritingFromTerminalGraphExtensionsTests : DiagnosticVerifier
+	{
+		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer() =>
+			new PXGraphAnalyzer(
+				CodeAnalysisSettings.Default.WithStaticAnalysisEnabled()
+											.WithSuppressionMechanismDisabled(),
+				new GraphAndGraphExtensionDeclarationAnalyzerForPX1114Tests());
+
+		[Theory]
+		[EmbeddedFileData(@"InheritingFromTerminalGraphExtensions\InheritFromAbstractOrGenericGraphExtension.cs")]
+		public async Task InheritFrom_Abstract_Or_Generic_GraphExtension_NoDiagnostic(string source) =>
+			await VerifyCSharpDiagnosticAsync(source);
+
+		
+
+		private sealed class GraphAndGraphExtensionDeclarationAnalyzerForPX1114Tests : GraphAndGraphExtensionDeclarationAnalyzer
+		{
+			public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+				ImmutableArray.Create
+				(
+					Descriptors.PX1114_GraphExtensionInheritFromNonAbstractGraphExtension
+				);
+
+			protected override void CheckIfGraphOrGraphExtensionIsGenericNonAbstract(SymbolAnalysisContext context, PXContext pxContext,
+																					 PXGraphEventSemanticModel graphOrGraphExt)
+			{
+			}
+
+			protected override void CheckIfGraphOrGraphExtensionIsSealed(SymbolAnalysisContext context, PXContext pxContext, 
+																		 PXGraphEventSemanticModel graphOrGraphExt)
+			{ }
+		}
+	}
+}

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/DeclarationAnalysisGraphAndDac/InheritingFromTerminalGraphExtensionsTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/DeclarationAnalysisGraphAndDac/InheritingFromTerminalGraphExtensionsTests.cs
@@ -10,7 +10,6 @@ using Acuminator.Tests.Verification;
 using Acuminator.Utilities;
 
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Diagnostics;
 
 using Xunit;
@@ -32,7 +31,34 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.DeclarationAnalysisGraphAndDac
 		public async Task InheritFrom_Abstract_Or_Generic_GraphExtension_NoDiagnostic(string source) =>
 			await VerifyCSharpDiagnosticAsync(source);
 
-		
+		[Theory]
+		[EmbeddedFileData(@"InheritingFromTerminalGraphExtensions\RegularGraphInheritance.cs")]
+		public async Task RegularGraph_InheritanceScenarios_NoDiagnostic(string source) =>
+			await VerifyCSharpDiagnosticAsync(source);
+
+		[Theory]
+		[EmbeddedFileData(@"InheritingFromTerminalGraphExtensions\FirstLevelGraphExtension.cs")]
+		public async Task FirstLevel_GraphExtension_NoDiagnostic(string source) =>
+			await VerifyCSharpDiagnosticAsync(source);
+
+		[Theory]
+		[EmbeddedFileData(@"InheritingFromTerminalGraphExtensions\InheritFromNonAbstractExtension.cs")]
+		public async Task InheritFrom_NonAbstract_GraphExtension(string source) =>
+			await VerifyCSharpDiagnosticAsync(source,
+				Descriptors.PX1114_GraphExtensionInheritFromNonAbstractGraphExtension.CreateFor(19, 39));
+
+		[Theory]
+		[EmbeddedFileData(@"InheritingFromTerminalGraphExtensions\InheritFromNonAbstractExtensionIndirectly.cs",
+						  @"InheritingFromTerminalGraphExtensions\InheritFromNonAbstractExtensionIndirectly.BaseTypes.cs")]
+		public async Task InheritFrom_NonAbstract_GraphExtension_Indirectly(string source, string baseSource) =>
+			await VerifyCSharpDiagnosticAsync(source, baseSource,
+				Descriptors.PX1114_GraphExtensionInheritFromNonAbstractGraphExtension.CreateFor(6, 43));
+
+		[Theory]
+		[EmbeddedFileData(@"InheritingFromTerminalGraphExtensions\InheritFromPXProtectedAccessExtension.cs")]
+		public async Task GraphExtension_InheritingFromPXProtectedAccessExtension(string source) =>
+			await VerifyCSharpDiagnosticAsync(source,
+				Descriptors.PX1114_GraphExtensionInheritFromNonAbstractGraphExtension.CreateFor(19, 47));
 
 		private sealed class GraphAndGraphExtensionDeclarationAnalyzerForPX1114Tests : GraphAndGraphExtensionDeclarationAnalyzer
 		{

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/DeclarationAnalysisGraphAndDac/SealedGraphsAndGraphExtensionsTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/DeclarationAnalysisGraphAndDac/SealedGraphsAndGraphExtensionsTests.cs
@@ -88,6 +88,10 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.DeclarationAnalysisGraphAndDac
 																					 PXGraphEventSemanticModel graphOrGraphExt)
 			{
 			}
+
+			protected override void CheckIfGraphExtensionInheritsFromNonAbstractGraphExtension(SymbolAnalysisContext context, PXContext pxContext, 
+																								PXGraphEventSemanticModel graphExtension)
+			{ }
 		}
 	}
 }

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/DeclarationAnalysisGraphAndDac/Sources/InheritingFromTerminalGraphExtensions/FirstLevelGraphExtension.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/DeclarationAnalysisGraphAndDac/Sources/InheritingFromTerminalGraphExtensions/FirstLevelGraphExtension.cs
@@ -1,0 +1,20 @@
+using PX.Data;
+
+namespace Acuminator.Tests.Tests.StaticAnalysis.DeclarationAnalysisGraphAndDac.Sources
+{
+	// First level graph extension - should NOT report diagnostic
+	// Acuminator disable once PX1016 ExtensionDoesNotDeclareIsActiveMethod extension should be constantly active
+	public class FirstLevelGraphExtension : PXGraphExtension<SomeGraph>
+	{
+	}
+
+	public class SomeGraph : PXGraph<SomeGraph>
+	{
+		public PXSelect<SomeDac> Documents = null!;
+	}
+
+	[PXHidden]
+	public class SomeDac : IBqlTable
+	{
+	}
+}

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/DeclarationAnalysisGraphAndDac/Sources/InheritingFromTerminalGraphExtensions/InheritFromAbstractOrGenericGraphExtension.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/DeclarationAnalysisGraphAndDac/Sources/InheritingFromTerminalGraphExtensions/InheritFromAbstractOrGenericGraphExtension.cs
@@ -1,6 +1,6 @@
 using PX.Data;
 
-namespace PX.Objects
+namespace Acuminator.Tests.Tests.StaticAnalysis.DeclarationAnalysisGraphAndDac.Sources
 {
 	// Extension inherits from abstract graph extension without PXProtectedAccess - should NOT report diagnostic
 	// Acuminator disable once PX1016 ExtensionDoesNotDeclareIsActiveMethod extension should be constantly active
@@ -10,6 +10,20 @@ namespace PX.Objects
 
 	public abstract class AbstractExtension : PXGraphExtension<SomeGraph>
 	{
+	}
+
+
+	// Acuminator disable once PX1016 ExtensionDoesNotDeclareIsActiveMethod extension should be constantly active
+	[PXProtectedAccess]
+	public abstract class InheritedFromAbstractExtensionWithPXProtectedAccessMembers : AbstractExtensionWithPXProtectedAccessMembers
+	{
+	}
+
+	// Is treated as abstract despite having PXProtectedAccess members
+	public abstract class AbstractExtensionWithPXProtectedAccessMembers : PXGraphExtension<SomeGraph>
+	{
+		[PXProtectedAccess]
+		protected abstract void Foo();
 	}
 
 	// Extension inherits from generic non-abstract extension - should NOT report diagnostic
@@ -28,6 +42,8 @@ namespace PX.Objects
 	public class SomeGraph : PXGraph<SomeGraph>
 	{
 		public PXSelect<SomeDac> Documents = null!;
+
+		protected void Foo() { }
 	}
 
 	[PXHidden]

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/DeclarationAnalysisGraphAndDac/Sources/InheritingFromTerminalGraphExtensions/InheritFromAbstractOrGenericGraphExtension.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/DeclarationAnalysisGraphAndDac/Sources/InheritingFromTerminalGraphExtensions/InheritFromAbstractOrGenericGraphExtension.cs
@@ -1,0 +1,37 @@
+using PX.Data;
+
+namespace PX.Objects
+{
+	// Extension inherits from abstract graph extension without PXProtectedAccess - should NOT report diagnostic
+	// Acuminator disable once PX1016 ExtensionDoesNotDeclareIsActiveMethod extension should be constantly active
+	public class InheritedFromAbstractExt : AbstractExtension
+	{
+	}
+
+	public abstract class AbstractExtension : PXGraphExtension<SomeGraph>
+	{
+	}
+
+	// Extension inherits from generic non-abstract extension - should NOT report diagnostic
+	// Acuminator disable once PX1016 ExtensionDoesNotDeclareIsActiveMethod extension should be constantly active
+	public class DerivedFromMultiGeneric : MultiGenericExtension<SomeDac, SomeDac>
+	{
+	}
+
+	// Non-abstract generic extension with multiple type parameters
+	public class MultiGenericExtension<TDac1, TDac2> : PXGraphExtension<SomeGraph>
+	where TDac1 : class, IBqlTable, new()
+	where TDac2 : class, IBqlTable, new()
+	{
+	}
+
+	public class SomeGraph : PXGraph<SomeGraph>
+	{
+		public PXSelect<SomeDac> Documents = null!;
+	}
+
+	[PXHidden]
+	public class SomeDac : IBqlTable
+	{
+	}
+}

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/DeclarationAnalysisGraphAndDac/Sources/InheritingFromTerminalGraphExtensions/InheritFromNonAbstractExtension.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/DeclarationAnalysisGraphAndDac/Sources/InheritingFromTerminalGraphExtensions/InheritFromNonAbstractExtension.cs
@@ -1,0 +1,31 @@
+using PX.Data;
+using PX.Data.DependencyInjection;
+
+namespace Acuminator.Tests.Tests.StaticAnalysis.DeclarationAnalysisGraphAndDac.Sources
+{
+	public class SomeGraph : PXGraph<SomeGraph>
+	{
+		public PXSelect<SomeDac> Documents = null!;
+	}
+
+	// Non-abstract graph extension - this is a terminal extension
+	// Acuminator disable once PX1016 ExtensionDoesNotDeclareIsActiveMethod extension should be constantly active
+	public class NonAbstractGraphExtension : PXGraphExtension<SomeGraph>
+	{
+	}
+
+	// This graph extension inherits from a non-abstract extension - should report PX1114
+	// Acuminator disable once PX1016 ExtensionDoesNotDeclareIsActiveMethod extension should be constantly active
+	public class DerivedGraphExtension : NonAbstractGraphExtension, ISomeInterface
+	{
+	}
+
+	public interface ISomeInterface 
+	{ }
+
+	[PXHidden]
+	public class SomeDac : IBqlTable
+	{
+		
+	}
+}

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/DeclarationAnalysisGraphAndDac/Sources/InheritingFromTerminalGraphExtensions/InheritFromNonAbstractExtensionIndirectly.BaseTypes.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/DeclarationAnalysisGraphAndDac/Sources/InheritingFromTerminalGraphExtensions/InheritFromNonAbstractExtensionIndirectly.BaseTypes.cs
@@ -1,0 +1,29 @@
+using PX.Data;
+
+namespace Acuminator.Tests.Tests.StaticAnalysis.DeclarationAnalysisGraphAndDac.Sources
+{
+	// Non-abstract graph extension - this is a terminal extension
+	// Acuminator disable once PX1016 ExtensionDoesNotDeclareIsActiveMethod extension should be constantly active
+	public class NonAbstractGraphExtension : PXGraphExtension<SomeGraph>
+	{
+	}
+
+	// Acuminator disable once PX1016 ExtensionDoesNotDeclareIsActiveMethod extension should be constantly active
+	public abstract class DerivedAbstractGraphExtension : NonAbstractGraphExtension, ISomeInterface
+	{
+	}
+
+	public class SomeGraph : PXGraph<SomeGraph>
+	{
+		public PXSelect<SomeDac> Documents = null!;
+	}
+
+	[PXHidden]
+	public class SomeDac : IBqlTable
+	{
+		
+	}
+
+	public interface ISomeInterface
+	{ }
+}

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/DeclarationAnalysisGraphAndDac/Sources/InheritingFromTerminalGraphExtensions/InheritFromNonAbstractExtensionIndirectly.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/DeclarationAnalysisGraphAndDac/Sources/InheritingFromTerminalGraphExtensions/InheritFromNonAbstractExtensionIndirectly.cs
@@ -1,0 +1,9 @@
+using PX.Data;
+
+namespace Acuminator.Tests.Tests.StaticAnalysis.DeclarationAnalysisGraphAndDac.Sources
+{
+	// Acuminator disable once PX1016 ExtensionDoesNotDeclareIsActiveMethod extension should be constantly active
+	public class MostDerivedGraphExtension : DerivedAbstractGraphExtension, ISomeInterface
+	{
+	}
+}

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/DeclarationAnalysisGraphAndDac/Sources/InheritingFromTerminalGraphExtensions/InheritFromPXProtectedAccessExtension.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/DeclarationAnalysisGraphAndDac/Sources/InheritingFromTerminalGraphExtensions/InheritFromPXProtectedAccessExtension.cs
@@ -1,0 +1,28 @@
+using PX.Data;
+
+namespace Acuminator.Tests.Tests.StaticAnalysis.DeclarationAnalysisGraphAndDac.Sources
+{
+	public class SomeGraph : PXGraph<SomeGraph>
+	{
+		public PXSelect<SomeDac> Documents = null!;
+	}
+
+	// Abstract graph extension with PXProtectedAccess - this is still considered terminal
+	// Acuminator disable once PX1016 ExtensionDoesNotDeclareIsActiveMethod extension should be constantly active
+	[PXProtectedAccess]
+	public abstract class PXProtectedAccessExtension : PXGraphExtension<SomeGraph>
+	{
+	}
+
+	// This graph extension inherits from PXProtectedAccess extension - should report PX1114
+	// Acuminator disable once PX1016 ExtensionDoesNotDeclareIsActiveMethod extension should be constantly active
+	public class DerivedFromProtectedExtension : PXProtectedAccessExtension
+	{
+	}
+
+	[PXHidden]
+	public class SomeDac : IBqlTable
+	{
+	
+	}
+}

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/DeclarationAnalysisGraphAndDac/Sources/InheritingFromTerminalGraphExtensions/RegularGraphInheritance.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/DeclarationAnalysisGraphAndDac/Sources/InheritingFromTerminalGraphExtensions/RegularGraphInheritance.cs
@@ -1,0 +1,31 @@
+using PX.Data;
+
+namespace Acuminator.Tests.Tests.StaticAnalysis.DeclarationAnalysisGraphAndDac.Sources
+{
+	// Graph inheriting from another non-abstract graph - should NOT report diagnostic
+	public class DerivedGraph : RegularGraph
+	{
+		public PXSelect<SomeDac> AdditionalDocuments = null!;
+	}
+
+	public class RegularGraph : PXGraph<RegularGraph>
+	{
+		public PXSelect<SomeDac> Documents = null!;
+	}
+
+	// Graph inheriting from abstract graph - should NOT report diagnostic
+	public class ConcreteGraph : AbstractGraph
+	{
+	}
+
+	public abstract class AbstractGraph : PXGraph<AbstractGraph>
+	{
+		public PXSelect<SomeDac> Documents = null!;
+	}
+
+	[PXHidden]
+	public class SomeDac : IBqlTable
+	{
+		
+	}
+}

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/ISymbolGenericUtils.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/ISymbolGenericUtils.cs
@@ -122,11 +122,11 @@ namespace Acuminator.Utilities.Roslyn.Semantic
 		}
 
 		/// <summary>
-		/// Gets the <paramref name="symbol"/> and its overriden symbols.
+		/// Gets the <paramref name="symbol"/> and its overridden symbols.
 		/// </summary>
 		/// <param name="symbol">The symbol to act on.</param>
 		/// <returns>
-		/// The <paramref name="symbol"/> and its overriden symbols.
+		/// The <paramref name="symbol"/> and its overridden symbols.
 		/// </returns>
 		public static IEnumerable<TSymbol> GetOverriddenAndThis<TSymbol>(this TSymbol symbol)
 		where TSymbol : class, ISymbol
@@ -138,11 +138,11 @@ namespace Acuminator.Utilities.Roslyn.Semantic
 		}
 
 		/// <summary>
-		/// Gets the overriden symbols of <paramref name="symbol"/>.
+		/// Gets the overridden symbols of <paramref name="symbol"/>.
 		/// </summary>
 		/// <param name="symbol">The symbol to act on.</param>
 		/// <returns>
-		/// The overriden symbols of <paramref name="symbol"/>.
+		/// The overridden symbols of <paramref name="symbol"/>.
 		/// </returns>
 		public static IEnumerable<TSymbol> GetOverridden<TSymbol>(this TSymbol symbol)
 		where TSymbol : class, ISymbol
@@ -199,8 +199,8 @@ namespace Acuminator.Utilities.Roslyn.Semantic
 		/// <remarks>
 		/// This method is a safety wrapper for locations that are obtained from <see cref="SyntaxToken.GetLocation"/> tokens.<br/>
 		/// Syntax tokens may return a special null-object location with <see cref="LocationKind.None"/> kind.<br/>
-		/// Such "null-object" location will prevent the usage of any fallback location that could have been obtained from coalesce chainings if the location was null.<br/>
-		/// This helper allows to use coalsesce chaining with fallback locations in a safe manner.<br/><br/>
+		/// Such "null-object" location will prevent the usage of any fallback location that could have been obtained from coalesce chaining if the location was null.<br/>
+		/// This helper allows to use coalesce chaining with fallback locations in a safe manner.<br/><br/>
 		/// Note, that locations obtained from <see cref="CSharpSyntaxNode.GetLocation"/> do not need to be checked this way.
 		/// </remarks>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Syntax/PXGraph/GraphSyntaxUtils.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Syntax/PXGraph/GraphSyntaxUtils.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
 
@@ -106,9 +107,21 @@ namespace Acuminator.Utilities.Roslyn.Syntax.PXGraph
 			return typeSymbol;
 		}
 
-		public static (INamedTypeSymbol TypeSymbol, TypeSyntax TypeNode)? GetBaseGraphTypeInfo(SemanticModel semanticModel, PXContext pxContext,
-																								ClassDeclarationSyntax? graphNode,
-																								CancellationToken cancellation)
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static (INamedTypeSymbol TypeSymbol, TypeSyntax TypeNode)? GetBaseGraphTypeInfo(SemanticModel semanticModel, 
+																								PXContext pxContext, ClassDeclarationSyntax? graphNode,
+																								CancellationToken cancellation) =>
+			GetBaseGraphOrExtensionTypeInfo(semanticModel, pxContext, graphNode, lookForGraphExtension: false, cancellation);
+
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static (INamedTypeSymbol TypeSymbol, TypeSyntax TypeNode)? GetBaseGraphExtensionTypeInfo(SemanticModel semanticModel,
+																										PXContext pxContext, ClassDeclarationSyntax? graphNode,
+																										CancellationToken cancellation) =>
+			GetBaseGraphOrExtensionTypeInfo(semanticModel, pxContext, graphNode, lookForGraphExtension: true, cancellation);
+
+		private static (INamedTypeSymbol TypeSymbol, TypeSyntax TypeNode)? GetBaseGraphOrExtensionTypeInfo(SemanticModel semanticModel,
+																						PXContext pxContext, ClassDeclarationSyntax? graphNode,
+																						bool lookForGraphExtension,  CancellationToken cancellation)
 		{
 			semanticModel.ThrowOnNull();
 			pxContext.ThrowOnNull();
@@ -131,7 +144,12 @@ namespace Acuminator.Utilities.Roslyn.Syntax.PXGraph
 					continue;
 				}
 
-				if (baseTypeSymbol.IsPXGraph(pxContext))
+				if (lookForGraphExtension)
+				{
+					if (baseTypeSymbol.IsPXGraphExtension(pxContext))
+						return (baseTypeSymbol, typeSyntax.Type);
+				}
+				else if (baseTypeSymbol.IsPXGraph(pxContext))
 					return (baseTypeSymbol, typeSyntax.Type);
 			}
 

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Syntax/PXGraph/GraphSyntaxUtils.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Syntax/PXGraph/GraphSyntaxUtils.cs
@@ -3,9 +3,11 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading;
+
 using Acuminator.Utilities.Common;
 using Acuminator.Utilities.Roslyn.Semantic;
 using Acuminator.Utilities.Roslyn.Semantic.PXGraph;
+
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
@@ -102,6 +104,38 @@ namespace Acuminator.Utilities.Roslyn.Syntax.PXGraph
 			}
 
 			return typeSymbol;
+		}
+
+		public static (INamedTypeSymbol TypeSymbol, TypeSyntax TypeNode)? GetBaseGraphTypeInfo(SemanticModel semanticModel, PXContext pxContext,
+																								ClassDeclarationSyntax? graphNode,
+																								CancellationToken cancellation)
+		{
+			semanticModel.ThrowOnNull();
+			pxContext.ThrowOnNull();
+
+			if (graphNode?.BaseList == null)
+				return null;
+
+			var baseTypes = graphNode.BaseList.Types;
+
+			if (baseTypes.Count == 0)
+				return null;
+
+			foreach (var typeSyntax in baseTypes)
+			{
+				cancellation.ThrowIfCancellationRequested();
+
+				if (typeSyntax?.Type == null ||
+					semanticModel.GetTypeInfo(typeSyntax.Type).Type is not INamedTypeSymbol baseTypeSymbol)
+				{
+					continue;
+				}
+
+				if (baseTypeSymbol.IsPXGraph(pxContext))
+					return (baseTypeSymbol, typeSyntax.Type);
+			}
+
+			return null;
 		}
 	}
 }


### PR DESCRIPTION
**MERGE INTO `dev` BRANCH AFTER https://github.com/Acumatica/Acuminator/pull/622** 

Added PX1114 diagnostic to report graph extensions inherited from terminal graph extensions.  

A **terminal** graph extension is a graph extension that will be instantiated by Acumatica Framework at runtime 
during the initialization of the corresponding graph. Currently, there are two types of terminal extensions:
1. **Non-abstract and non-generic graph extension**: A concrete graph extension without generic type parameters.
2. **Abstract graph extension with PXProtectedAccess attribute**: An abstract graph extension decorated with the `[PXProtectedAccess]` attribute.

#### Changes Overview
- Implemented PX1114 diagnostic logic to detect C# inheritance from terminal graph extensions.  
- Created unit tests for PX1114 with various inheritance scenarios.  
- Added new graph syntax helper to retrieve base graph or graph extension type information.
- Added prompt file **`UnitTests.prompt.md`** with AI guidelines for generation of Acuminator unit tests.   
- Added documentation for PX1114, including examples and diagnostic details. 
- Updated code examples in documentation for some other diagnostics
