### PR TITLE
Feature/atr 837 dev fix px1120 false alerts on lambdas

### DIFF
--- a/src/Acuminator/Acuminator.Analyzers/Resources.Designer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/Resources.Designer.cs
@@ -61,7 +61,7 @@ namespace Acuminator.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Fix action delegate return type and parameters.
+        ///   Looks up a localized string similar to Fix the return type and the parameters of the action delegate.
         /// </summary>
         public static string PX1000Fix {
             get {
@@ -1240,7 +1240,7 @@ namespace Acuminator.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to PXGraph and PXGraphExtension instances should not start long-running operations during the initialization phase.
+        ///   Looks up a localized string similar to PXGraph and PXGraphExtension instances should not start a long-running operation during the initialization phase.
         /// </summary>
         public static string PX1054Title {
             get {
@@ -2358,7 +2358,7 @@ namespace Acuminator.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Incorrect work with Task types in the Acumatica asynchronous code. Method returning a Task-typed expression should have Task type as its return type..
+        ///   Looks up a localized string similar to Incorrect work with the Task types in the Acumatica asynchronous code. Method returning a Task-typed expression should have the Task type as its return type..
         /// </summary>
         public static string PX1120Title_MethodReturnTypeIsNotTask {
             get {
@@ -2367,7 +2367,7 @@ namespace Acuminator.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Incorrect work with Task types in the Acumatica asynchronous code. Task-typed expressions should be awaited..
+        ///   Looks up a localized string similar to Incorrect work with the Task types in the Acumatica asynchronous code. Task-typed expressions should be awaited..
         /// </summary>
         public static string PX1120Title_NotAwaitedTaskReturningExpression {
             get {
@@ -2376,7 +2376,7 @@ namespace Acuminator.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Incorrect work with Task types in the Acumatica asynchronous code. You should not store Task instance in a local variable or parameter..
+        ///   Looks up a localized string similar to Incorrect work with the Task types in the Acumatica asynchronous code. You should not store the Task instance in a local variable or parameter..
         /// </summary>
         public static string PX1120Title_StoreTaskInVariable {
             get {

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/IncorrectTaskUsageInAsyncCode/IncorrectTaskUsageInAsyncCodeAnalyzer.TaskUsageCheckingWalker.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/IncorrectTaskUsageInAsyncCode/IncorrectTaskUsageInAsyncCodeAnalyzer.TaskUsageCheckingWalker.cs
@@ -116,6 +116,22 @@ namespace Acuminator.Analyzers.StaticAnalysis.IncorrectTaskUsageInAsyncCode
 				base.VisitArrowExpressionClause(arrowExpressionMethodBody);
 			}
 
+			// No need to check anonymous methods in addition to lambdas - they are covered by visiting return expressions
+
+			public override void VisitParenthesizedLambdaExpression(ParenthesizedLambdaExpressionSyntax parenthesizedLambdaExpression)
+			{
+				Cancellation.ThrowIfCancellationRequested();
+				CheckTypeMemberReturningTaskHasTaskReturnType(parenthesizedLambdaExpression.ExpressionBody);
+				base.VisitParenthesizedLambdaExpression(parenthesizedLambdaExpression);
+			}
+
+			public override void VisitSimpleLambdaExpression(SimpleLambdaExpressionSyntax simpleLambdaExpression)
+			{
+				Cancellation.ThrowIfCancellationRequested();
+				CheckTypeMemberReturningTaskHasTaskReturnType(simpleLambdaExpression.ExpressionBody);
+				base.VisitSimpleLambdaExpression(simpleLambdaExpression);
+			}
+
 			private void CheckTypeMemberReturningTaskHasTaskReturnType(ExpressionSyntax? returnExpression)
 			{
 				if (returnExpression == null)

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/IncorrectTaskUsageInAsyncCode/IncorrectTaskUsageInAsyncCodeAnalyzer.TaskUsageCheckingWalker.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/IncorrectTaskUsageInAsyncCode/IncorrectTaskUsageInAsyncCodeAnalyzer.TaskUsageCheckingWalker.cs
@@ -81,7 +81,8 @@ namespace Acuminator.Analyzers.StaticAnalysis.IncorrectTaskUsageInAsyncCode
 				Cancellation.ThrowIfCancellationRequested();
 
 				// Do a cheaper check for awaited or immediately returned invocations first to avoid extra queries to the semantic model
-				if (invocationExpression.Parent is AwaitExpressionSyntax or ReturnStatementSyntax or ArrowExpressionClauseSyntax)
+				if (invocationExpression.Parent is AwaitExpressionSyntax or ReturnStatementSyntax or ArrowExpressionClauseSyntax or
+												   AnonymousFunctionExpressionSyntax)
 				{
 					base.VisitInvocationExpression(invocationExpression);
 					return;

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/IncorrectTaskUsageInAsyncCode/IncorrectTaskUsageInAsyncCodeAnalyzer.TaskUsageCheckingWalker.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/IncorrectTaskUsageInAsyncCode/IncorrectTaskUsageInAsyncCodeAnalyzer.TaskUsageCheckingWalker.cs
@@ -126,7 +126,26 @@ namespace Acuminator.Analyzers.StaticAnalysis.IncorrectTaskUsageInAsyncCode
 				if (returnExpressionType == null || !IsTaskType(returnExpressionType))
 					return;
 
-				var containingMethodOrLocalFunction = returnExpression.GetContainingMemberOrLocalFunction();
+				var containingMethodOrLocalFunction = returnExpression.GetContainingMemberOrLocalFunctionOrLambda();
+				var returnTypeSymbol = GetContainingMethodReturnType(containingMethodOrLocalFunction);
+
+				if (returnTypeSymbol == null || IsTaskType(returnTypeSymbol))
+					return;
+
+				var location   = returnExpression.GetLocation();
+				var diagnostic = Diagnostic.Create(Descriptors.PX1120_IncorrectTaskUsageInAsyncCode_MethodReturnTypeIsNotTask, location);
+
+				_syntaxContext.ReportDiagnosticWithSuppressionCheck(diagnostic, _pxContext.CodeAnalysisSettings);
+			}
+
+			private ITypeSymbol? GetContainingMethodReturnType(SyntaxNode? containingMethodOrLocalFunction)
+			{
+				if (containingMethodOrLocalFunction is AnonymousFunctionExpressionSyntax lambdaDeclaration)
+				{
+					var lambdaSymbol = SemanticModel.GetSymbolOrFirstCandidate(lambdaDeclaration, Cancellation) as IMethodSymbol;
+					return lambdaSymbol?.ReturnType;
+				}
+
 				var returnTypeNode = containingMethodOrLocalFunction switch
 				{
 					MethodDeclarationSyntax methodDeclaration	  => methodDeclaration.ReturnType,
@@ -136,17 +155,10 @@ namespace Acuminator.Analyzers.StaticAnalysis.IncorrectTaskUsageInAsyncCode
 				};
 
 				if (returnTypeNode == null)
-					return;
+					return null;
 
 				var returnTypeSymbol = SemanticModel.GetSymbolOrFirstCandidate(returnTypeNode, Cancellation) as ITypeSymbol;
-
-				if (returnTypeSymbol == null || IsTaskType(returnTypeSymbol))
-					return;
-
-				var location   = returnExpression.GetLocation();
-				var diagnostic = Diagnostic.Create(Descriptors.PX1120_IncorrectTaskUsageInAsyncCode_MethodReturnTypeIsNotTask, location);
-
-				_syntaxContext.ReportDiagnosticWithSuppressionCheck(diagnostic, _pxContext.CodeAnalysisSettings);
+				return returnTypeSymbol;
 			}
 
 			private bool IsTaskType(ITypeSymbol typeSymbol) =>

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/LongOperationDelegateClosures/LongOperationDelegateClosuresAnalyzer.CapturedLocalInstancesInExpressionsChecker.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/LongOperationDelegateClosures/LongOperationDelegateClosuresAnalyzer.CapturedLocalInstancesInExpressionsChecker.cs
@@ -1,11 +1,10 @@
-﻿
-using System;
+﻿using System;
 using System.Linq;
-using System.Linq.Expressions;
 using System.Threading;
 
 using Acuminator.Utilities.Common;
 using Acuminator.Utilities.Roslyn.Semantic;
+using Acuminator.Utilities.Roslyn.Syntax;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -160,7 +159,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.LongOperationDelegateClosures
 				ISymbol? identifierSymbol = _semanticModel.GetSymbolInfo(identifierName, _cancellation).Symbol;
 
 				if (identifierSymbol == null || (identifierSymbol.Kind != SymbolKind.Method && identifierSymbol.IsStatic) ||
-					(identifierSymbol is IMethodSymbol methodSymbol && methodSymbol.IsDefinitelyStatic(_cancellation)))
+					(identifierSymbol is IMethodSymbol methodSymbol && methodSymbol.IsStatic))
 				{
 					return CapturedInstancesTypes.None;
 				}
@@ -168,12 +167,10 @@ namespace Acuminator.Analyzers.StaticAnalysis.LongOperationDelegateClosures
 				switch (identifierSymbol.Kind)
 				{
 					case SymbolKind.Local:
-						if (!(identifierSymbol is ILocalSymbol))
+						if (identifierSymbol is not ILocalSymbol)
 							return CapturedInstancesTypes.None;
 
-						var localVariableDeclarator = identifierSymbol.DeclaringSyntaxReferences
-																	  .FirstOrDefault()
-																	 ?.GetSyntax(_cancellation) as VariableDeclaratorSyntax;
+						var localVariableDeclarator = identifierSymbol.GetSyntax(_cancellation) as VariableDeclaratorSyntax;
 
 						// Check variable declaration to investigated assigned values.
 						// We do not check for assignments to the variable done after the declaration since this case is both difficult to analyze and very rare.
@@ -186,7 +183,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.LongOperationDelegateClosures
 						// Instance methods, properties, fields and events hold closure
 						return TypeMemberAccessCapturesGraph(identifierSymbol.ContainingType)
 							? CapturedInstancesTypes.PXGraph
-							: CapturedInstancesTypes.None;      
+							: CapturedInstancesTypes.None;
 
 					case SymbolKind.Parameter:
 						var nonCapturableParameter = FindNonCapturableParameterPassedToMethod(identifierSymbol.Name);

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/LongOperationDelegateClosures/LongOperationDelegateClosuresAnalyzer.LongOperationsChecker.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/LongOperationDelegateClosures/LongOperationDelegateClosuresAnalyzer.LongOperationsChecker.cs
@@ -318,7 +318,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.LongOperationDelegateClosures
 
 				var argumentsList = callSite.GetArgumentsList();
 
-				if (argumentsList == null || (argumentsList.Arguments.Count == 0 && calledMethod.MethodKind != MethodKind.LocalFunction))
+				if (argumentsList == null || (argumentsList.Arguments.Count == 0 && !calledMethod.IsNestedMethod()))
 					return null;
 
 				var callingTypeMemberOrLambdaOrLocalFunctionNode = callSite.GetContainingMemberOrLocalFunctionOrLambda();

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/LongOperationDelegateClosures/LongOperationDelegateClosuresAnalyzer.LongOperationsChecker.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/LongOperationDelegateClosures/LongOperationDelegateClosuresAnalyzer.LongOperationsChecker.cs
@@ -228,7 +228,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.LongOperationDelegateClosures
 					if (nonCapturableParametersOfMethodContainingCallSite == null)
 						return null;
 
-					var callingNode = longOperationStartMethodInvocationNode.GetContainingMemberOrLocalFunction();
+					var callingNode = longOperationStartMethodInvocationNode.GetContainingMemberOrLocalFunctionOrLambda();
 
 					if (callingNode == null)
 						return null;
@@ -245,7 +245,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.LongOperationDelegateClosures
 				}
 				else                           // if we are at the top of call stack then we need to look for adapter parameter in case we are in action handler
 				{
-					var callingMethodNode = longOperationStartMethodInvocationNode.GetContainingMemberOrLocalFunction();
+					var callingMethodNode = longOperationStartMethodInvocationNode.GetContainingMemberOrLocalFunctionOrLambda();
 
 					if (callingMethodNode == null)
 						return null;
@@ -300,7 +300,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.LongOperationDelegateClosures
 					return false;
 
 				// Otherwise, we need to step only into non-static methods of graphs/graph extensions since they can capture "this" reference
-				return calledMethod.IsDefinitelyStatic(calledMethodNode) || calledMethod.ContainingType == null || !calledMethod.ContainingType.IsPXGraphOrExtension(PxContext);
+				return calledMethod.IsStatic || calledMethod.ContainingType == null || !calledMethod.ContainingType.IsPXGraphOrExtension(PxContext);
 			}
 
 			protected override void AfterRecursiveVisit(IMethodSymbol calledMethod, CSharpSyntaxNode calledMethodNode, ExpressionSyntax callSite, bool wasVisited)
@@ -321,18 +321,18 @@ namespace Acuminator.Analyzers.StaticAnalysis.LongOperationDelegateClosures
 				if (argumentsList == null || (argumentsList.Arguments.Count == 0 && calledMethod.MethodKind != MethodKind.LocalFunction))
 					return null;
 
-				var callingTypeMemberOrLocalFunctionNode = callSite.GetContainingMemberOrLocalFunction();
+				var callingTypeMemberOrLambdaOrLocalFunctionNode = callSite.GetContainingMemberOrLocalFunctionOrLambda();
 
-				if (callingTypeMemberOrLocalFunctionNode == null)
+				if (callingTypeMemberOrLambdaOrLocalFunctionNode == null)
 					return null;
 
 				SemanticModel? semanticModel = GetSemanticModel(callSite.SyntaxTree);
-				ISymbol? callingTypeMember = semanticModel?.GetDeclaredSymbol(callingTypeMemberOrLocalFunctionNode, CancellationToken);
+				ISymbol? callingTypeMember = semanticModel?.GetDeclaredSymbol(callingTypeMemberOrLambdaOrLocalFunctionNode, CancellationToken);
 
 				if (callingTypeMember?.ContainingType == null)
 					return null;
 
-				var nonCapturableParameters = GetNonCapturableParameters(callingTypeMember, callingTypeMemberOrLocalFunctionNode, argumentsList, 
+				var nonCapturableParameters = GetNonCapturableParameters(callingTypeMember, callingTypeMemberOrLambdaOrLocalFunctionNode, argumentsList, 
 																		 callSite, semanticModel!, calledMethod, calledMethodNode);
 				if (nonCapturableParameters.IsNullOrEmpty())
 					return null;
@@ -347,7 +347,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.LongOperationDelegateClosures
 					return true;
 
 				// If the method doesn't have parameters it can capture this reference unless it is a static method
-				if (calledMethod.IsDefinitelyStatic(calledMethodNode))
+				if (calledMethod.IsStatic)
 					return false;
 
 				bool isInsideGraph = calledMethod.ContainingType?.IsPXGraphOrExtension(PxContext) ?? false;
@@ -356,8 +356,8 @@ namespace Acuminator.Analyzers.StaticAnalysis.LongOperationDelegateClosures
 				if (isInsideGraph)
 					return true;
 
-				// If the method is a non static local function it can also capture parameters from the outer method
-				if (calledMethod.MethodKind == MethodKind.LocalFunction && calledMethod.ContainingSymbol is IMethodSymbol containingMethod)
+				// If the method is a non static local function or lambda it can also capture parameters from the outer method
+				if (calledMethod.IsNestedMethod() && calledMethod.ContainingSymbol is IMethodSymbol containingMethod)
 					return !containingMethod.Parameters.IsDefaultOrEmpty;
 				
 				return false;
@@ -445,14 +445,14 @@ namespace Acuminator.Analyzers.StaticAnalysis.LongOperationDelegateClosures
 				if (callingMethod?.ContainingType == null)
 					return null;
 
-				var actionHandlerMethod = callingMethod.MethodKind != MethodKind.LocalFunction
+				var actionHandlerMethod = !callingMethod.IsNestedMethod()
 					? callingMethod
-					: callingMethod.GetStaticOrNonLocalContainingMethod(CancellationToken);
+					: callingMethod.GetStaticOrNonLocalContainingMethod();
 
-				// When we check local function declared we try to get the non local containing method OR first containing static local function
+				// When we check local function declared we try to get the non local containing method OR first containing static local function or lambda
 				// If we obtain the former than our local function can potentially use adapter parameter from the action handler.
-				// Otherwise, in case of a static local function it will be unavailable and we can return
-				if (actionHandlerMethod == null || actionHandlerMethod.MethodKind == MethodKind.LocalFunction)
+				// Otherwise, in case of a static local function or lambda it will be unavailable and we can return
+				if (actionHandlerMethod == null || actionHandlerMethod.IsNestedMethod())
 					return null;
 
 				if (actionHandlerMethod.Parameters.IsDefaultOrEmpty)
@@ -465,8 +465,8 @@ namespace Acuminator.Analyzers.StaticAnalysis.LongOperationDelegateClosures
 					return null;
 
 				// Check if parameter is redefined by local functions
-				if (callingMethod.MethodKind == MethodKind.LocalFunction &&
-					callingMethod.IsNonLocalMethodParameterRedefined(adapterParameter.Name, CancellationToken))
+				if (callingMethod.IsNestedMethod() &&
+					callingMethod.IsNonLocalMethodParameterRedefined(adapterParameter.Name))
 				{
 					return null;
 				}
@@ -529,9 +529,9 @@ namespace Acuminator.Analyzers.StaticAnalysis.LongOperationDelegateClosures
 				if (parametersPassedBefore == null || parametersPassedBefore.Count == 0)
 					return default;
 
-				// For called non static local functions we need to assume that all parameters passed before can be used inside the function
+				// For called non static local functions and lambdas we need to assume that all parameters passed before can be used inside the function
 				NonCapturableElementsInfo? nonCapturableElementsInfo = 
-					calledMethod.MethodKind == MethodKind.LocalFunction && !calledMethod.IsDefinitelyStatic(calledMethodNode)
+					calledMethod.IsNestedMethod() && !calledMethod.IsStatic
 						? new NonCapturableElementsInfo(nonCapturableContainingMethodsParameters: parametersPassedBefore)
 						: null;
 
@@ -593,13 +593,13 @@ namespace Acuminator.Analyzers.StaticAnalysis.LongOperationDelegateClosures
 
 				var parametersPassedToCallingMethod = PeekPassedParametersFromStack();
 
-				if (callingMethod.MethodKind != MethodKind.LocalFunction)
+				if (!callingMethod.IsNestedMethod())
 					return parametersPassedToCallingMethod;
 
-				// Local functions can capture parameters from their containing methods (unless the parameter is redefined or the containing method is a static local function)
-				// We need to combile all parameters from outer methods that have non-capturable elements. 
+				// Local functions and lambdas can capture parameters from their containing methods (unless the parameter is redefined or the containing method is a static local function or lambda)
+				// We need to combine all parameters from outer methods that have non-capturable elements. 
 				// We could have retrieved them from the NonCapturablePassedParameters stack and combine but that would require some complex combining logic 
-				// for eacn of the nested local functions (of course, it's a rare case to have local functions and its even more rare to have a local function nested in local function).
+				// for each of the nested local functions (of course, it's a rare case to have local functions and its even more rare to have a local function nested in local function).
 				// 
 				// Instead we'll take a dynamic programming approach. 
 				// We will assume that for a call located in a nested local function the NonCapturablePassedParameters stack already contains all possible combined non-capturable parameters
@@ -609,8 +609,8 @@ namespace Acuminator.Analyzers.StaticAnalysis.LongOperationDelegateClosures
 				// - For a call in local function we combine non-capturable parameters passed to it with non-capturable parameters passed to the containing non-local method
 				// - For a call to a nested local function we combine non-capturable parameters passed to it with non-capturable parameters passed to its containing local function
 				// - And so on.
-				if (callingMethod.IsDefinitelyStatic(callingMethodNode))
-					return parametersPassedToCallingMethod;     // no extra parameters from outer methods can be used by the static local function
+				if (callingMethod.IsStatic)
+					return parametersPassedToCallingMethod;		// no extra parameters from outer methods can be used by the static local function
 
 				if (callingMethod.ContainingSymbol is not IMethodSymbol methodContainingCallToCallingMethod)
 					return parametersPassedToCallingMethod;

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/LongOperationDelegateClosures/LongOperationDelegateClosuresAnalyzer.NonCapturableElementsInArgumentsFinder.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/LongOperationDelegateClosures/LongOperationDelegateClosuresAnalyzer.NonCapturableElementsInArgumentsFinder.cs
@@ -116,7 +116,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.LongOperationDelegateClosures
 
 			private bool CallerIsStatic() =>
 				_callingTypeMember is IMethodSymbol methodSymbol
-					? methodSymbol.IsDefinitelyStatic(_cancellation)
+					? methodSymbol.IsStatic
 					: _callingTypeMember!.IsStatic;
 
 			public override void VisitInitializerExpression(InitializerExpressionSyntax initializer)

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/IncorrectTaskUsageInAsyncCode/IncorrectTaskUsageInAsyncCodeTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/IncorrectTaskUsageInAsyncCode/IncorrectTaskUsageInAsyncCodeTests.cs
@@ -83,7 +83,10 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.IncorrectTaskUsageInAsyncCode
 				Descriptors.PX1120_IncorrectTaskUsageInAsyncCode_MethodReturnTypeIsNotTask.CreateFor(25, 43),
 				Descriptors.PX1120_IncorrectTaskUsageInAsyncCode_MethodReturnTypeIsNotTask.CreateFor(28, 38),
 				Descriptors.PX1120_IncorrectTaskUsageInAsyncCode_MethodReturnTypeIsNotTask.CreateFor(39, 12),
-				Descriptors.PX1120_IncorrectTaskUsageInAsyncCode_MethodReturnTypeIsNotTask.CreateFor(42, 31));
+				Descriptors.PX1120_IncorrectTaskUsageInAsyncCode_MethodReturnTypeIsNotTask.CreateFor(42, 31),
+				Descriptors.PX1120_IncorrectTaskUsageInAsyncCode_MethodReturnTypeIsNotTask.CreateFor(48, 26),
+				Descriptors.PX1120_IncorrectTaskUsageInAsyncCode_MethodReturnTypeIsNotTask.CreateFor(51, 40),
+				Descriptors.PX1120_IncorrectTaskUsageInAsyncCode_MethodReturnTypeIsNotTask.CreateFor(54, 41));
 
 		[Theory]
 		[EmbeddedFileData(@"CorrectTaskUsage.cs")]

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/IncorrectTaskUsageInAsyncCode/IncorrectTaskUsageInAsyncCodeTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/IncorrectTaskUsageInAsyncCode/IncorrectTaskUsageInAsyncCodeTests.cs
@@ -90,6 +90,10 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.IncorrectTaskUsageInAsyncCode
 		public Task CorrectTaskUsage_NoDiagnostic(string source) => VerifyCSharpDiagnosticAsync(source);
 
 		[Theory]
+		[EmbeddedFileData(@"CorrectTaskUsageInLongOperationAPIs.cs")]
+		public Task CorrectTaskUsage_InLongOperationAPIs_NoDiagnostic(string source) => VerifyCSharpDiagnosticAsync(source);
+
+		[Theory]
 		[EmbeddedFileData(@"NonAsyncCode.cs")]
 		public Task NonAsyncCode_NoDiagnostic(string source) => VerifyCSharpDiagnosticAsync(source);
 	}

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/IncorrectTaskUsageInAsyncCode/Sources/CorrectTaskUsageInLongOperationAPIs.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/IncorrectTaskUsageInAsyncCode/Sources/CorrectTaskUsageInLongOperationAPIs.cs
@@ -31,8 +31,6 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.IncorrectTaskUsageInAsyncCode.So
 				var graph = PXGraph.CreateInstance<MyGraph>();
 				return graph.AuthorizeWithTerminalAsync();
 			});
-
-			PXLongOperation.StartOperation(this, () => ProcessMobilePaymentAsync());
 		}
 
 		

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/IncorrectTaskUsageInAsyncCode/Sources/CorrectTaskUsageInLongOperationAPIs.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/IncorrectTaskUsageInAsyncCode/Sources/CorrectTaskUsageInLongOperationAPIs.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+using PX.Data;
+
+namespace Acuminator.Tests.Tests.StaticAnalysis.IncorrectTaskUsageInAsyncCode.Sources
+{
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "VSTHRD101:Avoid unsupported async delegates", Justification = "<Pending>")]
+	public class MyGraph : PXGraph<MyGraph>
+	{
+		
+		public void Process()
+		{
+			LongOperationManager.StartAsyncOperation(ct => ProcessMobilePaymentAsync());
+
+			LongOperationManager.StartAsyncOperation(ProcessMobilePaymentWithCancellationAsync);
+
+			LongOperationManager.Await(cancellationToken => GetHelper().PreparePaymentFormAsync());
+			LongOperationManager.Await(async cancellationToken => await GetHelper().PreparePaymentFormAsync());
+			
+
+			LongOperationManager.StartAsyncOperation(ct =>
+			{
+				var graph = PXGraph.CreateInstance<MyGraph>();
+				return graph.AuthorizeWithTerminalAsync();
+			});
+
+			LongOperationManager.StartAsyncOperation(delegate (CancellationToken ct)
+			{
+				var graph = PXGraph.CreateInstance<MyGraph>();
+				return graph.AuthorizeWithTerminalAsync();
+			});
+
+			PXLongOperation.StartOperation(this, () => ProcessMobilePaymentAsync());
+		}
+
+		
+		private static Task ProcessMobilePaymentAsync()
+		{
+			return Task.CompletedTask;
+		}
+
+		private static Task ProcessMobilePaymentWithCancellationAsync(CancellationToken cancellationToken)
+		{
+			return Task.CompletedTask;
+		}
+
+		public virtual Task AuthorizeWithTerminalAsync() => Task.CompletedTask;
+
+
+		private static Helper GetHelper() => new Helper();
+	}
+
+	public class Helper
+	{
+		public virtual Task PreparePaymentFormAsync() => Task.CompletedTask;
+	}
+}

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/IncorrectTaskUsageInAsyncCode/Sources/MethodReturnTypeIsNotTask.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/IncorrectTaskUsageInAsyncCode/Sources/MethodReturnTypeIsNotTask.cs
@@ -42,6 +42,20 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.IncorrectTaskUsageInAsyncCode.So
 			object LocalFunction2() => GetValueAsync();
 		}
 
+		public Task UseFuncDelegate()
+		{
+			// Should report diagnostic - local function returns Task but return type is object
+			ProcessFunction(() => DelayAsync());
+
+			// Should report diagnostic - local function returns Task but return type is object
+			ProcessFunction(delegate() { return DelayAsync(); });
+
+			// Should report diagnostic - local function returns Task but return type is object
+			System.Func<int, object> func = i => DelayAsync();
+
+			return Task.CompletedTask;
+		}
+
 		private Task DelayAsync() => Task.Delay(100);
 
 		private Task<int> GetValueAsync() => Task.FromResult(42);
@@ -49,5 +63,10 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.IncorrectTaskUsageInAsyncCode.So
 		private ValueTask ProcessValueTaskAsync() => new ValueTask();
 
 		private ValueTask<string> GetStringAsync() => new ValueTask<string>("test");
+
+		private void ProcessFunction(System.Func<object> func)
+		{
+			var result = func();
+		}
 	}
 }

--- a/src/Acuminator/Acuminator.Tests/Tests/Utilities/LocalFunction/LocalFunctionTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/Utilities/LocalFunction/LocalFunctionTests.cs
@@ -7,9 +7,7 @@ using System.Threading.Tasks;
 
 using Acuminator.Tests.Helpers;
 using Acuminator.Tests.Verification;
-using Acuminator.Utilities;
 using Acuminator.Utilities.Roslyn.Semantic;
-using Acuminator.Utilities.Roslyn.Semantic.PXGraph;
 
 using FluentAssertions;
 
@@ -49,6 +47,36 @@ namespace Acuminator.Tests.Tests.Utilities.SemanticModels
 					symbol!.MethodKind.Should().Be(MethodKind.LocalFunction);
 					bool isStatic = symbol.Name.StartsWith("Static", StringComparison.OrdinalIgnoreCase);
 
+					symbol.IsStatic.Should().Be(isStatic);
+				}
+			}
+		}
+
+		[Theory]
+		[EmbeddedFileData("StaticLambda.cs")]
+		public async Task Static_Lambdas_Have_StaticSymbols(string text)
+		{
+			var (document, semanticModel, root) = await PrepareTestSolutionAsync(text).ConfigureAwait(false);
+			var classDeclaration = root.DescendantNodes()
+									   .OfType<ClassDeclarationSyntax>()
+									   .FirstOrDefault();
+			classDeclaration.Should().NotBeNull();
+
+			var methods = classDeclaration.Members.OfType<MethodDeclarationSyntax>().ToList();
+
+			foreach (MethodDeclarationSyntax methodNode in methods)
+			{
+				string methodName = methodNode.Identifier.ValueText;
+				bool isStatic 	  = methodName.StartsWith("Static", StringComparison.OrdinalIgnoreCase);
+				var lambdas 	  = methodNode.DescendantNodes()
+											  .OfType<AnonymousFunctionExpressionSyntax>();
+
+				foreach (var lambda in lambdas)
+				{
+					var symbol = semanticModel.GetSymbolOrFirstCandidate(lambda, default) as IMethodSymbol;
+					symbol.Should().NotBeNull();
+
+					symbol!.MethodKind.Should().Be(MethodKind.LambdaMethod);
 					symbol.IsStatic.Should().Be(isStatic);
 				}
 			}

--- a/src/Acuminator/Acuminator.Tests/Tests/Utilities/LocalFunction/LocalFunctionTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/Utilities/LocalFunction/LocalFunctionTests.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Acuminator.Tests.Helpers;
+using Acuminator.Tests.Verification;
+using Acuminator.Utilities;
+using Acuminator.Utilities.Roslyn.Semantic;
+using Acuminator.Utilities.Roslyn.Semantic.PXGraph;
+
+using FluentAssertions;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+using Xunit;
+
+namespace Acuminator.Tests.Tests.Utilities.SemanticModels
+{
+	[SuppressMessage("Acuminator", "PX1120:Incorrect work with Task types in the Acumatica asynchronous code. Task-typed expressions should be awaited.",
+					 Justification = "<Pending>")]
+	public class LocalFunctionTests
+	{
+		[Theory]
+		[EmbeddedFileData("StaticLocalFunction.cs")]
+		public async Task Static_LocalFunctions_Have_StaticSymbols(string text)
+		{
+			var (document, semanticModel, root) = await PrepareTestSolutionAsync(text).ConfigureAwait(false);
+			var classDeclaration = root.DescendantNodes()
+									   .OfType<ClassDeclarationSyntax>()
+									   .FirstOrDefault();
+			classDeclaration.Should().NotBeNull();
+
+			var methods = classDeclaration.Members.OfType<MethodDeclarationSyntax>().ToList();
+
+			foreach (var methodNode in methods)
+			{
+				var localFunctions = methodNode.DescendantNodes()
+											   .OfType<LocalFunctionStatementSyntax>();
+
+				foreach (var localFunction in localFunctions)
+				{
+					var symbol = semanticModel.GetDeclaredSymbol(localFunction, default) as IMethodSymbol;
+					symbol.Should().NotBeNull();
+
+					symbol!.MethodKind.Should().Be(MethodKind.LocalFunction);
+					bool isStatic = symbol.Name.StartsWith("Static", StringComparison.OrdinalIgnoreCase);
+
+					symbol.IsStatic.Should().Be(isStatic);
+				}
+			}
+		}
+
+		protected async Task<(Document Document, SemanticModel SemanticModel, SyntaxNode Root)> PrepareTestSolutionAsync(string code, 
+																											CancellationToken cancellation = default)
+		{
+			code.Should().NotBeNullOrWhiteSpace();
+
+			Document document = SolutionBuilder.CreateDocument(code);
+
+			var compilationTask   = document.Project.GetCompilationAsync(cancellation);
+			var rootTask 		  = document.GetSyntaxRootAsync(cancellation);
+			var semanticModelTask = document.GetSemanticModelAsync(cancellation);
+
+			await Task.WhenAll(compilationTask, rootTask, semanticModelTask).ConfigureAwait(false);
+
+#pragma warning disable VSTHRD103 // Call async methods when in an async method
+			Compilation? compilation 	 = compilationTask.Result;
+			SyntaxNode? root 			 = rootTask.Result;
+			SemanticModel? semanticModel = semanticModelTask.Result;
+#pragma warning restore VSTHRD103 // Call async methods when in an async method
+
+			compilation.Should().NotBeNull();
+			semanticModel.Should().NotBeNull();
+			root.Should().NotBeNull();
+			
+			return (document, semanticModel!, root!);
+		}
+	}
+}

--- a/src/Acuminator/Acuminator.Tests/Tests/Utilities/LocalFunction/Sources/StaticLambda.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/Utilities/LocalFunction/Sources/StaticLambda.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Acuminator.Tests.Tests.Utilities.LocalFunction.Sources
+{
+	public class LocalFunctionContainer
+	{
+		public void Static()
+		{
+			Action staticAction1 = static () => Console.WriteLine("Static local function in instance method.");
+
+			Action<int> staticAction2 = static i =>
+			{
+				Console.WriteLine("Static local function in instance method.");
+			};
+
+			Action<int> staticAction3 = static (int i) =>
+			{
+				Console.WriteLine("Static local function in instance method.");
+			};
+
+			Action<int> staticAction4 = static delegate (int i)
+			{
+				Console.WriteLine("Static local function in instance method.");
+			};
+		}
+
+		public void Instance()
+		{
+			Action action1 = () =>
+			{
+				Console.WriteLine("Static local function in instance method.");
+			};
+
+			Action<int> action2 = i =>
+			{
+				Console.WriteLine("Static local function in instance method.");
+			};
+
+			Action<int> action3 = (int i) =>
+			{
+				Console.WriteLine("Static local function in instance method.");
+			};
+
+			Action<int> action4 = delegate (int i) {
+				Console.WriteLine("Static local function in instance method.");
+			};
+		}
+	}
+}

--- a/src/Acuminator/Acuminator.Tests/Tests/Utilities/LocalFunction/Sources/StaticLocalFunction.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/Utilities/LocalFunction/Sources/StaticLocalFunction.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Acuminator.Tests.Tests.Utilities.LocalFunction.Sources
+{
+	public class LocalFunctionContainer
+	{
+		public void InstanceMethodWithStaticLocalFunction()
+		{
+			StaticLocalFunction();
+			InstanceLocalFunction();
+
+			//------------------------------Local Function--------------------------------------------
+			static void StaticLocalFunction()
+			{
+				Console.WriteLine("Hello from static local function!");
+			}
+
+			void InstanceLocalFunction()
+			{
+				Console.WriteLine("Hello from instance local function!");
+			}
+		}
+
+		public static void StaticMethodWithStaticLocalFunction()
+		{
+			StaticLocalFunction();
+			InstanceLocalFunction();
+
+			//------------------------------Local Function--------------------------------------------
+			static void StaticLocalFunction()
+			{
+				Console.WriteLine("Hello from static local function!");
+			}
+
+			void InstanceLocalFunction()
+			{
+				Console.WriteLine("Hello from instance local function!");
+			}
+		}
+	}
+}

--- a/src/Acuminator/Acuminator.Tests/Tests/Utilities/SemanticModels/SemanticModelTestsBase.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/Utilities/SemanticModels/SemanticModelTestsBase.cs
@@ -18,7 +18,7 @@ using FluentAssertions;
 namespace Acuminator.Tests.Tests.Utilities.SemanticModels
 {
 	/// <summary>
-	/// A vase class for semantic model tests with some shared logic.
+	/// A base class for semantic model tests with some shared logic.
 	/// </summary>
 	public abstract class SemanticModelTestsBase<TSemanticModel>
 	where TSemanticModel : ISemanticModel

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/IMethodSymbolExtensions.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/IMethodSymbolExtensions.cs
@@ -167,51 +167,6 @@ namespace Acuminator.Utilities.Roslyn.Semantic
 			return false;
 		}
 
-
-		/// <summary>
-		/// Check if <paramref name="method"/> definitely static.
-		/// </summary>
-		/// <remarks>
-		/// There is a bug in older versions of Roslyn that local functions are always static: https://github.com/dotnet/roslyn/issues/27719 This code attempts to workaround it. <br/>
-		/// TODO: we need to remove this method after migration to more modern version of Roslyn.
-		/// </remarks>
-		/// <param name="method">The method to act on.</param>
-		/// <param name="cancellation">A token that allows processing to be cancelled.</param>
-		/// <returns>
-		/// True if <paramref name="method"/> is definitely static, false if not.
-		/// </returns>
-		public static bool IsDefinitelyStatic(this IMethodSymbol method, CancellationToken cancellation)
-		{
-			if (method.MethodKind != MethodKind.LocalFunction)
-				return method.IsStatic;
-
-			var methodDeclaration = method.GetSyntax(cancellation);
-			return methodDeclaration?.IsStatic() ?? method.IsStatic;
-		}
-
-		/// <summary>
-		/// Check if <paramref name="method"/> definitely static.
-		/// </summary>
-		/// <remarks>
-		/// There is a bug in older versions of Roslyn that local functions are always static: https://github.com/dotnet/roslyn/issues/27719 This code attempts to workaround it. <br/>
-		/// TODO: we need to remove this method after migration to more modern version of Roslyn.
-		/// </remarks>
-		/// <param name="method">The method to act on.</param>
-		/// <param name="methodDeclaration">The method declaration node.</param>
-		/// <returns>
-		/// True if <paramref name="method"/> is definitely static, false if not.
-		/// </returns>
-		public static bool IsDefinitelyStatic(this IMethodSymbol method, SyntaxNode methodDeclaration)
-		{
-			method.ThrowOnNull();
-			methodDeclaration.ThrowOnNull();
-
-			if (method.MethodKind != MethodKind.LocalFunction)
-				return method.IsStatic;
-
-			return methodDeclaration.IsStatic();
-		}
-
 		/// <summary>
 		/// Check if <paramref name="method"/> has either virtual, override or abstract signature.
 		/// </summary>

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/IMethodSymbolExtensions.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/IMethodSymbolExtensions.cs
@@ -24,7 +24,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic
 		}
 
 		/// <summary>
-		/// Check if the <paramref name="methodSymbol"/> is nested method ().
+		/// Check if the <paramref name="methodSymbol"/> is a nested method (local function or lambda).
 		/// </summary>
 		/// <param name="methodSymbol">The method to act on.</param>
 		/// <returns>

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/IMethodSymbolExtensions.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/IMethodSymbolExtensions.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading;
 
 using Acuminator.Utilities.Common;
@@ -14,6 +15,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic
 {
 	public static class IMethodSymbolExtensions
 	{
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static bool IsInstanceConstructor(this IMethodSymbol methodSymbol)
 		{
 			methodSymbol.ThrowOnNull();
@@ -22,51 +24,64 @@ namespace Acuminator.Utilities.Roslyn.Semantic
 		}
 
 		/// <summary>
+		/// Check if the <paramref name="methodSymbol"/> is nested method ().
+		/// </summary>
+		/// <param name="methodSymbol">The method to act on.</param>
+		/// <returns>
+		/// True if method is local function or lambda, false if not.
+		/// </returns>
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static bool IsNestedMethod([NotNullWhen(returnValue: true)] this IMethodSymbol? methodSymbol) =>
+			methodSymbol?.MethodKind is MethodKind.LocalFunction or MethodKind.LambdaMethod;
+
+		/// <summary>
 		/// Gets the topmost non-local method containing the local function declaration. In case of a non-local method returns itself.
 		/// </summary>
 		/// <param name="localFunction">The method that can be local function.</param>
 		/// <returns>
 		/// The non-local method containing the local function.
 		/// </returns>
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static IMethodSymbol? GetContainingNonLocalMethod(this IMethodSymbol localFunction) =>
-			GetStaticOrNonLocalContainingMethod(localFunction, stopOnStaticMethod: false, CancellationToken.None);
+			GetStaticOrNonLocalContainingMethod(localFunction, stopOnStaticMethod: false);
 
 		/// <summary>
 		/// Gets the topmost static or non-local method containing the <paramref name="localFunction"/>. In case of a non-local method returns itself.
 		/// </summary>
 		/// <param name="localFunction">The method that can be local function.</param>
-		/// <param name="cancellation">A token that allows processing to be cancelled.</param>
 		/// <returns>
 		/// the topmost static or non-local method containing the <paramref name="localFunction"/>.
 		/// </returns>
-		public static IMethodSymbol? GetStaticOrNonLocalContainingMethod(this IMethodSymbol localFunction, CancellationToken cancellation) =>
-			GetStaticOrNonLocalContainingMethod(localFunction, stopOnStaticMethod: true, cancellation);
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static IMethodSymbol? GetStaticOrNonLocalContainingMethod(this IMethodSymbol localFunction) =>
+			GetStaticOrNonLocalContainingMethod(localFunction, stopOnStaticMethod: true);
 
-		private static IMethodSymbol? GetStaticOrNonLocalContainingMethod(IMethodSymbol localFunction, bool stopOnStaticMethod,
-																		  CancellationToken cancellation)
+		private static IMethodSymbol? GetStaticOrNonLocalContainingMethod(IMethodSymbol localFunctionOrLambda, bool stopOnStaticMethod)
 		{
-			localFunction.ThrowOnNull();
+			localFunctionOrLambda.ThrowOnNull();
 
-			if (localFunction.MethodKind != MethodKind.LocalFunction)
-				return localFunction;
+			if (!localFunctionOrLambda.IsNestedMethod())
+				return localFunctionOrLambda;
 
-			IMethodSymbol? current = localFunction;
+			IMethodSymbol? current = localFunctionOrLambda;
 
-			while (current != null && current.MethodKind == MethodKind.LocalFunction && (!stopOnStaticMethod || !localFunction.IsDefinitelyStatic(cancellation)))
+			while (current.IsNestedMethod() && (!stopOnStaticMethod || !localFunctionOrLambda.IsStatic))
 				current = current.ContainingSymbol as IMethodSymbol;
 
 			return current;
 		}
 
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static IEnumerable<IMethodSymbol> GetContainingMethodsAndThis(this IMethodSymbol localFunction) =>
-			localFunction.CheckIfNull().MethodKind == MethodKind.LocalFunction
+			localFunction.CheckIfNull().IsNestedMethod()
 				? localFunction.GetContainingMethods(includeThis: true)
-				: new[] { localFunction };
+				: [localFunction];
 
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static IEnumerable<IMethodSymbol> GetContainingMethods(this IMethodSymbol localFunction) =>
-			localFunction.CheckIfNull().MethodKind == MethodKind.LocalFunction
+			localFunction.CheckIfNull().IsNestedMethod()
 				? localFunction.GetContainingMethods(includeThis: false)
-				: Enumerable.Empty<IMethodSymbol>();
+				: [];
 
 		private static IEnumerable<IMethodSymbol> GetContainingMethods(this IMethodSymbol localFunction, bool includeThis)
 		{
@@ -82,39 +97,41 @@ namespace Acuminator.Utilities.Roslyn.Semantic
 		}
 
 		/// <summary>
-		/// Gets all parameters available for local function including parameters from containing methods.
+		/// Gets all parameters available for local function or lambda including parameters from containing methods.
 		/// </summary>
-		/// <param name="localFunction">The method that can be a local function.</param>
-		/// <param name="includeOwnParameters">True to include, false to exclude <paramref name="localFunction"/>'s own parameters.</param>
+		/// <param name="localFunctionOrLambda">The method that can be a local function or lambda.</param>
+		/// <param name="includeOwnParameters">True to include, false to exclude <paramref name="localFunctionOrLambda"/>'s own parameters.</param>
+		/// <param name="cancellation">Cancellation token.</param>
 		/// <returns>
-		/// All parameters available for the local function including parameters from containing methods.
+		/// All parameters available for the local function or lambda including parameters from containing methods.
 		/// </returns>
-		public static ImmutableArray<IParameterSymbol> GetAllParametersAvailableForLocalFunction(this IMethodSymbol localFunction, bool includeOwnParameters,
-																								 CancellationToken cancellation)
+		public static ImmutableArray<IParameterSymbol> GetAllParametersAvailableForLocalFunctionOrLambda(this IMethodSymbol localFunctionOrLambda, 
+																										 bool includeOwnParameters, 
+																										 CancellationToken cancellation)
 		{
-			if (localFunction.CheckIfNull().MethodKind != MethodKind.LocalFunction)
-				return localFunction.Parameters;
+			if (!localFunctionOrLambda.CheckIfNull().IsNestedMethod())
+				return localFunctionOrLambda.Parameters;
 
 			ImmutableArray<IParameterSymbol>.Builder parametersBuilder;
 
-			if (localFunction.Parameters.IsDefaultOrEmpty || !includeOwnParameters)
+			if (localFunctionOrLambda.Parameters.IsDefaultOrEmpty || !includeOwnParameters)
 				parametersBuilder = ImmutableArray.CreateBuilder<IParameterSymbol>();
 			else
 			{
-				parametersBuilder = ImmutableArray.CreateBuilder<IParameterSymbol>(initialCapacity: localFunction.Parameters.Length);
-				parametersBuilder.AddRange(localFunction.Parameters);
+				parametersBuilder = ImmutableArray.CreateBuilder<IParameterSymbol>(initialCapacity: localFunctionOrLambda.Parameters.Length);
+				parametersBuilder.AddRange(localFunctionOrLambda.Parameters);
 			}
 
-			if (localFunction.IsStatic)
+			if (localFunctionOrLambda.IsStatic)
 				return parametersBuilder.ToImmutable();
 
-			IMethodSymbol? current = localFunction;
+			IMethodSymbol? current = localFunctionOrLambda;
 
 			do
 			{
 				cancellation.ThrowIfCancellationRequested();
 
-				var containingMethod = current.ContainingSymbol as IMethodSymbol;
+				var containingMethod = current!.ContainingSymbol as IMethodSymbol;
 
 				// For a non static nested local function we can add parameters from its containing local function even if it is static
 				// But we must stop after that and won't take parameters from the methods containing static local function
@@ -123,15 +140,16 @@ namespace Acuminator.Utilities.Roslyn.Semantic
 					// If we do not include parameters from the local function then check if the outer parameters are redefined by the local function parameters.
 					// Redefined parameters won't be available to the local function
 					var notReassignedParameters = from parameter in containingMethod.Parameters
-												  where !parametersBuilder.Contains(parameter) && 												
-														(includeOwnParameters || !localFunction.Parameters.Any(localParameter => localParameter.Name == parameter.Name))
+												  where !parametersBuilder.Contains(parameter) &&
+														(includeOwnParameters || 
+														 !localFunctionOrLambda.Parameters.Any(localParameter => localParameter.Name == parameter.Name))
 												  select parameter;
 					parametersBuilder.AddRange(notReassignedParameters);
 				}
 
 				current = containingMethod;
 			}
-			while (current?.MethodKind == MethodKind.LocalFunction && !current.IsDefinitelyStatic(cancellation));	
+			while (current.IsNestedMethod() && !current.IsStatic);
 
 			return parametersBuilder.ToImmutable();
 		}
@@ -139,24 +157,24 @@ namespace Acuminator.Utilities.Roslyn.Semantic
 		/// <summary>
 		/// Check if  the parameter <paramref name="parameterName"/> from the non local method is redefined.
 		/// </summary>
-		/// <param name="localMethod">The method that can be local function.</param>
+		/// <param name="localMethodOrLambda">The method that can be local function or lambda.</param>
 		/// <param name="parameterName">Name of the parameter.</param>
 		/// <returns>
-		/// True if non local method parameter is redefined in a local method, false if not.
+		/// True if non local method parameter is redefined in a local method or lambda, false if not.
 		/// </returns>
-		public static bool IsNonLocalMethodParameterRedefined(this IMethodSymbol localMethod, string parameterName, CancellationToken cancellation)
+		public static bool IsNonLocalMethodParameterRedefined(this IMethodSymbol localMethodOrLambda, string parameterName)
 		{
-			localMethod.ThrowOnNull();
+			localMethodOrLambda.ThrowOnNull();
 
-			if (parameterName.IsNullOrWhiteSpace() || localMethod.MethodKind != MethodKind.LocalFunction)
+			if (parameterName.IsNullOrWhiteSpace() || !localMethodOrLambda.IsNestedMethod())
 				return false;
 
-			IMethodSymbol? current = localMethod;
+			IMethodSymbol? current = localMethodOrLambda;
 
-			while (current?.MethodKind == MethodKind.LocalFunction)
+			while (current.IsNestedMethod())
 			{
 				if ((!current.Parameters.IsDefaultOrEmpty && current.Parameters.Any(p => p.Name == parameterName)) ||
-					current.IsDefinitelyStatic(cancellation))
+					current.IsStatic)
 				{
 					return true;
 				}

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Syntax/MethodDeclarationUtils.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Syntax/MethodDeclarationUtils.cs
@@ -129,21 +129,21 @@ namespace Acuminator.Utilities.Roslyn.Syntax
 		}
 
 		/// <summary>
-		/// A <see cref="SyntaxNode"/> extension method that gets containing type member or local function node for syntax <paramref name="node"/> inside the type member.<br/>
+		/// A <see cref="SyntaxNode"/> extension method that gets containing type member, local function node, or lambda for syntax <paramref name="node"/> inside the type member.<br/>
 		/// For <paramref name="node"/> outside any type members returns <c>null</c>.
 		/// </summary>
 		/// <param name="node">The syntax node.</param>
 		/// <returns>
-		/// Declaration of the containing type member or local function.
+		/// Declaration of the containing type member, local function, or lambda.
 		/// </returns>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static SyntaxNode? GetContainingMemberOrLocalFunction(this SyntaxNode? node)
+		public static SyntaxNode? GetContainingMemberOrLocalFunctionOrLambda(this SyntaxNode? node)
 		{
 			SyntaxNode? curNode = node?.Parent;
 
 			while (curNode != null)
 			{
-				if (curNode is (MemberDeclarationSyntax or LocalFunctionStatementSyntax))
+				if (curNode is (MemberDeclarationSyntax or LocalFunctionStatementSyntax or AnonymousFunctionExpressionSyntax))
 					return curNode;
 
 				curNode = curNode.Parent;

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Walkers/ParametersReassignedFinder.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Walkers/ParametersReassignedFinder.cs
@@ -255,28 +255,27 @@ namespace Acuminator.Utilities.Roslyn.Walkers
 				if (invocationExpression.Expression is not IdentifierNameSyntax)
 					return;
 
-				var symbolInfo = _semanticModel.GetSymbolInfo(invocationExpression, _cancellation);
-				var localFunction = (symbolInfo.Symbol ?? symbolInfo.CandidateSymbols.FirstOrDefault()) as IMethodSymbol;
+				var localFunctionOrLambda = _semanticModel?.GetSymbolOrFirstCandidate(invocationExpression, _cancellation) as IMethodSymbol;
 
 				// Analyse local functions since they can reassign parameters from containing methods
-				if (localFunction == null || localFunction.MethodKind != MethodKind.LocalFunction)
+				if (localFunctionOrLambda == null || !localFunctionOrLambda.IsNestedMethod())
 					return;
 
-				if (_checkedLocalFunctions?.Contains(localFunction) == true)
+				if (_checkedLocalFunctions?.Contains(localFunctionOrLambda) == true)
 					return;
 
-				AddToCheckedLocalFunctions(localFunction);
+				AddToCheckedLocalFunctions(localFunctionOrLambda);
 
 				// Local method may have parameters with the same name as outer method parameters which will hide the outer method parameters
-				var nonRedeclaredParameters = localFunction.Parameters.IsDefaultOrEmpty
+				var nonRedeclaredParameters = localFunctionOrLambda.Parameters.IsDefaultOrEmpty
 					? _parametersToCheck
-					: _parametersToCheck.Where(checkedParameterName => localFunction.Parameters.All(p => p.Name != checkedParameterName))
+					: _parametersToCheck.Where(checkedParameterName => localFunctionOrLambda.Parameters.All(p => p.Name != checkedParameterName))
 										.ToList(capacity: _parametersToCheck!.Count);
 
 				if (nonRedeclaredParameters!.Count == 0)
 					return;
 
-				List<ISymbol>? reassignedContainingMethodsParameters = GetReassignedContainingMethodsParameters(localFunction);
+				List<ISymbol>? reassignedContainingMethodsParameters = GetReassignedContainingMethodsParameters(localFunctionOrLambda);
 
 				if (reassignedContainingMethodsParameters.IsNullOrEmpty())
 					return;
@@ -317,14 +316,13 @@ namespace Acuminator.Utilities.Roslyn.Walkers
 				var localFunctionBody = localFunctionDeclaration?.GetBody();
 
 				// Static local functions can't reassign parameters from containing methods
-				if (localFunctionBody == null || localFunction.IsDefinitelyStatic(localFunctionDeclaration!))
+				if (localFunctionBody == null || localFunction.IsStatic)
 					return null;
 
 				// If there are containing local functions we must check for the first containing static local function.
 				// Only its parameters and parameters of its local functions can be reassigned by this localFunction
 				var containingMethodsWithReassignableParameters = localFunction.GetContainingMethods()
-																			   .TakeWhile(function => function.MethodKind != MethodKind.LocalFunction ||
-																									  !function.IsDefinitelyStatic(_cancellation))
+																			   .TakeWhile(function => !function.IsNestedMethod() || !function.IsStatic)
 																			   .ToList(capacity: 1);
 				if (containingMethodsWithReassignableParameters.Count == 0)
 					return null;
@@ -363,7 +361,7 @@ namespace Acuminator.Utilities.Roslyn.Walkers
 			}
 
 			#region Skip visiting anonymous functions and lambdas
-			// Lambdas and amomymous functions can be declared in the middle of the code. 
+			// Lambdas and anonymous functions can be declared in the middle of the code. 
 			// We don't visit them from the normal tree walking since their declaration is not a running code that can reassign something
 			// Also, currently analysis of invocations of lambdas is not supported
 			public override void VisitAnonymousMethodExpression(AnonymousMethodExpressionSyntax anonymousMethodExpression)


### PR DESCRIPTION
**Changes Overview**
- Fixed false alert for PX1120 that reported lambda functions passed to long-running operation manager API
- Updated support for lambdas in the analysis and in PX1008
- Removed `IsDefinitelyStatic` helpers that were used to workaround old Roslyn bug with incorrect determination of static local functions by Roslyn. The Roslyn version was updated, so the currently used Roslyn version includes bugfix.
- Updated unit tests for PX1120