### PR TITLE
Bugfix/atr 925 dev px1008 does not report

### DIFF
--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/LongOperationDelegateClosures/LongOperationDelegateClosuresAnalyzer.LongOperationsChecker.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/LongOperationDelegateClosures/LongOperationDelegateClosuresAnalyzer.LongOperationsChecker.cs
@@ -1,10 +1,7 @@
-﻿
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
-using System.Runtime.CompilerServices;
-using System.Xml.Linq;
 
 using Acuminator.Utilities.Common;
 using Acuminator.Utilities.Roslyn;
@@ -43,7 +40,18 @@ namespace Acuminator.Analyzers.StaticAnalysis.LongOperationDelegateClosures
 			{
 				ThrowIfCancellationRequested();
 
-				typeDeclarationNode.Accept(this);
+				try
+				{
+					typeDeclarationNode.Accept(this);
+				}
+				finally
+				{
+					// Clear state
+					if (NonCapturablePassedParameters == null)
+						NonCapturablePassedParameters = new();
+					else if (NonCapturablePassedParameters.Count > 0)
+						NonCapturablePassedParameters.Clear();
+				}
 			}
 
 			#region Visitor Optimization - do not visit some subtrees

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/LongOperationDelegateClosures/LongOperationDelegateClosuresAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/LongOperationDelegateClosures/LongOperationDelegateClosuresAnalyzer.cs
@@ -1,5 +1,4 @@
-﻿
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -28,20 +27,31 @@ namespace Acuminator.Analyzers.StaticAnalysis.LongOperationDelegateClosures
 
 		protected override void AnalyzeCompilation(CompilationStartAnalysisContext compilationStartContext, PXContext pxContext)
 		{
-			compilationStartContext.RegisterSyntaxNodeAction(c => AnalyzeLongOperationDelegates(c, pxContext), 
-															 SyntaxKind.ClassDeclaration, SyntaxKind.StructDeclaration, SyntaxKind.InterfaceDeclaration,
-															 SyntaxKind.RecordDeclaration, SyntaxKind.RecordStructDeclaration);
+			compilationStartContext.RegisterSyntaxNodeAction(c => AnalyzeLongOperationDelegates(c, pxContext), SyntaxKind.CompilationUnit);
 		}
 
 		private static void AnalyzeLongOperationDelegates(SyntaxNodeAnalysisContext syntaxContext, PXContext pxContext)
 		{
 			syntaxContext.CancellationToken.ThrowIfCancellationRequested();
 
-			if (syntaxContext.Node is not TypeDeclarationSyntax typeDeclaration)
+			if (syntaxContext.Node is not CompilationUnitSyntax rootNode)
 				return;
 
 			var longOperationsChecker = new LongOperationsChecker(syntaxContext, pxContext);
-			longOperationsChecker.CheckForCapturedGraphReferencesInDelegateClosures(typeDeclaration);
+			var typeDeclarations = rootNode.DescendantNodes()
+										   .OfType<TypeDeclarationSyntax>();
+	
+			foreach (TypeDeclarationSyntax typeDeclaration in typeDeclarations)
+			{
+				syntaxContext.CancellationToken.ThrowIfCancellationRequested();
+
+				var typeMembers = typeDeclaration.Members;
+
+				if (typeMembers.Count > 0)
+				{
+					longOperationsChecker.CheckForCapturedGraphReferencesInDelegateClosures(typeDeclaration);
+				}
+			}
 		}
 	}
 }

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/LongOperationDelegateClosures/LongOperationDelegateTypeClassifier.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/LongOperationDelegateClosures/LongOperationDelegateTypeClassifier.cs
@@ -66,7 +66,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.LongOperationDelegateClosures
 					if (longRunDelegate == null)
 						return null;
 
-					return pxContext.AsyncOperations.AllMethodsStartingLongRun.Contains(longRunDelegate)
+					return pxContext.AsyncOperations.AllMethodsStartingLongRun.Contains(longRunDelegate.OriginalDefinition)
 						? (LongOperationDelegateType.LongRunDelegate, longRunDelegate)
 						: null;
 

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/LongOperationStart/StartLongOperationDelegateWalker.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/LongOperationStart/StartLongOperationDelegateWalker.cs
@@ -33,7 +33,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.LongOperationStart
 			IMethodSymbol? methodSymbol = GetSymbol<IMethodSymbol>(node);
 
 			if (methodSymbol == null || node.ArgumentList?.Arguments.Count is null or 0 ||
-				!PxContext.AsyncOperations.AllMethodsStartingLongRun.Contains<IMethodSymbol>(methodSymbol, SymbolEqualityComparer.Default))
+				!PxContext.AsyncOperations.AllMethodsStartingLongRun.Contains(methodSymbol.OriginalDefinition))
 			{
 				base.VisitInvocationExpression(node);
 				return;

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/LongOperationStart/StartLongOperationWalker.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/LongOperationStart/StartLongOperationWalker.cs
@@ -46,11 +46,10 @@ namespace Acuminator.Analyzers.StaticAnalysis.LongOperationStart
 
 		private bool DoesMethodStartLongRunOperation(IMethodSymbol methodSymbol)
 		{
-			if (PxContext.AsyncOperations.AllMethodsStartingLongRun.Contains(methodSymbol))
+			if (PxContext.AsyncOperations.AllMethodsStartingLongRun.Contains(methodSymbol.OriginalDefinition))
 				return true;
 
-			return !methodSymbol.IsDefinition && methodSymbol.OriginalDefinition != null &&
-					PxContext.AsyncOperations.AllMethodsStartingLongRun.Contains(methodSymbol.OriginalDefinition);
+			return !methodSymbol.IsDefinition && PxContext.AsyncOperations.AllMethodsStartingLongRun.Contains(methodSymbol);
 		}
 	}
 }

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/LongOperationDelegateClosures/LongOperationDelegateClosuresTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/LongOperationDelegateClosures/LongOperationDelegateClosuresTests.cs
@@ -225,6 +225,16 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.LongOperationDelegateClosures
 				Descriptors.PX1008_LongOperationDelegateClosures.CreateFor(line: 35, column: 5, formatArgs));
 		}
 
+		[Theory]
+		[EmbeddedFileData("LongRunDelegateClosures_CaptureThis.cs")]
+		public Task This_Reference_ToScreenGraph_Captured_InLongRun(string actual)
+		{
+			string[] formatArgs = [AnalyzerResources.PX1008Title_CapturedGraphFormatArg, AnalyzerResources.PX1008Title_LongRunDelegateFormatArg];
+			return VerifyCSharpDiagnosticAsync(actual,
+				Descriptors.PX1008_LongOperationDelegateClosures.CreateFor(line: 20, column: 24, formatArgs));
+		}
+
+
 		[Theory(Skip = "Recursive analysis of passed delegates currently is not supported for this diagnostic and is skipped for now")]
 		[EmbeddedFileData("LongRunDelegateClosures_Delegates.cs")]
 		public Task GraphDelegateCaptured_InLocalFunctions_InLongRun(string actual)

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/LongOperationDelegateClosures/Sources/LongRunDelegateClosures_CaptureThis.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/LongOperationDelegateClosures/Sources/LongRunDelegateClosures_CaptureThis.cs
@@ -1,0 +1,38 @@
+﻿using PX.Data;
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Acuminator.Tests.Sources
+{
+	public class ProcessingGraph : PXGraph<ProcessingGraph>
+	{
+		public PXAction<MyDac> testCredentials = null!;
+
+		[PXButton]
+		[PXUIField]
+		public virtual IEnumerable TestCredentials(PXAdapter adapter)
+		{
+			var graph = PXGraph.CreateInstance<TestCredsGraph>();
+			var credsAreValid = LongOperationManager.Await(ct => graph.TestCredentialAsync(this));
+			return adapter.Get();
+		}
+	}
+
+
+	public class TestCredsGraph : PXGraph<TestCredsGraph>
+	{
+		public Task<bool> TestCredentialAsync(ProcessingGraph graph)
+		{
+			return Task.FromResult(true);
+		}
+	}
+
+	[PXHidden]
+	public class MyDac : PXBqlTable, IBqlTable
+	{ 
+	}
+}


### PR DESCRIPTION
### Changes Overview
- Fixed bug in PX1008 - incorrect lookup in the list of Acumatica async methods. Added fixes to similar other places
- Optimization - reworked PX1008 to register analyzer for the syntax root and analyze all type nodes in it. Added filtering of the empty types
- Added unit test for PX1008 for scenario with the problem