### PR TITLE
Bugfix/atr 901 dev improve px1001 docs

### DIFF
--- a/docs/Summary.md
+++ b/docs/Summary.md
@@ -12,9 +12,9 @@ Acuminator does not perform static analysis of projects whose names contain `Tes
 | Code   | Short Description                                                                         | Type  | Code Fix  |
 | ------ | ----------------------------------------------------------------------------------------- | ----- | --------- |
 | [PX1000](diagnostics/PX1000.md) | The action delegate has incompatible return type and parameters. | Error | Available |
-| [PX1001](diagnostics/PX1001.md) | A `PXGraph` instance must be created with the `PXGraph.CreateInstance()` factory method. | Error/Warning | Available |
+| [PX1001](diagnostics/PX1001.md) | An instance of the concrete graph type must be created with the `PXGraph.CreateInstance()` factory method. | Error | Available |
 | [PX1002](diagnostics/PX1002.md) | The field must have a type attribute that corresponds to the list attribute. | Error | Available |
-| [PX1003](diagnostics/PX1003.md) | Consider using a specific implementation of `PXGraph`. | Warning (ISV Level 2: Production Quality) | Unavailable |
+| [PX1003](diagnostics/PX1003.md) | An instance of the base graph type should be created with the `PXGraph.CreateInstance()` factory method. | Warning | Available |
 | [PX1004](diagnostics/PX1004.md) | The order of view declarations will cause the creation of two cache instances. | Message | Unavailable |
 | [PX1005](diagnostics/PX1005.md) | There is probably a typo in the name of the view delegate or the action delegate. | Warning (ISV Level 3: Informational) | Available |
 | [PX1006](diagnostics/PX1006.md) | The order of view declarations will cause the creation of one cache instance for multiple DACs | Message | Unavailable |

--- a/docs/Summary.md
+++ b/docs/Summary.md
@@ -12,7 +12,7 @@ Acuminator does not perform static analysis of projects whose names contain `Tes
 | Code   | Short Description                                                                         | Type  | Code Fix  |
 | ------ | ----------------------------------------------------------------------------------------- | ----- | --------- |
 | [PX1000](diagnostics/PX1000.md) | The action delegate has incompatible return type and parameters. | Error | Available |
-| [PX1001](diagnostics/PX1001.md) | A `PXGraph` instance must be created with the `PXGraph.CreateInstance()` factory method. | Error | Available |
+| [PX1001](diagnostics/PX1001.md) | A `PXGraph` instance must be created with the `PXGraph.CreateInstance()` factory method. | Error/Warning | Available |
 | [PX1002](diagnostics/PX1002.md) | The field must have a type attribute that corresponds to the list attribute. | Error | Available |
 | [PX1003](diagnostics/PX1003.md) | Consider using a specific implementation of `PXGraph`. | Warning (ISV Level 2: Production Quality) | Unavailable |
 | [PX1004](diagnostics/PX1004.md) | The order of view declarations will cause the creation of two cache instances. | Message | Unavailable |

--- a/docs/diagnostics/PX1001.md
+++ b/docs/diagnostics/PX1001.md
@@ -19,21 +19,21 @@ This diagnostic has two severity levels depending on the type of graph being ins
 ### Difference between Graph Constructor Calls and PXGraph.CreateInstance Factory Method
 
 #### Graph Extensions 
-The Acumatica Framework relies on a complex extension mechanism to provide customization capabilities. Proper initialization of graph instances is essential for this mechanism to function correctly.
-Such initialization is implemented in the `PXGraph.CreateInstance()` factory method via the dynamic generation of a proxy class that derives from the original graph type and integrates all graph extensions 
-into the original graph's logic. Among extension mechanisms that rely on this dynamic code generation are:
-- The `PXOverride` attribute mechanism,
-- The `PXProtectedAccess` attribute mechanism,
-- The overrides of event handlers.
+The Acumatica Framework relies on a complex extension mechanism to provide customization capabilities. It is essential to initialize graph instances properly so that this mechanism can function correctly.
+Correct graph initialization is implemented in the `PXGraph.CreateInstance()` factory method via the dynamic generation of a proxy class that derives from the original graph type and integrates all graph extensions 
+into the original graph's logic. The following extension mechanisms rely on this dynamic code generation:
+- The `PXOverride` attribute mechanism
+- The `PXProtectedAccess` attribute mechanism
+- The overrides of event handlers
 
-On the other hand, graph constructors will only create instances of the original graph type without any graph extensions loaded for it. This can lead to incorrect and unexpected behavior at runtime.
+Another reason to use `PXGraph.CreateInstance()` instead of graph constructors is that they create only instances of the original graph type without any graph extensions loaded for it. This can lead to incorrect and unexpected behavior at runtime.
 
 #### Dependency Injection
 The Acumatica Framework provides its own Dependency Injection (DI) mechanism to inject different services into the graph instance via the property injection pattern. The `PXGraph.CreateInstance()` factory method ensures that 
 all DI services are correctly injected into the graph instance, while direct constructor calls bypass this mechanism. This means that graphs created via constructors may lack necessary DI services, leading to runtime errors.
 
 ### Error Severity for Concrete Graph Types
-The PX1001 diagnostic has **Error** severity for calls to constructors of concrete graph types. For custom graphs (graphs derived from `PXGraph<T>`), proper initialization is critical because:
+The PX1001 diagnostic has the **Error** severity for calls to constructors of concrete graph types. For custom graphs (graphs derived from `PXGraph<T>`), proper initialization is critical because:
 - Most graph extensions are created for custom graphs, not for the base `PXGraph` type.
 - Custom graphs are usually used to execute business logic that relies on correctly initialized graph extensions and DI services.
 
@@ -41,18 +41,18 @@ Therefore, the diagnostic displays an **Error** for concrete graph type construc
 
 ### Warning Severity for Base `PXGraph` Type
 For the base `PXGraph` type, direct constructor calls are also discouraged. In most cases, the application logic should not use instances of the base graph directly. The Acumatica Framework contains graph extensions 
-created for the base `PXGraph` type are applied to **all** graphs derived from it (essentially every graph in the system). There are also DI services that are injected into the base `PXGraph` type and expected 
+created for the base `PXGraph` type. These extensions are applied to **all** graphs derived from `PXGraph` (essentially every graph in the system). There are also DI services that are injected into the base `PXGraph` type and expected 
 to be available in all derived graphs.
 
-Instantiating the base `PXGraph` type directly bypasses these extensions and DI services, which can lead to unexpected behavior. If you need a general graph with all initialized extensions and DI services, you can create it 
+If you create an instance of the base `PXGraph` type, you directly bypass these extensions and DI services, which can lead to unexpected behavior. If you need a general graph with all initialized extensions and DI services, you can create it 
 using the following code:
 ```C#
 var generalGraphWithAllExtensionsAndDiServices = PXGraph.CreateInstance<PXGraph>();
 ```
 
 #### Lightweight Data Querying
-However, there is one usage scenario where the direct instantiation of the base `PXGraph` type is acceptable. This is when a base `PXGraph` instance created via a direct constructor call is used **only** to query data 
-from the database (for example, for some service). Sometimes, Acumatica developers use such "cheaper," not fully initialized graph instances just to retrieve data. In this case the full graph initialization via `CreateInstance` 
+Direct instantiation of the base `PXGraph` type is acceptable in one scenario: When a base `PXGraph` instance created via a direct constructor call is used **only** to query data 
+from the database (for example, for some service). For example, Acumatica developers sometimes use such "cheaper," not fully initialized graph instances just to retrieve data. In this case, the full graph initialization via `CreateInstance` 
 can be an unnecessarily expensive operation. 
  
 Because of this specific use case, the diagnostic displays a **Warning** rather than an error for the base `PXGraph` type, while still discouraging the practice.

--- a/docs/diagnostics/PX1001.md
+++ b/docs/diagnostics/PX1001.md
@@ -3,23 +3,82 @@ This document describes the PX1001 diagnostic.
 
 ## Summary
 
-| Code   | Short Description                                                                        | Type  | Code Fix  | 
-| ------ | ---------------------------------------------------------------------------------------- | ----- | --------- | 
-| PX1001 | A `PXGraph` instance must be created with the `PXGraph.CreateInstance()` factory method. | Error | Available |
+| Code   | Short Description                                                                        |      Type     | Code Fix  | 
+| ------ | ---------------------------------------------------------------------------------------- | ------------- | --------- | 
+| PX1001 | A `PXGraph` instance must be created with the `PXGraph.CreateInstance()` factory method. | Error/Warning | Available |
 
 ## Diagnostic Description
-The `PXGraph.CreateInstance<T>()` method must be used to instantiate graph types from code. You cannot use the graph constructor `new T()`.
+The PX1001 diagnostic reports graphs that are instantiated directly with a graph constructor. The `PXGraph.CreateInstance<T>()` factory method should be used instead to instantiate graph types from code.
 
-The code fix replaces `new T()` with `PXGraph.CreateInstance<T>()`.
+### Severity Levels
+This diagnostic has two severity levels depending on the type of graph being instantiated:
+
+- **Error**: For calls to constructors of concrete graph types (e.g., `new SOOrderEntry()`, `new MyGraph()`)
+- **Warning**: For calls to the base `PXGraph` constructor (e.g., `new PXGraph()`)
+
+### Difference between Graph Constructor Calls and PXGraph.CreateInstance Factory Method
+
+#### Graph Extensions 
+The Acumatica Framework relies on a complex extension mechanism to provide customization capabilities. Proper initialization of graph instances is essential for this mechanism to function correctly.
+Such initialization is implemented in the `PXGraph.CreateInstance()` factory method via the dynamic generation of a proxy class that derives from the original graph type and integrates all graph extensions 
+into the original graph's logic. Among extension mechanisms that rely on this dynamic code generation are:
+- The `PXOverride` attribute mechanism,
+- The `PXProtectedAccess` attribute mechanism,
+- The overrides of event handlers.
+
+On the other hand, graph constructors will only create instances of the original graph type without any graph extensions loaded for it. This can lead to incorrect and unexpected behavior at runtime.
+
+#### Dependency Injection
+The Acumatica Framework provides its own Dependency Injection (DI) mechanism to inject different services into the graph instance via the property injection pattern. The `PXGraph.CreateInstance()` factory method ensures that 
+all DI services are correctly injected into the graph instance, while direct constructor calls bypass this mechanism. This means that graphs created via constructors may lack necessary DI services, leading to runtime errors.
+
+### Error Severity for Concrete Graph Types
+The PX1001 diagnostic has **Error** severity for calls to constructors of concrete graph types. For custom graphs (graphs derived from `PXGraph<T>`), proper initialization is critical because:
+- Most graph extensions are created for custom graphs, not for the base `PXGraph` type.
+- Custom graphs are usually used to execute business logic that relies on correctly initialized graph extensions and DI services.
+
+Therefore, the diagnostic displays an **Error** for concrete graph type constructors to prevent these issues.
+
+### Warning Severity for Base `PXGraph` Type
+For the base `PXGraph` type, direct constructor calls are also discouraged. In most cases, the application logic should not use instances of the base graph directly. The Acumatica Framework contains graph extensions 
+that are created for the base `PXGraph` type are applied to **all** graphs derived from it (essentially every graph in the system). There are also DI services that are injected into the base `PXGraph` type and expected 
+to be available in all derived graphs.
+
+Instantiating the base `PXGraph` type directly bypasses these extensions and DI services, which can lead to unexpected behavior. If you need a general graph with all initialized extensions and DI services, you can create it 
+using the following code:
+```C#
+var generalGraphWithAllExtensionsAndDiServices = PXGraph.CreateInstance<PXGraph>();
+```
+
+#### Lightweight Data Querying
+However, there is one usage scenario where the direct instantiation of the base `PXGraph` type is acceptable. This is when a base `PXGraph` instance created via a direct constructor call is used **only** to query data 
+from the database (for example, for some service). Sometimes, Acumatica developers use such "cheaper," not fully initialized graph instances just to retrieve data. In this case the full graph initialization via `CreateInstance` 
+can be an unnecessarily expensive operation. 
+ 
+Because of this specific use case, the diagnostic displays a **Warning** rather than an error for the base `PXGraph` type, while still discouraging the practice.
+
+## Code Fix Behavior
+The code fix replaces the direct call to the graph constructor with the call to the `PXGraph.CreateInstance<T>()` factory method.
 
 ## Example of Incorrect Code
-
 ```C#
-var graph = new SOOrderEntry(); // The PX1001 error is displayed for this line.
+// Error: Constructor call for a concrete graph type
+var orderGraph = new SOOrderEntry();
+
+// Warning: Constructor call for the base PXGraph type
+var graph = new PXGraph();
 ```
 
 ## Example of Code Fix
-
 ```C#
-var graph = PXGraph.CreateInstance<SOOrderEntry>();
+// Correct: Use CreateInstance for concrete graph types
+var orderGraph = PXGraph.CreateInstance<SOOrderEntry>();
+
+// Correct: Use CreateInstance for the base PXGraph type
+var graph = PXGraph.CreateInstance<PXGraph>();
 ```
+
+## Related Articles
+
+- [Business Logic Customization](https://help.acumatica.com/Help?ScreenId=ShowWiki&pageid=b02bd27f-3e86-4210-9e0f-c0df7aa701d9)
+- [Graph Extensions: General Information](https://help.acumatica.com/Help?ScreenId=ShowWiki&pageid=e220486e-32d1-439b-a858-7c10f44a9bac)

--- a/docs/diagnostics/PX1001.md
+++ b/docs/diagnostics/PX1001.md
@@ -11,32 +11,34 @@ This document describes the PX1001 diagnostic.
 The PX1001 diagnostic reports graphs of concrete types derived from `PXGraph<T>` that are instantiated directly with a graph constructor (for example, `new SOOrderEntry()`, `new MyGraph()`). The `PXGraph.CreateInstance<T>()` factory
 method should be used instead to instantiate correctly initialized graph instances from code.
 
-This diagnostic has a complementary rule, PX1003, which reports direct constructor calls for the base `PXGraph` type (for example, `new PXGraph()`). Both diagnostics share similar reasoning, but they have different severity levels.
+This diagnostic has a complementary rule, [PX1003](diagnostics/PX1003.md), which reports direct constructor calls for the base `PXGraph` type (for example, `new PXGraph()`). Both diagnostics share similar reasoning, but they have different severity levels.
 
 ### Difference between Graph Constructor Calls and PXGraph.CreateInstance Factory Method
 During the execution of the `PXGraph.CreateInstance` factory method, the Acumatica Framework performs a complex initialization of the graph instance, including the following steps:
- - Collection and initialization of graph extensions.
- - Dependency injection of services into graph.
- - Loading and unloading of the graph state from the session.
+ - Collection and initialization of graph extensions
+ - Dependency injection of services into a graph
+ - Loading and unloading of the graph state from the session
 
-These steps are omitted when the graph instance is created via a direct constructor call. Next sections describe some of the initialization steps.
+These steps are omitted when the graph instance is created via a direct constructor call. 
+
+The sections below describe some of the steps that are performed during the graph initialization.
 
 #### Graph Extensions 
 The Acumatica Framework relies on a complex extension mechanism to provide customization capabilities. Proper initialization of graph instances is essential for this mechanism to function correctly.
 Such initialization is implemented in the `PXGraph.CreateInstance()` factory method via the dynamic generation of a proxy class that derives from the original graph type and integrates all graph extensions 
 into the original graph's logic. Among extension mechanisms that rely on this dynamic code generation are:
-- The `PXOverride` attribute mechanism,
-- The `PXProtectedAccess` attribute mechanism,
-- The overrides of event handlers.
+- The `PXOverride` attribute mechanism
+- The `PXProtectedAccess` attribute mechanism
+- The overrides of event handlers
 
-On the other hand, graph constructors will only create instances of the original graph type without any graph extensions loaded for it. This can lead to incorrect and unexpected behavior at runtime.
+Graph constructors will only create instances of the original graph type without any graph extensions loaded for it. This can lead to incorrect and unexpected behavior at runtime.
 
 #### Dependency Injection
 The Acumatica Framework provides its own Dependency Injection (DI) mechanism to inject different services into the graph instance via the property injection pattern. The `PXGraph.CreateInstance()` factory method ensures that 
 all DI services are correctly injected into the graph instance, while direct constructor calls bypass this mechanism. This means that graphs created via constructors may lack necessary DI services, leading to runtime errors.
 
 ### Why "Error" Severity for Concrete Graph Types
-The PX1001 diagnostic has **Error** severity because for custom graphs (graphs derived from `PXGraph<T>`) proper initialization is critical. Custom graphs are usually used to execute business logic that relies on correctly 
+The PX1001 diagnostic has the **Error** severity because for custom graphs (graphs derived from `PXGraph<T>`) proper initialization is critical. Custom graphs are usually used to execute business logic that relies on correctly 
 initialized graph extensions and DI services.
 
 ## Code Fix Behavior

--- a/docs/diagnostics/PX1001.md
+++ b/docs/diagnostics/PX1001.md
@@ -9,12 +9,17 @@ This document describes the PX1001 diagnostic.
 
 ## Diagnostic Description
 The PX1001 diagnostic reports graphs of concrete types derived from `PXGraph<T>` that are instantiated directly with a graph constructor (for example, `new SOOrderEntry()`, `new MyGraph()`). The `PXGraph.CreateInstance<T>()` factory
-method should be used instead to instantiate graph types from code.
+method should be used instead to instantiate correctly initialized graph instances from code.
 
-This diagnostic has a complementary rule, PX1003, which reports direct constructor calls for the base `PXGraph` type (for example, `new PXGraph()`). Both diagnostics share similar reasoning, 
-but they have different severity levels and justifications.
+This diagnostic has a complementary rule, PX1003, which reports direct constructor calls for the base `PXGraph` type (for example, `new PXGraph()`). Both diagnostics share similar reasoning, but they have different severity levels.
 
 ### Difference between Graph Constructor Calls and PXGraph.CreateInstance Factory Method
+During the execution of the `PXGraph.CreateInstance` factory method, the Acumatica Framework performs a complex initialization of the graph instance, including the following steps:
+ - Collection and initialization of graph extensions.
+ - Dependency injection of services into graph.
+ - Loading and unloading of the graph state from the session.
+
+These steps are omitted when the graph instance is created via a direct constructor call. Next sections describe some of the initialization steps.
 
 #### Graph Extensions 
 The Acumatica Framework relies on a complex extension mechanism to provide customization capabilities. Proper initialization of graph instances is essential for this mechanism to function correctly.
@@ -51,5 +56,6 @@ var orderGraph = PXGraph.CreateInstance<SOOrderEntry>();
 
 ## Related Articles
 
+- [PX1003 Diagnostic](PX1003.md)
 - [Business Logic Customization](https://help.acumatica.com/Help?ScreenId=ShowWiki&pageid=b02bd27f-3e86-4210-9e0f-c0df7aa701d9)
 - [Graph Extensions: General Information](https://help.acumatica.com/Help?ScreenId=ShowWiki&pageid=e220486e-32d1-439b-a858-7c10f44a9bac)

--- a/docs/diagnostics/PX1001.md
+++ b/docs/diagnostics/PX1001.md
@@ -3,61 +3,36 @@ This document describes the PX1001 diagnostic.
 
 ## Summary
 
-| Code   | Short Description                                                                        |      Type     | Code Fix  | 
-| ------ | ---------------------------------------------------------------------------------------- | ------------- | --------- | 
-| PX1001 | A `PXGraph` instance must be created with the `PXGraph.CreateInstance()` factory method. | Error/Warning | Available |
+| Code   | Short Description                                                                                          | Type  | Code Fix  | 
+| ------ | ---------------------------------------------------------------------------------------------------------- | ----- | --------- | 
+| PX1001 | An instance of the concrete graph type must be created with the `PXGraph.CreateInstance()` factory method. | Error | Available |
 
 ## Diagnostic Description
-The PX1001 diagnostic reports graphs that are instantiated directly with a graph constructor. The `PXGraph.CreateInstance<T>()` factory method should be used instead to instantiate graph types from code.
+The PX1001 diagnostic reports graphs of concrete types derived from `PXGraph<T>` that are instantiated directly with a graph constructor (for example, `new SOOrderEntry()`, `new MyGraph()`). The `PXGraph.CreateInstance<T>()` factory
+method should be used instead to instantiate graph types from code.
 
-### Severity Levels
-This diagnostic has two severity levels depending on the type of graph being instantiated:
-
-- **Error**: For calls to constructors of concrete graph types (e.g., `new SOOrderEntry()`, `new MyGraph()`)
-- **Warning**: For calls to the base `PXGraph` constructor (e.g., `new PXGraph()`)
+This diagnostic has a complementary rule, PX1003, which reports direct constructor calls for the base `PXGraph` type (for example, `new PXGraph()`). Both diagnostics share similar reasoning, 
+but they have different severity levels and justifications.
 
 ### Difference between Graph Constructor Calls and PXGraph.CreateInstance Factory Method
 
 #### Graph Extensions 
-The Acumatica Framework relies on a complex extension mechanism to provide customization capabilities. It is essential to initialize graph instances properly so that this mechanism can function correctly.
-Correct graph initialization is implemented in the `PXGraph.CreateInstance()` factory method via the dynamic generation of a proxy class that derives from the original graph type and integrates all graph extensions 
-into the original graph's logic. The following extension mechanisms rely on this dynamic code generation:
-- The `PXOverride` attribute mechanism
-- The `PXProtectedAccess` attribute mechanism
-- The overrides of event handlers
+The Acumatica Framework relies on a complex extension mechanism to provide customization capabilities. Proper initialization of graph instances is essential for this mechanism to function correctly.
+Such initialization is implemented in the `PXGraph.CreateInstance()` factory method via the dynamic generation of a proxy class that derives from the original graph type and integrates all graph extensions 
+into the original graph's logic. Among extension mechanisms that rely on this dynamic code generation are:
+- The `PXOverride` attribute mechanism,
+- The `PXProtectedAccess` attribute mechanism,
+- The overrides of event handlers.
 
-Another reason to use `PXGraph.CreateInstance()` instead of graph constructors is that they create only instances of the original graph type without any graph extensions loaded for it. This can lead to incorrect and unexpected behavior at runtime.
+On the other hand, graph constructors will only create instances of the original graph type without any graph extensions loaded for it. This can lead to incorrect and unexpected behavior at runtime.
 
 #### Dependency Injection
 The Acumatica Framework provides its own Dependency Injection (DI) mechanism to inject different services into the graph instance via the property injection pattern. The `PXGraph.CreateInstance()` factory method ensures that 
 all DI services are correctly injected into the graph instance, while direct constructor calls bypass this mechanism. This means that graphs created via constructors may lack necessary DI services, leading to runtime errors.
 
-### Error Severity for Concrete Graph Types
-The PX1001 diagnostic has the **Error** severity for calls to constructors of concrete graph types. For custom graphs (graphs derived from `PXGraph<T>`), proper initialization is critical because:
-- Most graph extensions are created for custom graphs, not for the base `PXGraph` type.
-- Custom graphs are usually used to execute business logic that relies on correctly initialized graph extensions and DI services.
-
-Therefore, the diagnostic displays an **Error** for concrete graph type constructors to prevent these issues.
-
-### Warning Severity for Base `PXGraph` Type
-For the base `PXGraph` type, direct constructor calls are also discouraged. In most cases, the application logic should not use instances of the base graph directly. The Acumatica Framework contains graph extensions 
-created for the base `PXGraph` type. These extensions are applied to **all** graphs derived from `PXGraph` (essentially every graph in the system). There are also DI services that are injected into the base `PXGraph` type and expected 
-to be available in all derived graphs.
-
-If you create an instance of the base `PXGraph` type, you directly bypass these extensions and DI services, which can lead to unexpected behavior. If you need a general graph with all initialized extensions and DI services, you can create it 
-using the following code:
-```C#
-var generalGraphWithAllExtensionsAndDiServices = PXGraph.CreateInstance<PXGraph>();
-```
-
-#### Lightweight Data Querying
-Direct instantiation of the base `PXGraph` type is acceptable in one scenario: When a base `PXGraph` instance created via a direct constructor call is used **only** to query data 
-from the database (for example, for some service). For example, Acumatica developers sometimes use such "cheaper," not fully initialized graph instances just to retrieve data. In this case, the full graph initialization via `CreateInstance` 
-can be an unnecessarily expensive operation. 
- 
-Because of this specific use case, the diagnostic displays a **Warning** rather than an error for the base `PXGraph` type, while still discouraging the practice.
-
-**If you need to create lightweight `PXGraph` instance via direct constructor call for data querying, you should just suppress the PX1001 warning on the constructor call with Acuminator suppression comment.**
+### Why "Error" Severity for Concrete Graph Types
+The PX1001 diagnostic has **Error** severity because for custom graphs (graphs derived from `PXGraph<T>`) proper initialization is critical. Custom graphs are usually used to execute business logic that relies on correctly 
+initialized graph extensions and DI services.
 
 ## Code Fix Behavior
 The code fix replaces the direct call to the graph constructor with the call to the `PXGraph.CreateInstance<T>()` factory method.
@@ -66,18 +41,12 @@ The code fix replaces the direct call to the graph constructor with the call to 
 ```C#
 // Error: Constructor call for a concrete graph type
 var orderGraph = new SOOrderEntry();
-
-// Warning: Constructor call for the base PXGraph type
-var graph = new PXGraph();
 ```
 
 ## Example of Code Fix
 ```C#
 // Correct: Use CreateInstance for concrete graph types
 var orderGraph = PXGraph.CreateInstance<SOOrderEntry>();
-
-// Correct: Use CreateInstance for the base PXGraph type
-var graph = PXGraph.CreateInstance<PXGraph>();
 ```
 
 ## Related Articles

--- a/docs/diagnostics/PX1001.md
+++ b/docs/diagnostics/PX1001.md
@@ -57,6 +57,8 @@ can be an unnecessarily expensive operation.
  
 Because of this specific use case, the diagnostic displays a **Warning** rather than an error for the base `PXGraph` type, while still discouraging the practice.
 
+**If you need to create lightweight `PXGraph` instance via direct constructor call for data querying, you should just suppress the PX1001 warning on the constructor call with Acuminator suppression comment.**
+
 ## Code Fix Behavior
 The code fix replaces the direct call to the graph constructor with the call to the `PXGraph.CreateInstance<T>()` factory method.
 

--- a/docs/diagnostics/PX1001.md
+++ b/docs/diagnostics/PX1001.md
@@ -41,7 +41,7 @@ Therefore, the diagnostic displays an **Error** for concrete graph type construc
 
 ### Warning Severity for Base `PXGraph` Type
 For the base `PXGraph` type, direct constructor calls are also discouraged. In most cases, the application logic should not use instances of the base graph directly. The Acumatica Framework contains graph extensions 
-that are created for the base `PXGraph` type are applied to **all** graphs derived from it (essentially every graph in the system). There are also DI services that are injected into the base `PXGraph` type and expected 
+created for the base `PXGraph` type are applied to **all** graphs derived from it (essentially every graph in the system). There are also DI services that are injected into the base `PXGraph` type and expected 
 to be available in all derived graphs.
 
 Instantiating the base `PXGraph` type directly bypasses these extensions and DI services, which can lead to unexpected behavior. If you need a general graph with all initialized extensions and DI services, you can create it 

--- a/docs/diagnostics/PX1003.md
+++ b/docs/diagnostics/PX1003.md
@@ -11,53 +11,52 @@ This document describes the PX1003 diagnostic.
 The PX1003 diagnostic reports graph instances of the base `PXGraph` type that are instantiated directly with a graph constructor (for example, `new PXGraph()`). The `PXGraph.CreateInstance<T>()` factory method should be used 
 instead to instantiate correctly initialized graph instances from code.
 
-This diagnostic has a complementary rule, PX1001, which reports direct constructor calls for concrete graph types derived from the `PXGraph` type (for example, `new SOOrderEntry()`). Both diagnostics share similar reasoning, 
+This diagnostic has a complementary rule, [PX1001](diagnostics/PX1001.md), which reports direct constructor calls for concrete graph types derived from the `PXGraph` type (for example, `new SOOrderEntry()`). Both diagnostics share similar reasoning, 
 but they have different severity levels.
 
 ### Difference between Graph Constructor Calls and PXGraph.CreateInstance Factory Method
 During the execution of the `PXGraph.CreateInstance` factory method, the Acumatica Framework performs a complex initialization of the graph instance, including the following steps:
- - Collection and initialization of graph extensions.
- - Dependency injection of services into graph.
- - Loading and unloading of the graph state from the session.
+ - Collection and initialization of graph extensions
+ - Dependency injection of services into a graph
+ - Loading and unloading of the graph state from the session
 
-These steps are omitted when the graph instance is created via a direct constructor call. Next sections describe some of the initialization steps.
+These steps are omitted when the graph instance is created via a direct constructor call. 
+
+The sections below describe some of the steps that are performed during the graph initialization.
 
 #### Graph Extensions 
 The Acumatica Framework relies on a complex extension mechanism to provide customization capabilities. Proper initialization of graph instances is essential for this mechanism to function correctly.
 Such initialization is implemented in the `PXGraph.CreateInstance()` factory method via the dynamic generation of a proxy class that derives from the original graph type and integrates all graph extensions 
 into the original graph's logic. Among extension mechanisms that rely on this dynamic code generation are:
-- The `PXOverride` attribute mechanism,
-- The `PXProtectedAccess` attribute mechanism,
-- The overrides of event handlers.
+- The `PXOverride` attribute mechanism
+- The `PXProtectedAccess` attribute mechanism
+- The overrides of event handlers
 
-On the other hand, graph constructors will only create instances of the original graph type without any graph extensions loaded for it. This can lead to incorrect and unexpected behavior at runtime.
+Graph constructors will only create instances of the original graph type without any graph extensions loaded for it. This can lead to incorrect and unexpected behavior at runtime.
 
 #### Dependency Injection
 The Acumatica Framework provides its own Dependency Injection (DI) mechanism to inject different services into the graph instance via the property injection pattern. The `PXGraph.CreateInstance()` factory method ensures that 
 all DI services are correctly injected into the graph instance, while direct constructor calls bypass this mechanism. This means that graphs created via constructors may lack necessary DI services, leading to runtime errors.
 
 ### Why Warning Severity for Base `PXGraph` Type
-The Acumatica Framework contains graph extensions created for the base `PXGraph` type are applied to **all** graphs derived from it (essentially every graph in the system). There are also DI services that are injected into 
-the base `PXGraph` type and expected to be available in all derived graphs. This means that even the instance of the base `PXGraph` type should be properly initialized to ensure that these extensions and DI services are available.
+The Acumatica Framework contains graph extensions created for the base `PXGraph` type. These extensions are applied to **all** graphs derived from the `PXGraph` type (essentially every graph in the system). The Acumatica Framework also includes DI services that are injected into the base `PXGraph` type and expected to be available in all derived graphs. This means that even the instance of the base `PXGraph` type should be properly initialized to ensure that these extensions and DI services are available.
 
-Creating an instance of the base `PXGraph` type directly will bypass the initialization of these extensions and DI services, which can lead to unexpected behavior. If you need a general graph instance with all initialized extensions 
-and DI services, you can create it using the following code:
+If you create an instance of the base `PXGraph` type directly, the initialization of these extensions and DI services will not be performed, which can lead to unexpected behavior. If you need a general graph instance with all initialized extensions 
+and DI services, you can create it by using the following code.
 ```C#
 var generalGraphWithAllExtensionsAndDiServices = PXGraph.CreateInstance<PXGraph>();
 ```
 
-However, the business logic rarely uses `PXGraph` instances preferring concrete graph types derived from it. Therefore, the direct instantiation of the base `PXGraph` type is a less critical issue compared to concrete graph types.
-In addition, there is a specific usage scenario with the data querying from the database where the direct instantiation of the base `PXGraph` type is acceptable, as described in the next section. 
+However, the business logic rarely uses `PXGraph` instances. Instead, it uses concrete graph types that are derived from `PXGraph`. Therefore, the direct instantiation of the base `PXGraph` type is a less critical issue compared to concrete graph types.
+It is acceptable to instantiate the base `PXGraph` directly in a single use case scenario: When you need to query data directly from the database. This scenario is described in detail below.
 
-Because of these reasons, the PX1003 diagnostic has a **Warning** severity instead of an **Error** like the PX1001 diagnostic.
+Because of these reasons, the PX1003 diagnostic has the **Warning** severity instead of **Error** unlike the PX1001 diagnostic.
 
 #### Lightweight Data Querying
-There is one usage scenario where the direct instantiation of the base `PXGraph` type is acceptable. This is when a base `PXGraph` instance created via a direct constructor call is used **only** to query data 
-from the database (for example, for some service). Sometimes, Acumatica developers use such "cheaper," not fully initialized graph instances just to retrieve data. In this case the full graph initialization via `CreateInstance` 
-is an unnecessary expensive operation and developers use a cheaper alternative.
+It is acceptable to directly instantiate the base `PXGraph` type in the following scenario: When you use the base `PXGraph` instance created via a direct constructor call **only** to query data from the database (for example, for some service). Sometimes, Acumatica developers use such "cheaper," not fully initialized graph instances just to retrieve data. In this case, the full graph initialization via `CreateInstance` is an unnecessary expensive operation, and developers use a cheaper alternative.
 
-**If you need to create lightweight `PXGraph` instance via direct constructor call for data querying, you should just suppress the PX1003 warning on the constructor call with Acuminator suppression comment.**
-Acuminator knows about this scenario and will even generate a default justification for such suppressions in this case.
+**If you need to create a lightweight `PXGraph` instance via direct constructor call for data querying, you should just suppress the PX1003 warning on the constructor call with Acuminator suppression comment.**
+Acuminator is aware of this scenario and will even generate a default justification for such suppressions in this case.
 
 ## Code Fix Behavior
 The code fix replaces the direct call to the `PXGraph` constructor with the call to the `PXGraph.CreateInstance<PXGraph>()` factory method.

--- a/docs/diagnostics/PX1003.md
+++ b/docs/diagnostics/PX1003.md
@@ -3,9 +3,9 @@ This document describes the PX1003 diagnostic.
 
 ## Summary
 
-| Code   | Short Description                                      | Type                                  | Code Fix    | 
-| ------ | ------------------------------------------------------ | ------------------------------------- | ----------- | 
-| PX1003 | Consider using a specific implementation of `PXGraph`. | Warning (ISV Level 2: Production Quality) | Unavailable |
+| Code   | Short Description                                                                                        |  Type   | Code Fix  |
+| ------ | -------------------------------------------------------------------------------------------------------- | ------- | --------- |
+| PX1003 | An instance of the base graph type should be created with the `PXGraph.CreateInstance()` factory method. | Warning | Available |
 
 ## Diagnostic Description
 To instantiate a graph type from code, you cannot use the graph constructor `new T()`. However, you can use `new PXGraph()` if you select or change records in the system context or generic context and if no specific implementation of `PXGraph` can be used.
@@ -20,8 +20,39 @@ However, `new PXGraph()` works faster than the instantiation of a specific graph
 
 To fix the issue, you should consider replacing `new PXGraph()` with the instantiation of an instance of a specific graph type through the `PXGraph.CreateInstance<T>()` method.
 
-## Example of Code that Results in the Warning
+### Why Warning Severity for Base `PXGraph` Type
+For the base `PXGraph` type, direct constructor calls are also discouraged. In most cases, the application logic should not use instances of the base graph directly. The Acumatica Framework contains graph extensions 
+created for the base `PXGraph` type are applied to **all** graphs derived from it (essentially every graph in the system). There are also DI services that are injected into the base `PXGraph` type and expected 
+to be available in all derived graphs.
 
+Instantiating the base `PXGraph` type directly bypasses these extensions and DI services, which can lead to unexpected behavior. If you need a general graph with all initialized extensions and DI services, you can create it 
+using the following code:
 ```C#
-var graph = new PXGraph(); // The PX1003 warning is displayed for this line.
+var generalGraphWithAllExtensionsAndDiServices = PXGraph.CreateInstance<PXGraph>();
 ```
+
+#### Lightweight Data Querying
+However, there is one usage scenario where the direct instantiation of the base `PXGraph` type is acceptable. This is when a base `PXGraph` instance created via a direct constructor call is used **only** to query data 
+from the database (for example, for some service). Sometimes, Acumatica developers use such "cheaper," not fully initialized graph instances just to retrieve data. In this case the full graph initialization via `CreateInstance` 
+can be an unnecessarily expensive operation. 
+ 
+Because of this specific use case, the diagnostic displays a **Warning** rather than an error for the base `PXGraph` type, while still discouraging the practice.
+
+**If you need to create lightweight `PXGraph` instance via direct constructor call for data querying, you should just suppress the PX1001 warning on the constructor call with Acuminator suppression comment.**
+
+## Example of Incorrect Code
+```C#
+// Warning: Constructor call for the base PXGraph type
+var graph = new PXGraph();
+```
+
+## Example of Code Fix
+```C#
+// Correct: Use CreateInstance for the base PXGraph type
+var graph = PXGraph.CreateInstance<PXGraph>();
+```
+
+## Related Articles
+
+- [Business Logic Customization](https://help.acumatica.com/Help?ScreenId=ShowWiki&pageid=b02bd27f-3e86-4210-9e0f-c0df7aa701d9)
+- [Graph Extensions: General Information](https://help.acumatica.com/Help?ScreenId=ShowWiki&pageid=e220486e-32d1-439b-a858-7c10f44a9bac)

--- a/docs/diagnostics/PX1003.md
+++ b/docs/diagnostics/PX1003.md
@@ -8,37 +8,59 @@ This document describes the PX1003 diagnostic.
 | PX1003 | An instance of the base graph type should be created with the `PXGraph.CreateInstance()` factory method. | Warning | Available |
 
 ## Diagnostic Description
-To instantiate a graph type from code, you cannot use the graph constructor `new T()`. However, you can use `new PXGraph()` if you select or change records in the system context or generic context and if no specific implementation of `PXGraph` can be used.
+The PX1003 diagnostic reports graph instances of the base `PXGraph` type that are instantiated directly with a graph constructor (for example, `new PXGraph()`). The `PXGraph.CreateInstance<T>()` factory method should be used 
+instead to instantiate correctly initialized graph instances from code.
 
-If you use `new PXGraph()` instead of the instantiation of an instance of specific graph type, a part of platform-specific logic is omitted, such as the following:
+This diagnostic has a complementary rule, PX1001, which reports direct constructor calls for concrete graph types derived from the `PXGraph` type (for example, `new SOOrderEntry()`). Both diagnostics share similar reasoning, 
+but they have different severity levels.
 
- - Collection and initialization of graph extensions
- - Dependency injection
- - Loading and unloading of the graph state from the session
+### Difference between Graph Constructor Calls and PXGraph.CreateInstance Factory Method
+During the execution of the `PXGraph.CreateInstance` factory method, the Acumatica Framework performs a complex initialization of the graph instance, including the following steps:
+ - Collection and initialization of graph extensions.
+ - Dependency injection of services into graph.
+ - Loading and unloading of the graph state from the session.
 
-However, `new PXGraph()` works faster than the instantiation of a specific graph type through the `PXGraph.CreateInstance<T>()` method.
+These steps are omitted when the graph instance is created via a direct constructor call. Next sections describe some of the initialization steps.
 
-To fix the issue, you should consider replacing `new PXGraph()` with the instantiation of an instance of a specific graph type through the `PXGraph.CreateInstance<T>()` method.
+#### Graph Extensions 
+The Acumatica Framework relies on a complex extension mechanism to provide customization capabilities. Proper initialization of graph instances is essential for this mechanism to function correctly.
+Such initialization is implemented in the `PXGraph.CreateInstance()` factory method via the dynamic generation of a proxy class that derives from the original graph type and integrates all graph extensions 
+into the original graph's logic. Among extension mechanisms that rely on this dynamic code generation are:
+- The `PXOverride` attribute mechanism,
+- The `PXProtectedAccess` attribute mechanism,
+- The overrides of event handlers.
+
+On the other hand, graph constructors will only create instances of the original graph type without any graph extensions loaded for it. This can lead to incorrect and unexpected behavior at runtime.
+
+#### Dependency Injection
+The Acumatica Framework provides its own Dependency Injection (DI) mechanism to inject different services into the graph instance via the property injection pattern. The `PXGraph.CreateInstance()` factory method ensures that 
+all DI services are correctly injected into the graph instance, while direct constructor calls bypass this mechanism. This means that graphs created via constructors may lack necessary DI services, leading to runtime errors.
 
 ### Why Warning Severity for Base `PXGraph` Type
-For the base `PXGraph` type, direct constructor calls are also discouraged. In most cases, the application logic should not use instances of the base graph directly. The Acumatica Framework contains graph extensions 
-created for the base `PXGraph` type are applied to **all** graphs derived from it (essentially every graph in the system). There are also DI services that are injected into the base `PXGraph` type and expected 
-to be available in all derived graphs.
+The Acumatica Framework contains graph extensions created for the base `PXGraph` type are applied to **all** graphs derived from it (essentially every graph in the system). There are also DI services that are injected into 
+the base `PXGraph` type and expected to be available in all derived graphs. This means that even the instance of the base `PXGraph` type should be properly initialized to ensure that these extensions and DI services are available.
 
-Instantiating the base `PXGraph` type directly bypasses these extensions and DI services, which can lead to unexpected behavior. If you need a general graph with all initialized extensions and DI services, you can create it 
-using the following code:
+Creating an instance of the base `PXGraph` type directly will bypass the initialization of these extensions and DI services, which can lead to unexpected behavior. If you need a general graph instance with all initialized extensions 
+and DI services, you can create it using the following code:
 ```C#
 var generalGraphWithAllExtensionsAndDiServices = PXGraph.CreateInstance<PXGraph>();
 ```
 
+However, the business logic rarely uses `PXGraph` instances preferring concrete graph types derived from it. Therefore, the direct instantiation of the base `PXGraph` type is a less critical issue compared to concrete graph types.
+In addition, there is a specific usage scenario with the data querying from the database where the direct instantiation of the base `PXGraph` type is acceptable, as described in the next section. 
+
+Because of these reasons, the PX1003 diagnostic has a **Warning** severity instead of an **Error** like the PX1001 diagnostic.
+
 #### Lightweight Data Querying
-However, there is one usage scenario where the direct instantiation of the base `PXGraph` type is acceptable. This is when a base `PXGraph` instance created via a direct constructor call is used **only** to query data 
+There is one usage scenario where the direct instantiation of the base `PXGraph` type is acceptable. This is when a base `PXGraph` instance created via a direct constructor call is used **only** to query data 
 from the database (for example, for some service). Sometimes, Acumatica developers use such "cheaper," not fully initialized graph instances just to retrieve data. In this case the full graph initialization via `CreateInstance` 
-can be an unnecessarily expensive operation. 
- 
-Because of this specific use case, the diagnostic displays a **Warning** rather than an error for the base `PXGraph` type, while still discouraging the practice.
+is an unnecessary expensive operation and developers use a cheaper alternative.
 
 **If you need to create lightweight `PXGraph` instance via direct constructor call for data querying, you should just suppress the PX1001 warning on the constructor call with Acuminator suppression comment.**
+Acuminator knows about this scenario and will even generate a default justification for such suppressions in this case.
+
+## Code Fix Behavior
+The code fix replaces the direct call to the `PXGraph` constructor with the call to the `PXGraph.CreateInstance<PXGraph>()` factory method.
 
 ## Example of Incorrect Code
 ```C#
@@ -54,5 +76,6 @@ var graph = PXGraph.CreateInstance<PXGraph>();
 
 ## Related Articles
 
+- [PX1001 Diagnostic](PX1001.md)
 - [Business Logic Customization](https://help.acumatica.com/Help?ScreenId=ShowWiki&pageid=b02bd27f-3e86-4210-9e0f-c0df7aa701d9)
 - [Graph Extensions: General Information](https://help.acumatica.com/Help?ScreenId=ShowWiki&pageid=e220486e-32d1-439b-a858-7c10f44a9bac)

--- a/docs/diagnostics/PX1003.md
+++ b/docs/diagnostics/PX1003.md
@@ -56,7 +56,7 @@ There is one usage scenario where the direct instantiation of the base `PXGraph`
 from the database (for example, for some service). Sometimes, Acumatica developers use such "cheaper," not fully initialized graph instances just to retrieve data. In this case the full graph initialization via `CreateInstance` 
 is an unnecessary expensive operation and developers use a cheaper alternative.
 
-**If you need to create lightweight `PXGraph` instance via direct constructor call for data querying, you should just suppress the PX1001 warning on the constructor call with Acuminator suppression comment.**
+**If you need to create lightweight `PXGraph` instance via direct constructor call for data querying, you should just suppress the PX1003 warning on the constructor call with Acuminator suppression comment.**
 Acuminator knows about this scenario and will even generate a default justification for such suppressions in this case.
 
 ## Code Fix Behavior

--- a/src/Acuminator/Acuminator.Analyzers/DiagnosticsDefaultJustification.Designer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/DiagnosticsDefaultJustification.Designer.cs
@@ -70,6 +70,15 @@ namespace Acuminator.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to graph is used only for data retrieval from the database.
+        /// </summary>
+        public static string PX1003 {
+            get {
+                return ResourceManager.GetString("PX1003", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to to be documented later.
         /// </summary>
         public static string PX1007 {

--- a/src/Acuminator/Acuminator.Analyzers/DiagnosticsDefaultJustification.resx
+++ b/src/Acuminator/Acuminator.Analyzers/DiagnosticsDefaultJustification.resx
@@ -121,7 +121,7 @@
     <value>[Justification]</value>
   </data>
   <data name="PX1003" xml:space="preserve">
-    <value>graph is used only for data retrieval from the database</value>
+    <value>the graph is used only for data retrieval from the database</value>
   </data>
   <data name="PX1007" xml:space="preserve">
     <value>to be documented later</value>

--- a/src/Acuminator/Acuminator.Analyzers/DiagnosticsDefaultJustification.resx
+++ b/src/Acuminator/Acuminator.Analyzers/DiagnosticsDefaultJustification.resx
@@ -120,6 +120,9 @@
   <data name="Default" xml:space="preserve">
     <value>[Justification]</value>
   </data>
+  <data name="PX1003" xml:space="preserve">
+    <value>graph is used only for data retrieval from the database</value>
+  </data>
   <data name="PX1007" xml:space="preserve">
     <value>to be documented later</value>
   </data>

--- a/src/Acuminator/Acuminator.Analyzers/Resources.Designer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/Resources.Designer.cs
@@ -115,7 +115,16 @@ namespace Acuminator.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Consider using a specific implementation of PXGraph.
+        ///   Looks up a localized string similar to Create a base graph instance by using the factory method.
+        /// </summary>
+        public static string PX1003Fix {
+            get {
+                return ResourceManager.GetString("PX1003Fix", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to An instance of the base graph type should be created with the PXGraph.CreateInstance() factory method.
         /// </summary>
         public static string PX1003Title {
             get {

--- a/src/Acuminator/Acuminator.Analyzers/Resources.resx
+++ b/src/Acuminator/Acuminator.Analyzers/Resources.resx
@@ -135,8 +135,11 @@
   <data name="PX1002Title" xml:space="preserve">
     <value>The field must have the type attribute corresponding to the list attribute</value>
   </data>
+  <data name="PX1003Fix" xml:space="preserve">
+    <value>Create a base graph instance by using the factory method</value>
+  </data>
   <data name="PX1003Title" xml:space="preserve">
-    <value>Consider using a specific implementation of PXGraph</value>
+    <value>An instance of the base graph type should be created with the PXGraph.CreateInstance() factory method</value>
   </data>
   <data name="PX1004Fix" xml:space="preserve">
     <value>Consider changing the declaration order</value>
@@ -703,7 +706,7 @@ public virtual int? SomeDacField{ get; set; }</value>
     <value>Event handlers should be protected and virtual</value>
   </data>
   <data name="PX1077TitleFormatWithReason" xml:space="preserve">
-	<value>Event handlers should be {0}</value>
+    <value>Event handlers should be {0}</value>
   </data>
   <data name="PX1077Title_EventHandlersShouldNotBePrivate" xml:space="preserve">
     <value>Event handlers should not be private</value>

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/DacExtensionDefaultAttribute/DacExtensionDefaultAttributeAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/DacExtensionDefaultAttribute/DacExtensionDefaultAttributeAnalyzer.cs
@@ -30,8 +30,8 @@ namespace Acuminator.Analyzers.StaticAnalysis.DacExtensionDefaultAttribute
 		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
 			ImmutableArray.Create(
                 Descriptors.PX1030_DefaultAttibuteToExistingRecordsOnDAC,
-                Descriptors.PX1030_DefaultAttibuteToExistingRecordsError,
-                Descriptors.PX1030_DefaultAttibuteToExistingRecordsWarning);
+                Descriptors.PX1030_DefaultAttributeToExistingRecordsError,
+                Descriptors.PX1030_DefaultAttributeToExistingRecordsWarning);
 
 		public override void Analyze(SymbolAnalysisContext context, PXContext pxContext, DacSemanticModel dacOrExtension)
 		{
@@ -86,7 +86,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.DacExtensionDefaultAttribute
 																		   .Add(DiagnosticProperty.IsBoundField, bool.FalseString);
             var descriptor = dacOrExtension.DacType == DacType.Dac
 				? Descriptors.PX1030_DefaultAttibuteToExistingRecordsOnDAC 
-				: Descriptors.PX1030_DefaultAttibuteToExistingRecordsError;
+				: Descriptors.PX1030_DefaultAttributeToExistingRecordsError;
             var diagnostic = Diagnostic.Create(descriptor, attributeLocation, diagnosticProperties);
 
             symbolContext.ReportDiagnosticWithSuppressionCheck(diagnostic, pxContext.CodeAnalysisSettings);
@@ -105,7 +105,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.DacExtensionDefaultAttribute
 
             var diagnosticProperties = ImmutableDictionary<string, string?>.Empty
 																		   .Add(DiagnosticProperty.IsBoundField, bool.TrueString);
-            var diagnostic = Diagnostic.Create(Descriptors.PX1030_DefaultAttibuteToExistingRecordsWarning, attributeLocation, diagnosticProperties);
+            var diagnostic = Diagnostic.Create(Descriptors.PX1030_DefaultAttributeToExistingRecordsWarning, attributeLocation, diagnosticProperties);
 
             symbolContext.ReportDiagnosticWithSuppressionCheck(diagnostic, pxContext.CodeAnalysisSettings);
         }

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/DacExtensionDefaultAttribute/DacExtensionDefaultAttributeFix.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/DacExtensionDefaultAttribute/DacExtensionDefaultAttributeFix.cs
@@ -23,8 +23,8 @@ namespace Acuminator.Analyzers.StaticAnalysis.DacExtensionDefaultAttribute
 	{
 		public override ImmutableArray<string> FixableDiagnosticIds { get; } =
 			ImmutableArray.Create(
-				Descriptors.PX1030_DefaultAttibuteToExistingRecordsError.Id,
-				Descriptors.PX1030_DefaultAttibuteToExistingRecordsWarning.Id,
+				Descriptors.PX1030_DefaultAttributeToExistingRecordsError.Id,
+				Descriptors.PX1030_DefaultAttributeToExistingRecordsWarning.Id,
 				Descriptors.PX1030_DefaultAttibuteToExistingRecordsOnDAC.Id);
 
 		protected override async Task RegisterCodeFixesForDiagnosticAsync(CodeFixContext context, Diagnostic diagnostic)

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/Descriptors.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/Descriptors.cs
@@ -46,7 +46,7 @@ namespace Acuminator.Analyzers.StaticAnalysis
 			Rule("PX1002", nameof(Resources.PX1002Title).GetLocalized(), Category.Acuminator,
 				DiagnosticSeverity.Error, DiagnosticsShortName.PX1002);
 
-		public static DiagnosticDescriptor PX1003_NonSpecificPXGraphCreateInstance { get; } =
+		public static DiagnosticDescriptor PX1003_BasePXGraphCreateInstance { get; } =
 			Rule("PX1003", nameof(Resources.PX1003Title).GetLocalized(), Category.Acuminator,
 				DiagnosticSeverity.Warning, DiagnosticsShortName.PX1003);
 

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/Descriptors.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/Descriptors.cs
@@ -39,16 +39,15 @@ namespace Acuminator.Analyzers.StaticAnalysis
 				DiagnosticSeverity.Error, DiagnosticsShortName.PX1000);
 
 		public static DiagnosticDescriptor PX1001_PXGraphCreateInstance { get; } =
-			Rule("PX1001", nameof(Resources.PX1001Title).GetLocalized(), Category.Acuminator,
-				DiagnosticSeverity.Error, DiagnosticsShortName.PX1001);
+			Rule("PX1001", nameof(Resources.PX1001Title).GetLocalized(), Category.Acuminator, DiagnosticSeverity.Error, DiagnosticsShortName.PX1001);
 
 		public static DiagnosticDescriptor PX1002_MissingTypeListAttributeAnalyzer { get; } =
 			Rule("PX1002", nameof(Resources.PX1002Title).GetLocalized(), Category.Acuminator,
 				DiagnosticSeverity.Error, DiagnosticsShortName.PX1002);
 
 		public static DiagnosticDescriptor PX1003_BasePXGraphCreateInstance { get; } =
-			Rule("PX1003", nameof(Resources.PX1003Title).GetLocalized(), Category.Acuminator,
-				DiagnosticSeverity.Warning, DiagnosticsShortName.PX1003);
+			Rule("PX1003", nameof(Resources.PX1003Title).GetLocalized(), Category.Acuminator, DiagnosticSeverity.Warning, DiagnosticsShortName.PX1003,
+				 diagnosticDefaultJustification: DiagnosticsDefaultJustification.PX1003);
 
 		public static DiagnosticDescriptor PX1004_ViewDeclarationOrder { get; } =
 			Rule("PX1004", nameof(Resources.PX1004Title).GetLocalized(), Category.Acuminator,

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/Descriptors.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/Descriptors.cs
@@ -15,7 +15,7 @@ namespace Acuminator.Analyzers.StaticAnalysis
 	public static class Descriptors
 	{
 		private const string DocumentationLinkPrefix = @"https://github.com/Acumatica/Acuminator/blob/master/docs/diagnostics";
-		private const string DocumentatonFileExtension = "md";
+		private const string DocumentationFileExtension = "md";
 
 		private static readonly ConcurrentDictionary<Category, string> _categoryMapping = new ConcurrentDictionary<Category, string>();
 
@@ -25,7 +25,7 @@ namespace Acuminator.Analyzers.StaticAnalysis
 		{
 			bool isEnabledByDefault = true;
 			messageFormat = messageFormat ?? title;
-			string diagnosticLink = $"{DocumentationLinkPrefix}/{id}.{DocumentatonFileExtension}";
+			string diagnosticLink = $"{DocumentationLinkPrefix}/{id}.{DocumentationFileExtension}";
 			string[] customTags = diagnosticDefaultJustification.IsNullOrWhiteSpace()
 				? [diagnosticShortName]
 				: [diagnosticShortName, diagnosticDefaultJustification];
@@ -197,11 +197,11 @@ namespace Acuminator.Analyzers.StaticAnalysis
 			Rule("PX1029", nameof(Resources.PX1029Title).GetLocalized(), Category.Acuminator, DiagnosticSeverity.Error,
 				DiagnosticsShortName.PX1029);
 
-		public static DiagnosticDescriptor PX1030_DefaultAttibuteToExistingRecordsError { get; } =
+		public static DiagnosticDescriptor PX1030_DefaultAttributeToExistingRecordsError { get; } =
 			Rule("PX1030", nameof(Resources.PX1030TitleDefaultAttributeOnDacExtension).GetLocalized(), Category.Acuminator,
 				DiagnosticSeverity.Error, DiagnosticsShortName.PX1030);
 
-		public static DiagnosticDescriptor PX1030_DefaultAttibuteToExistingRecordsWarning { get; } =
+		public static DiagnosticDescriptor PX1030_DefaultAttributeToExistingRecordsWarning { get; } =
 			Rule("PX1030", nameof(Resources.PX1030TitleDefaultAttributeOnDacExtension).GetLocalized(), Category.Acuminator,
 				DiagnosticSeverity.Warning, DiagnosticsShortName.PX1030);
 
@@ -273,7 +273,7 @@ namespace Acuminator.Analyzers.StaticAnalysis
 			Rule("PX1043", nameof(Resources.PX1043Title).GetLocalized(), Category.Acuminator, DiagnosticSeverity.Error,
 				DiagnosticsShortName.PX1043);
 
-		public static DiagnosticDescriptor PX1043_SavingChangesInRowPerstisting { get; } =
+		public static DiagnosticDescriptor PX1043_SavingChangesInRowPersisting { get; } =
 			Rule("PX1043", nameof(Resources.PX1043TitleRowPersisting).GetLocalized(), Category.Acuminator, DiagnosticSeverity.Error, DiagnosticsShortName.PX1043);
 
 		public static DiagnosticDescriptor PX1043_SavingChangesInRowPerstistedNonISV { get; } =

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXGraphCreateInstance/PXGraphCreateInstanceAnalyzer.Walker.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXGraphCreateInstance/PXGraphCreateInstanceAnalyzer.Walker.cs
@@ -17,7 +17,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXGraphCreateInstance
 			private readonly SemanticModel _semanticModel;
 
 			private static readonly DiagnosticDescriptor _px1001Descriptor = Descriptors.PX1001_PXGraphCreateInstance;
-			private static readonly DiagnosticDescriptor _px1003Descriptor = Descriptors.PX1003_NonSpecificPXGraphCreateInstance;
+			private static readonly DiagnosticDescriptor _px1003Descriptor = Descriptors.PX1003_BasePXGraphCreateInstance;
 
 			public Walker(SyntaxNodeAnalysisContext context, PXContext pxContext, SemanticModel semanticModel)
 			{

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXGraphCreateInstance/PXGraphCreateInstanceAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXGraphCreateInstance/PXGraphCreateInstanceAnalyzer.cs
@@ -15,7 +15,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXGraphCreateInstance
 	{
 		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(
 				Descriptors.PX1001_PXGraphCreateInstance,
-				Descriptors.PX1003_NonSpecificPXGraphCreateInstance);
+				Descriptors.PX1003_BasePXGraphCreateInstance);
 
 		public PXGraphCreateInstanceAnalyzer() : this(null)
 		{ }

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXGraphCreateInstance/PXGraphCreateInstanceFix.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXGraphCreateInstance/PXGraphCreateInstanceFix.cs
@@ -20,14 +20,21 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXGraphCreateInstance
 	[ExportCodeFixProvider(LanguageNames.CSharp), Shared]
 	public class PXGraphCreateInstanceFix : PXCodeFixProvider
 	{
+		private static readonly DiagnosticDescriptor _cachedPX1001Descriptor = Descriptors.PX1001_PXGraphCreateInstance;
+
 		public override ImmutableArray<string> FixableDiagnosticIds { get; } =
-			ImmutableArray.Create(Descriptors.PX1001_PXGraphCreateInstance.Id);
+			[
+				_cachedPX1001Descriptor.Id,
+				Descriptors.PX1003_BasePXGraphCreateInstance.Id
+			];
 
 		protected override Task RegisterCodeFixesForDiagnosticAsync(CodeFixContext context, Diagnostic diagnostic)
 		{
 			context.CancellationToken.ThrowIfCancellationRequested();
 
-			string title = nameof(Resources.PX1001Fix).GetLocalized().ToString();
+			string title = diagnostic.Id == _cachedPX1001Descriptor.Id
+				? nameof(Resources.PX1001Fix).GetLocalized().ToString()
+				: nameof(Resources.PX1003Fix).GetLocalized().ToString();
 			var codeAction = CodeAction.Create(title, cancellation => RewriteGraphConstructionAsync(context.Document, context.Span, cancellation),
 											   equivalenceKey: title);
 
@@ -80,7 +87,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXGraphCreateInstance
 				if (_generator == null) 
 					return base.VisitObjectCreationExpression(node);
 
-				var graphTypeSymbol		   = _semanticModel.GetSymbolInfo(node.Type, _cancellation).Symbol as ITypeSymbol;
+				var graphTypeSymbol		   = _semanticModel.GetSymbolOrFirstCandidate(node.Type, _cancellation) as ITypeSymbol;
 				var createInstanceCallNode = GeneratePXGraphCreateInstanceCall(graphTypeSymbol);
 
 				return createInstanceCallNode ?? base.VisitObjectCreationExpression(node);
@@ -93,7 +100,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXGraphCreateInstance
 				if (_generator == null)
 					return base.VisitImplicitObjectCreationExpression(node);
 
-				var constructor = _semanticModel.GetSymbolInfo(node, _cancellation).Symbol as IMethodSymbol;
+				var constructor = _semanticModel.GetSymbolOrFirstCandidate(node, _cancellation) as IMethodSymbol;
 
 				if (constructor?.ContainingType == null || constructor.MethodKind != MethodKind.Constructor)
 					return base.VisitImplicitObjectCreationExpression(node);

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/SavingChanges/SavingChangesInEventHandlersAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/SavingChanges/SavingChangesInEventHandlersAnalyzer.cs
@@ -20,7 +20,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.SavingChanges
 	{
 		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(
 			Descriptors.PX1043_SavingChangesInEventHandlers,
-			Descriptors.PX1043_SavingChangesInRowPerstisting,
+			Descriptors.PX1043_SavingChangesInRowPersisting,
 			Descriptors.PX1043_SavingChangesInRowPerstistedNonISV);
 
 		public override void Analyze(SymbolAnalysisContext context, PXContext pxContext, EventHandlerLooseInfo eventHandlerLooseInfo)
@@ -109,7 +109,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.SavingChanges
 					{
 						if (saveOperationKind != SaveOperationKind.CachePersist)
 						{
-							ReportDiagnostic(_context.ReportDiagnostic, Descriptors.PX1043_SavingChangesInRowPerstisting, node);
+							ReportDiagnostic(_context.ReportDiagnostic, Descriptors.PX1043_SavingChangesInRowPersisting, node);
 							return true;
 						}
 					}

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/DacExtensionDefaultAttribute/DefaultAttributeDacTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/DacExtensionDefaultAttribute/DefaultAttributeDacTests.cs
@@ -35,37 +35,37 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.DacExtensionDefaultAttribute
         [EmbeddedFileData("DacExtensionWithoutPersistingCheckNothingInvalid.cs")]
         public async Task InvalidDacExtensionWithoutPersistingcheckNothing(string source) =>
             await VerifyCSharpDiagnosticAsync(source,
-                Descriptors.PX1030_DefaultAttibuteToExistingRecordsWarning.CreateFor(8, 10));
+                Descriptors.PX1030_DefaultAttributeToExistingRecordsWarning.CreateFor(8, 10));
 
         [Theory]
 		[EmbeddedFileData("DacExtensionWithBoundFields.cs")]
 		public virtual Task DacExtensionWithBoundAttribute(string source) =>
 			VerifyCSharpDiagnosticAsync(new[] { source },
-				Descriptors.PX1030_DefaultAttibuteToExistingRecordsWarning.CreateFor(line: 23, column: 4),
-				Descriptors.PX1030_DefaultAttibuteToExistingRecordsWarning.CreateFor(line: 30, column: 4),
-				Descriptors.PX1030_DefaultAttibuteToExistingRecordsWarning.CreateFor(line: 44, column: 4),
-				Descriptors.PX1030_DefaultAttibuteToExistingRecordsWarning.CreateFor(line: 50, column: 13),
-				Descriptors.PX1030_DefaultAttibuteToExistingRecordsWarning.CreateFor(line: 56, column: 13),
-				Descriptors.PX1030_DefaultAttibuteToExistingRecordsWarning.CreateFor(line: 62, column: 4));
+				Descriptors.PX1030_DefaultAttributeToExistingRecordsWarning.CreateFor(line: 23, column: 4),
+				Descriptors.PX1030_DefaultAttributeToExistingRecordsWarning.CreateFor(line: 30, column: 4),
+				Descriptors.PX1030_DefaultAttributeToExistingRecordsWarning.CreateFor(line: 44, column: 4),
+				Descriptors.PX1030_DefaultAttributeToExistingRecordsWarning.CreateFor(line: 50, column: 13),
+				Descriptors.PX1030_DefaultAttributeToExistingRecordsWarning.CreateFor(line: 56, column: 13),
+				Descriptors.PX1030_DefaultAttributeToExistingRecordsWarning.CreateFor(line: 62, column: 4));
 
 		[Theory]
 		[EmbeddedFileData("DacExtensionWithUnboundFields.cs")]
 		public virtual Task DacExtensionWithUnboundFields(string source) =>
 			VerifyCSharpDiagnosticAsync(new[] { source },
-				Descriptors.PX1030_DefaultAttibuteToExistingRecordsError.CreateFor(line: 35, column: 4));
+				Descriptors.PX1030_DefaultAttributeToExistingRecordsError.CreateFor(line: 35, column: 4));
 
 		[Theory]
 		[EmbeddedFileData("DacExtensionWithBoundAndUnboundFields.cs", "SOOrder.cs")]
 		public virtual Task DacExtensionWithBoundAndUnboundAttribute(string source, string additionalSource) =>
 			VerifyCSharpDiagnosticAsync(new[] { source, additionalSource },
-				Descriptors.PX1030_DefaultAttibuteToExistingRecordsError.CreateFor(line: 16, column: 4),
-				Descriptors.PX1030_DefaultAttibuteToExistingRecordsWarning.CreateFor(line: 35, column: 4));
+				Descriptors.PX1030_DefaultAttributeToExistingRecordsError.CreateFor(line: 16, column: 4),
+				Descriptors.PX1030_DefaultAttributeToExistingRecordsWarning.CreateFor(line: 35, column: 4));
 
 		[Theory]
 		[EmbeddedFileData("DacExtensionWithAggregateAttributesOnFields.cs", "SOOrder.cs")]
 		public virtual Task DacExtensionWithAggregateAttributeFields(string source, string additionalSource) =>
 			VerifyCSharpDiagnosticAsync(new[] { source, additionalSource },
-				Descriptors.PX1030_DefaultAttibuteToExistingRecordsError.CreateFor(line: 36, column: 4));
+				Descriptors.PX1030_DefaultAttributeToExistingRecordsError.CreateFor(line: 36, column: 4));
 
 		[Theory]
 		[EmbeddedFileData("DacExtensionWithAggregateAttributesOnFields.cs",

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreateInstance/PXGraphCreateInstanceTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreateInstance/PXGraphCreateInstanceTests.cs
@@ -43,7 +43,7 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.PXGraphCreateInstance
 		[Theory]
 		[EmbeddedFileData("MethodWithNonSpecificPXGraph.cs")]
 		public Task CallTo_NonSpecificPXGraph_Constructor_In_Method(string actual) => 
-			VerifyCSharpDiagnosticAsync(actual, Descriptors.PX1003_NonSpecificPXGraphCreateInstance.CreateFor(14, 16));
+			VerifyCSharpDiagnosticAsync(actual, Descriptors.PX1003_BasePXGraphCreateInstance.CreateFor(14, 16));
 
 		[Theory]
 		[EmbeddedFileData("Method.cs", "Method_Expected.cs")]

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreateInstance/PXGraphCreateInstanceTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreateInstance/PXGraphCreateInstanceTests.cs
@@ -28,17 +28,22 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.PXGraphCreateInstance
 		public Task CallTo_Constructor_In_Method(string actual) =>
 			VerifyCSharpDiagnosticAsync(actual,
 				Descriptors.PX1001_PXGraphCreateInstance.CreateFor(15, 16),
-				Descriptors.PX1001_PXGraphCreateInstance.CreateFor(16, 31));
+				Descriptors.PX1001_PXGraphCreateInstance.CreateFor(16, 31),
+				Descriptors.PX1003_BasePXGraphCreateInstance.CreateFor(17, 20));
 
 		[Theory]
 		[EmbeddedFileData("Field.cs")]
-		public Task CallTo_Constructor_In_FieldInitializer(string actual) => 
-			VerifyCSharpDiagnosticAsync(actual, Descriptors.PX1001_PXGraphCreateInstance.CreateFor(12, 43));
+		public Task CallTo_Constructor_In_FieldInitializer(string actual) =>
+			VerifyCSharpDiagnosticAsync(actual,
+				Descriptors.PX1001_PXGraphCreateInstance.CreateFor(12, 37),
+				Descriptors.PX1003_BasePXGraphCreateInstance.CreateFor(13, 38));
 
 		[Theory]
 		[EmbeddedFileData("Property.cs")]
-		public Task CallTo_Constructor_In_Property(string actual) => 
-			VerifyCSharpDiagnosticAsync(actual, Descriptors.PX1001_PXGraphCreateInstance.CreateFor(14, 17));
+		public Task CallTo_Constructor_In_Property(string actual) =>
+			VerifyCSharpDiagnosticAsync(actual,
+				Descriptors.PX1001_PXGraphCreateInstance.CreateFor(14, 17),
+				Descriptors.PX1003_BasePXGraphCreateInstance.CreateFor(19, 17));
 
 		[Theory]
 		[EmbeddedFileData("MethodWithNonSpecificPXGraph.cs")]

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreateInstance/Sources/Field.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreateInstance/Sources/Field.cs
@@ -7,12 +7,13 @@ using PX.Data;
 
 namespace Acuminator.Tests.Tests.StaticAnalysis.PXGraphCreateInstance
 {
-    class PX1001ClassWithField
-    {
-        private readonly PXGraph _field = new PX1001FieldGraph();
-    }
+	class PX1001ClassWithField
+	{
+		private readonly PXGraph _field = new PX1001FieldGraph();
+		private readonly PXGraph _field2 = new PXGraph();
+	}
 
-    class PX1001FieldGraph : PXGraph<PX1001FieldGraph>
-    {
-    }
+	class PX1001FieldGraph : PXGraph<PX1001FieldGraph>
+	{
+	}
 }

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreateInstance/Sources/Field_Expected.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreateInstance/Sources/Field_Expected.cs
@@ -7,12 +7,13 @@ using PX.Data;
 
 namespace Acuminator.Tests.Tests.StaticAnalysis.PXGraphCreateInstance
 {
-    class PX1001ClassWithField
-    {
-        private readonly PXGraph _field = PXGraph.CreateInstance<PX1001FieldGraph>();
-    }
+	class PX1001ClassWithField
+	{
+		private readonly PXGraph _field = PXGraph.CreateInstance<PX1001FieldGraph>();
+		private readonly PXGraph _field2 = PXGraph.CreateInstance<PXGraph>();
+	}
 
-    class PX1001FieldGraph : PXGraph<PX1001FieldGraph>
-    {
-    }
+	class PX1001FieldGraph : PXGraph<PX1001FieldGraph>
+	{
+	}
 }

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreateInstance/Sources/Method.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreateInstance/Sources/Method.cs
@@ -14,6 +14,7 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.PXGraphCreateInstance
 		{
 			var graph = new PX1001MethodGraph();
 			PX1001MethodGraph graph2 = new();
+			var baseGraph = new PXGraph();
 		}
 	}
 

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreateInstance/Sources/Method_Expected.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreateInstance/Sources/Method_Expected.cs
@@ -14,6 +14,7 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.PXGraphCreateInstance
 		{
 			var graph = PXGraph.CreateInstance<PX1001MethodGraph>();
 			PX1001MethodGraph graph2 = PXGraph.CreateInstance<PX1001MethodGraph>();
+			var baseGraph = PXGraph.CreateInstance<PXGraph>();
 		}
 	}
 

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreateInstance/Sources/Property.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreateInstance/Sources/Property.cs
@@ -13,9 +13,14 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.PXGraphCreateInstance
 		{
 			get { return new PX1001PropertyGraph(); }
 		}
+
+		public PXGraph Graph2
+		{
+			get { return new(); }
+		}
 	}
 
-	class PX1001PropertyGraph : PXGraph<PX1001PropertyGraph>
+	public class PX1001PropertyGraph : PXGraph<PX1001PropertyGraph>
 	{
 	}
 }

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreateInstance/Sources/Property_Expected.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXGraphCreateInstance/Sources/Property_Expected.cs
@@ -13,9 +13,14 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.PXGraphCreateInstance
 		{
 			get { return PXGraph.CreateInstance<PX1001PropertyGraph>(); }
 		}
+
+		public PXGraph Graph2
+		{
+			get { return PXGraph.CreateInstance<PXGraph>(); }
+		}
 	}
 
-	class PX1001PropertyGraph : PXGraph<PX1001PropertyGraph>
+	public class PX1001PropertyGraph : PXGraph<PX1001PropertyGraph>
 	{
 	}
 }

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/SavingChanges/SavingChangesInEventHandlersTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/SavingChanges/SavingChangesInEventHandlersTests.cs
@@ -55,7 +55,7 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.SavingChanges
 		[Theory]
 		[EmbeddedFileData(@"EventHandlers\PressSaveInsideRowPersisting.cs")]
 		public Task PressSaveInsideRowPersisting(string actual) =>
-			VerifyCSharpDiagnosticAsync(actual, Descriptors.PX1043_SavingChangesInRowPerstisting.CreateFor(14, 4));
+			VerifyCSharpDiagnosticAsync(actual, Descriptors.PX1043_SavingChangesInRowPersisting.CreateFor(14, 4));
 
 		[Theory]
 		[EmbeddedFileData(@"EventHandlers\CachePersistInsideRowPersisting.cs")]


### PR DESCRIPTION
**Changes Overview**
- Rewrote the documentation for PX1001 and PX1003 diagnostics
- Replaced diagnostic message for PX1003 diagnostic for the creation of base graph instances via constructor
- Added default justification for PX1003 diagnostic
- Added support for code fix of the PX1001 diagnostic to the PX1003 diagnostic
- Added unit tests for the PX1003 diagnostic and its new code fix scenario
- Refactoring - mass renaming of descriptors with mistypes in names 