### PR TITLE
Bugfix/atr 931 dev stack overflow in px1008

### DIFF
--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/LongOperationDelegateClosures/LongOperationDelegateClosuresAnalyzer.LongOperationsChecker.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/LongOperationDelegateClosures/LongOperationDelegateClosuresAnalyzer.LongOperationsChecker.cs
@@ -67,7 +67,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.LongOperationDelegateClosures
 			public override void VisitLocalFunctionStatement(LocalFunctionStatementSyntax localFunctionDeclaration)
 			{
 				// There are two ways to get into local function statement with the nested invocation walker:
-				// 1. Visit it during the recursive visit of a local function call. In such case it can be processesd as usual
+				// 1. Visit it during the recursive visit of a local function call. In such case it can be processed as usual
 				// 2. Visit the declaration during the normal syntax walking.
 				
 				if (localFunctionDeclaration.Equals(NodeCurrentlyVisitedRecursively))

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/LongOperationDelegateClosures/LongOperationDelegateClosuresAnalyzer.LongOperationsChecker.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/LongOperationDelegateClosures/LongOperationDelegateClosuresAnalyzer.LongOperationsChecker.cs
@@ -62,6 +62,8 @@ namespace Acuminator.Analyzers.StaticAnalysis.LongOperationDelegateClosures
 			public override void VisitDocumentationCommentTrivia(DocumentationCommentTriviaSyntax node) { }
 
 			public override void VisitXmlComment(XmlCommentSyntax node) { }
+
+			public override void VisitAttributeList(AttributeListSyntax node) { }
 			#endregion
 
 			public override void VisitLocalFunctionStatement(LocalFunctionStatementSyntax localFunctionDeclaration)

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/LongOperationDelegateClosures/LongOperationDelegateClosuresTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/LongOperationDelegateClosures/LongOperationDelegateClosuresTests.cs
@@ -234,6 +234,10 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.LongOperationDelegateClosures
 				Descriptors.PX1008_LongOperationDelegateClosures.CreateFor(line: 20, column: 24, formatArgs));
 		}
 
+		[Theory]
+		[EmbeddedFileData("CircularReferenceInCalls.cs")]
+		public Task InterProcedureAnalysis_WithCircularReferences_NoDiagnostic(string actual) =>
+			VerifyCSharpDiagnosticAsync(actual);
 
 		[Theory(Skip = "Recursive analysis of passed delegates currently is not supported for this diagnostic and is skipped for now")]
 		[EmbeddedFileData("LongRunDelegateClosures_Delegates.cs")]

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/LongOperationDelegateClosures/Sources/CircularReferenceInCalls.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/LongOperationDelegateClosures/Sources/CircularReferenceInCalls.cs
@@ -1,0 +1,47 @@
+﻿using PX.Async;
+using PX.Data;
+
+using System;
+using System.Collections;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Acuminator.Tests.Sources
+{
+	[PXHidden]
+	public class SomeDAC : PXBqlTable, IBqlTable { }
+
+	public class SomeGraph : PXGraph<SomeGraph>
+	{
+		PXAction<SomeDAC> SomeAction = null!;
+
+		public IEnumerable someAction(PXAdapter adapter)
+		{
+			RecursiveCallWithLocalFunction(recursionDepth: 0);
+			RecursiveCall(recursionDepth: 0);
+			return adapter.Get();
+		}
+
+		private void RecursiveCallWithLocalFunction(int recursionDepth)
+		{
+			if (recursionDepth > 100)
+				return;
+
+			LocalFunction(recursionDepth);
+
+			//--------------------------------------------Local Function-----------------------------------------------
+			void LocalFunction(int recursionDepth)
+			{
+				RecursiveCallWithLocalFunction(recursionDepth + 1);
+			}
+		}
+
+		private void RecursiveCall(int recursionDepth)
+		{
+			if (recursionDepth > 100)
+				return;
+
+			RecursiveCall(recursionDepth + 1);
+		}
+	}
+}

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/NestedInvocationWalker.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/NestedInvocationWalker.cs
@@ -1,10 +1,7 @@
-﻿#nullable enable
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
-using System.Xml.Linq;
 
 using Acuminator.Utilities.Common;
 using Acuminator.Utilities.DiagnosticSuppression;

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/NestedInvocationWalker.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/NestedInvocationWalker.cs
@@ -71,6 +71,8 @@ namespace Acuminator.Utilities.Roslyn
 
         private HashSet<IMethodSymbol> MethodsInStack { get; set; } = new HashSet<IMethodSymbol>(SymbolEqualityComparer.Default);
 
+		private Stack<IMethodSymbol> LocalFunctionsStack { get; set; } = new Stack<IMethodSymbol>();
+
 		private readonly Lazy<HashSet<INamedTypeSymbol>> _typesToBypass;
 		private readonly Func<IMethodSymbol, bool>? _extraBypassCheck;
 
@@ -308,17 +310,21 @@ namespace Acuminator.Utilities.Roslyn
 				return;
 			}
 
-			// When we visit local function declaration during the normal syntax walking it is like we start visiting another method at the top of call stack
-			// No previous recursive context applies to the local function declaration itself because it is a declaration, not a call. 
-			// In fact, the method can be never called. Thus, we need to save previous recursive context, reset it, visit local function and then restore saved context
+			// Visit of a local function as a declaration during the normal syntax walking.
 			var semanticModel = GetSemanticModel(localFunctionStatement.SyntaxTree);
 			var localMethodSymbol = semanticModel?.GetDeclaredSymbol(localFunctionStatement, CancellationToken) as IMethodSymbol;
 
 			// When we are visiting the local method via the normal syntax walking, we need to check that we haven't already visited it recursively.
 			// This can happen in a scenario when a method declares a local function that calls the containing method recursively.
-			if (localMethodSymbol == null || IsMethodInStack(localMethodSymbol))
+			// 
+			// We use a separate stack for this purpose to not mix local function declarations with the logic of normal method calls.
+			// The logic analyzing normal method calls relies on the context whether the analyzer currently is inside a recursive call or not. 
+			if (localMethodSymbol == null || IsMethodInLocalFunctionsStack(localMethodSymbol))
 				return;
 
+			// When we visit local function declaration during the normal syntax walking it is like we start visiting another method at the top of call stack
+			// No previous recursive context applies to the local function declaration itself because it is a declaration, not a call. 
+			// In fact, the method can be never called. Thus, we need to save previous recursive context, reset it, visit local function and then restore saved context
 			var oldNodesStack                      = NodesStack;
 			var oldMethodsInStack                  = MethodsInStack;
 			var oldOriginalNode                    = OriginalNode;
@@ -326,22 +332,22 @@ namespace Acuminator.Utilities.Roslyn
 
 			try
 			{
-				// We need to initialize a new context and call stack for local function. The new call stack should start with the local function at the top.
-				NodesStack = new Stack<SyntaxNode>(capacity: 1);
-				NodesStack.Push(localFunctionStatement);
-
-				MethodsInStack = new HashSet<IMethodSymbol>(SymbolEqualityComparer.Default)
-				{
-					localMethodSymbol
-				};
-
-				OriginalNode                    = localFunctionStatement;
+				// We need to initialize a new empty context and method call stack to imitate a situation where we start the analysis 
+				// with the local function as a top function.
+				NodesStack	   					= new Stack<SyntaxNode>();
+				MethodsInStack 					= new HashSet<IMethodSymbol>(SymbolEqualityComparer.Default);
+				OriginalNode 					= null;
 				NodeCurrentlyVisitedRecursively = null;
+
+				// Push the local function to the local functions stack to avoid re-visiting it recursively
+				LocalFunctionsStack.Push(localMethodSymbol);
 
 				base.VisitLocalFunctionStatement(localFunctionStatement);
 			}
 			finally
 			{
+				LocalFunctionsStack.Pop();
+
 				NodesStack                      = oldNodesStack;
 				MethodsInStack                  = oldMethodsInStack;
 				OriginalNode                    = oldOriginalNode;
@@ -381,8 +387,11 @@ namespace Acuminator.Utilities.Roslyn
 			AfterRecursiveVisit(calledMethod, calledMethodNode, callSite, wasVisited);
 		}
 
-        private bool IsMethodInStack(IMethodSymbol calledMethod) =>
-			MethodsInStack.Contains(calledMethod);
+		private bool IsMethodInStack(IMethodSymbol calledMethod) => MethodsInStack.Contains(calledMethod);
+
+		private bool IsMethodInLocalFunctionsStack(IMethodSymbol localFunction) => 
+			localFunction.MethodKind == MethodKind.LocalFunction && 
+			LocalFunctionsStack.Contains(localFunction, SymbolEqualityComparer.Default);
 
 		/// <summary>
 		/// Extensibility point that allows to add some logic executed before <paramref name="calledMethod"/> is checked by the bypass check <see cref="BypassMethod(IMethodSymbol)"/>.

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/NestedInvocationWalker.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/NestedInvocationWalker.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using System.Xml.Linq;
 
 using Acuminator.Utilities.Common;
 using Acuminator.Utilities.DiagnosticSuppression;
@@ -306,10 +307,18 @@ namespace Acuminator.Utilities.Roslyn
 				base.VisitLocalFunctionStatement(localFunctionStatement);   //Process recursive call as usual
 				return;
 			}
-			
+
 			// When we visit local function declaration during the normal syntax walking it is like we start visiting another method at the top of call stack
 			// No previous recursive context applies to the local function declaration itself because it is a declaration, not a call. 
 			// In fact, the method can be never called. Thus, we need to save previous recursive context, reset it, visit local function and then restore saved context
+			var semanticModel = GetSemanticModel(localFunctionStatement.SyntaxTree);
+			var localMethodSymbol = semanticModel?.GetDeclaredSymbol(localFunctionStatement, CancellationToken) as IMethodSymbol;
+
+			// When we are visiting the local method via the normal syntax walking, we need to check that we haven't already visited it recursively.
+			// This can happen in a scenario when a method declares a local function that calls the containing method recursively.
+			if (localMethodSymbol == null || IsMethodInStack(localMethodSymbol))
+				return;
+
 			var oldNodesStack                      = NodesStack;
 			var oldMethodsInStack                  = MethodsInStack;
 			var oldOriginalNode                    = OriginalNode;
@@ -317,9 +326,16 @@ namespace Acuminator.Utilities.Roslyn
 
 			try
 			{
-				NodesStack                      = new Stack<SyntaxNode>();
-				MethodsInStack                  = new HashSet<IMethodSymbol>(SymbolEqualityComparer.Default);
-				OriginalNode                    = null;
+				// We need to initialize a new context and call stack for local function. The new call stack should start with the local function at the top.
+				NodesStack = new Stack<SyntaxNode>(capacity: 1);
+				NodesStack.Push(localFunctionStatement);
+
+				MethodsInStack = new HashSet<IMethodSymbol>(SymbolEqualityComparer.Default)
+				{
+					localMethodSymbol
+				};
+
+				OriginalNode                    = localFunctionStatement;
 				NodeCurrentlyVisitedRecursively = null;
 
 				base.VisitLocalFunctionStatement(localFunctionStatement);

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/NestedInvocationWalker.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/NestedInvocationWalker.cs
@@ -295,7 +295,7 @@ namespace Acuminator.Utilities.Roslyn
 		public override void VisitLocalFunctionStatement(LocalFunctionStatementSyntax localFunctionStatement)
 		{
 			// There are two ways to get into local function statement with the nested invocation walker:
-			// 1. Visit it during the recursive visit of a local function call. In such case it can be processesd as usual
+			// 1. Visit it during the recursive visit of a local function call. In such case it can be processed as usual
 			// 2. Visit the declaration during the normal syntax walking.
 
 			// We are visiting local function declaration currently from a recursive call only if the currently visited node equals to the localFunctionStatement
@@ -409,7 +409,7 @@ namespace Acuminator.Utilities.Roslyn
 		/// The default implementation will check <paramref name="calledMethod"/>.ContainingType and bypass all types obtained from the extendable <see cref="GetTypesToBypass"/> method.<br/>
 		/// If the method containing type is one of bypassed types then the code will immediately return <see langword="true"/> and <paramref name="calledMethod"/> will be bypassed. If custom
 		/// extraBypassCheck delegate was specified in the <see cref=" NestedInvocationWalker"/> constructor then it will be called after the check for bypassed types.<br/>
-		/// The method be overriden for custom skip logic.
+		/// The method be overridden for custom skip logic.
 		/// </remarks>
 		/// <param name="calledMethod">The called method symbol to check.</param>
 		/// <param name="calledMethodNode">The called method node.</param>


### PR DESCRIPTION
**Changes Overview**
- fixed stack overflow exception in the inter-procedural analysis caused by the recursive visits of a local function that calls their containing method. Added a dedicated stack `LocalFunctionsStack` to track visited local functions separately from regular method calls.
- slightly optimized the PX1008 diagnostic
- added unit test for the scenario with the bug