### PR TITLE
Bugfix/atr 937 dev add support of pxvirtual attribute and note

### DIFF
--- a/docs/diagnostics/PX1036.md
+++ b/docs/diagnostics/PX1036.md
@@ -21,7 +21,13 @@ public class PK_Dirty : PrimaryKeyOf<INUnit>.By<recordID>.Dirty
 For a foreign key, the name can be arbitrary but the key should be declared in a public static class called `FK`. For a single unique key, the name should be `UK`. 
 If a DAC has multiple unique keys, they can have arbitrary names but they must be declared in a public static class called `UK`.
 The warning is shown only for DACs that have an attribute derived from the `PXCacheName` attribute, or an attribute derived from the `PXPrimaryGraphBase` attribute such as `PXPrimaryGraphAttribute`.
-The diagnostic does not check abstract DACs or DACs that have only unbound DAC properties (fully unbound DACs used for custom pop-ups and filters for inquiry forms).
+
+The diagnostic does not check abstract DACs or *fully unbound* DACs (also called *virtual* DACs) used for custom pop-ups and filters for inquiry forms. Such DACs do not require primary, foreign, or unique key declarations.
+Acuminator does not access the database. Thus it determines whether a DAC is fully unbound based on the following rules:
+- DAC without any DAC fields or with only unbound DAC fields is considered fully unbound.
+- DAC marked with `PX.Data.PXVirtualAttribute` is always considered fully unbound even if it has DB bound fields,
+- DAC marked with `PX.Data.PXProjectionAttribute` or `PX.Data.PXAccumulatorAttribute` is always considered DB bound even if it has only unbound fields.
+- DAC with a DB bound `NoteID` field is considered fully unbound if `NoteID` is the only DB bound field in the DAC.
 
 The diagnostic also checks the declaration and implementation of a unique key by using the following rules:
  - A single unique key in a DAC declaration must have the name `UK`.
@@ -40,8 +46,8 @@ The code fix suggests that you do the following:
  
 For foreign keys, the diagnostic searches for a public static class named `FK`. There could be three possible outcomes:
  - The `FK` class is not found. Then the diagnostic suggests to generate it and move all DAC foreign keys there.
- - The `FK` class is found and it is public and static. The diagnositc suggests to move all DAC foreign key declarations which are not already inside the `FK` class into the found class.
- - The `FK` class is found but it is not declared correctly (not public or static). In this case, the diagnositc does not suggest a code fix.
+ - The `FK` class is found and it is public and static. The diagnostic suggests to move all DAC foreign key declarations which are not already inside the `FK` class into the found class.
+ - The `FK` class is found but it is not declared correctly (not public or static). In this case, the diagnostic does not suggest a code fix.
 
 ## Example of Incorrectly Named Primary Key
 

--- a/docs/diagnostics/PX1036.md
+++ b/docs/diagnostics/PX1036.md
@@ -27,7 +27,7 @@ Acuminator does not access the database. Thus it determines whether a DAC is ful
 - DAC without any DAC fields or with only unbound DAC fields is considered fully unbound.
 - DAC marked with `PX.Data.PXVirtualAttribute` is always considered fully unbound even if it has DB bound fields,
 - DAC marked with `PX.Data.PXProjectionAttribute` or `PX.Data.PXAccumulatorAttribute` is always considered DB bound even if it has only unbound fields.
-- DAC with a DB bound `NoteID` field is considered fully unbound if `NoteID` is the only DB bound field in the DAC.
+- DAC with a DB bound `NoteID` field is considered fully unbound if `NoteID` is the only DB bound field in the DAC and there is more than one field in DAC.
 
 The diagnostic also checks the declaration and implementation of a unique key by using the following rules:
  - A single unique key in a DAC declaration must have the name `UK`.

--- a/docs/diagnostics/PX1036.md
+++ b/docs/diagnostics/PX1036.md
@@ -22,12 +22,12 @@ For a foreign key, the name can be arbitrary but the key should be declared in a
 If a DAC has multiple unique keys, they can have arbitrary names but they must be declared in a public static class called `UK`.
 The warning is shown only for DACs that have an attribute derived from the `PXCacheName` attribute, or an attribute derived from the `PXPrimaryGraphBase` attribute such as `PXPrimaryGraphAttribute`.
 
-The diagnostic does not check abstract DACs or *fully unbound* DACs (also called *virtual* DACs) used for custom pop-ups and filters for inquiry forms. Such DACs do not require primary, foreign, or unique key declarations.
+The diagnostic does not check abstract DACs or *fully unbound* DACs (also called *virtual* DACs) which are used for custom pop-ups and filters on the inquiry forms. Such DACs do not require primary, foreign, or unique key declarations.
 Since Acuminator does not access the database, it determines whether a DAC is fully unbound based on the following rules:
-- DAC without any DAC fields or with only unbound DAC fields is considered fully unbound.
-- DAC marked with `PX.Data.PXVirtualAttribute` is always considered fully unbound even if it has DB bound fields,
-- DAC marked with `PX.Data.PXProjectionAttribute` or `PX.Data.PXAccumulatorAttribute` is always considered DB bound even if it has only unbound fields.
-- DAC with a DB bound `NoteID` field is considered fully unbound if `NoteID` is the only DB bound field in the DAC and there is more than one field in DAC.
+- A DAC without any DAC fields or with only unbound DAC fields is considered fully unbound.
+- A DAC marked with `PX.Data.PXVirtualAttribute` is always considered fully unbound even if it has DB bound fields.
+- A DAC marked with `PX.Data.PXProjectionAttribute` or `PX.Data.PXAccumulatorAttribute` is always considered DB bound even if it has only unbound fields.
+- A DAC with a DB bound `NoteID` field is considered fully unbound if `NoteID` is the only DB bound field in the DAC and all other fields in the DAC are unbound.
 
 The diagnostic also checks the declaration and implementation of a unique key by using the following rules:
  - A single unique key in a DAC declaration must have the name `UK`.

--- a/docs/diagnostics/PX1036.md
+++ b/docs/diagnostics/PX1036.md
@@ -23,7 +23,7 @@ If a DAC has multiple unique keys, they can have arbitrary names but they must b
 The warning is shown only for DACs that have an attribute derived from the `PXCacheName` attribute, or an attribute derived from the `PXPrimaryGraphBase` attribute such as `PXPrimaryGraphAttribute`.
 
 The diagnostic does not check abstract DACs or *fully unbound* DACs (also called *virtual* DACs) used for custom pop-ups and filters for inquiry forms. Such DACs do not require primary, foreign, or unique key declarations.
-Acuminator does not access the database. Thus it determines whether a DAC is fully unbound based on the following rules:
+Since Acuminator does not access the database, it determines whether a DAC is fully unbound based on the following rules:
 - DAC without any DAC fields or with only unbound DAC fields is considered fully unbound.
 - DAC marked with `PX.Data.PXVirtualAttribute` is always considered fully unbound even if it has DB bound fields,
 - DAC marked with `PX.Data.PXProjectionAttribute` or `PX.Data.PXAccumulatorAttribute` is always considered DB bound even if it has only unbound fields.

--- a/docs/diagnostics/PX1036.md
+++ b/docs/diagnostics/PX1036.md
@@ -25,8 +25,8 @@ The warning is shown only for DACs that have an attribute derived from the `PXCa
 The diagnostic does not check abstract DACs or *fully unbound* DACs (also called *virtual* DACs) which are used for custom pop-ups and filters on the inquiry forms. Such DACs do not require primary, foreign, or unique key declarations.
 Since Acuminator does not access the database, it determines whether a DAC is fully unbound based on the following rules:
 - A DAC without any DAC fields or with only unbound DAC fields is considered fully unbound.
-- A DAC marked with `PX.Data.PXVirtualAttribute` is always considered fully unbound even if it has DB bound fields.
-- A DAC marked with `PX.Data.PXProjectionAttribute` or `PX.Data.PXAccumulatorAttribute` is always considered DB bound even if it has only unbound fields.
+- A DAC marked with `PX.Data.PXVirtualAttribute` is always considered fully unbound even if it has DB bound fields,
+- A DAC marked with `PX.Data.PXProjectionAttribute`, `PX.Data.PXAccumulatorAttribute` or any other attribute derived from `PX.Data.PXDBInterceptorAttribute` is always considered DB bound even if it has only unbound fields.
 - A DAC with a DB bound `NoteID` field is considered fully unbound if `NoteID` is the only DB bound field in the DAC and all other fields in the DAC are unbound.
 
 The diagnostic also checks the declaration and implementation of a unique key by using the following rules:

--- a/docs/diagnostics/PX1069.md
+++ b/docs/diagnostics/PX1069.md
@@ -39,10 +39,10 @@ There are some exceptions to the PX069 diagnostic when the mandatory fields are 
 ### How Fully Unbound DACs are Determined
 
 Since Acuminator does not access the database, it determines whether a DAC is fully unbound based on the following rules:
-- DAC without any DAC fields or with only unbound DAC fields is considered fully unbound.
-- DAC marked with `PX.Data.PXVirtualAttribute` is always considered fully unbound even if it has DB bound fields,
-- DAC marked with `PX.Data.PXProjectionAttribute` or `PX.Data.PXAccumulatorAttribute` is always considered DB bound even if it has only unbound fields.
-- DAC with a DB bound `NoteID` field is considered fully unbound if `NoteID` is the only DB bound field in the DAC and there is more than one field in DAC.
+- A DAC without any DAC fields or with only unbound DAC fields is considered fully unbound.
+- A DAC marked with `PX.Data.PXVirtualAttribute` is always considered fully unbound even if it has DB bound fields.
+- A DAC marked with `PX.Data.PXProjectionAttribute` or `PX.Data.PXAccumulatorAttribute` is always considered DB bound even if it has only unbound fields.
+- A DAC with a DB bound `NoteID` field is considered fully unbound if `NoteID` is the only DB bound field in the DAC and all other fields in the DAC are unbound.
 
 ## Code Fix Behavior
 

--- a/docs/diagnostics/PX1069.md
+++ b/docs/diagnostics/PX1069.md
@@ -29,12 +29,20 @@ There are some exceptions to the PX069 diagnostic when the mandatory fields are 
 - The DAC has the `PXAccumulator` attribute or an attribute derived from the `PXAccumulator` attribute. Such DACs are used for special scenarios that involve accumulation of data. 
   These scenarios are handled differently by the Acumatica Framework. Thus, DACs with the `PXAccumulator` attribute do not require audit or timestamp fields.
 - The DAC has the `PXProjection` attribute or an attribute derived from the `PXProjection` attribute. These DACs (also called _projection DACs_) usually represent readonly database views or complex queries 
-  rather than direct table mappings. Such readonly projection DACs do not require audit or timestamp fields.
+  rather than direct table mappings. Such read-only projection DACs do not require audit or timestamp fields.
 
   However, Acumatica also supports writable projection DACs (also called [_persistent projection DACs_](https://help.acumatica.com/Help?ScreenId=ShowWiki&pageid=e8f097ea-69a0-496d-84d1-807f21b072b4)). 
-  **Such DACs also must declare audit and timestamp fields!** Currently, the PX1069 diagnostic does not report the absense of these fields in projection DACs.
-- The DAC is fully unbound from the database, meaning there are no tables in the database that correspond to it. Such DACs are also known as **virtual DACs**. They do not require audit or timestamp fields because they do not interact with the database directly and do not persist any audit data.
-- The DAC does not declare any DAC fields. Empty DACs are considered to be the same as virtual DACs in this context.
+  **Such DACs also must declare audit and timestamp fields!** Currently, the PX1069 diagnostic does not report the absence of these fields in projection DACs.
+- The DAC is *fully unbound* from the database, meaning there are no tables in the database that correspond to it. Such DACs are also known as **virtual DACs**. They do not require audit or timestamp fields 
+  because they do not interact with the database directly and do not persist any audit data.
+
+### How Fully Unbound DACs are Determined
+
+Acuminator does not access the database. Thus it determines whether a DAC is fully unbound based on the following rules:
+- DAC without any DAC fields or with only unbound DAC fields is considered fully unbound.
+- DAC marked with `PX.Data.PXVirtualAttribute` is always considered fully unbound even if it has DB bound fields,
+- DAC marked with `PX.Data.PXProjectionAttribute` or `PX.Data.PXAccumulatorAttribute` is always considered DB bound even if it has only unbound fields.
+- DAC with a DB bound `NoteID` field is considered fully unbound if `NoteID` is the only DB bound field in the DAC.
 
 ## Code Fix Behavior
 

--- a/docs/diagnostics/PX1069.md
+++ b/docs/diagnostics/PX1069.md
@@ -38,7 +38,7 @@ There are some exceptions to the PX069 diagnostic when the mandatory fields are 
 
 ### How Fully Unbound DACs are Determined
 
-Acuminator does not access the database. Thus it determines whether a DAC is fully unbound based on the following rules:
+Since Acuminator does not access the database, it determines whether a DAC is fully unbound based on the following rules:
 - DAC without any DAC fields or with only unbound DAC fields is considered fully unbound.
 - DAC marked with `PX.Data.PXVirtualAttribute` is always considered fully unbound even if it has DB bound fields,
 - DAC marked with `PX.Data.PXProjectionAttribute` or `PX.Data.PXAccumulatorAttribute` is always considered DB bound even if it has only unbound fields.

--- a/docs/diagnostics/PX1069.md
+++ b/docs/diagnostics/PX1069.md
@@ -41,7 +41,7 @@ There are some exceptions to the PX069 diagnostic when the mandatory fields are 
 Since Acuminator does not access the database, it determines whether a DAC is fully unbound based on the following rules:
 - A DAC without any DAC fields or with only unbound DAC fields is considered fully unbound.
 - A DAC marked with `PX.Data.PXVirtualAttribute` is always considered fully unbound even if it has DB bound fields.
-- A DAC marked with `PX.Data.PXProjectionAttribute` or `PX.Data.PXAccumulatorAttribute` is always considered DB bound even if it has only unbound fields.
+- A DAC marked with `PX.Data.PXProjectionAttribute`, `PX.Data.PXAccumulatorAttribute` or any other attribute derived from `PX.Data.PXDBInterceptorAttribute` is always considered DB bound even if it has only unbound fields.
 - A DAC with a DB bound `NoteID` field is considered fully unbound if `NoteID` is the only DB bound field in the DAC and all other fields in the DAC are unbound.
 
 ## Code Fix Behavior

--- a/docs/diagnostics/PX1069.md
+++ b/docs/diagnostics/PX1069.md
@@ -42,7 +42,7 @@ Acuminator does not access the database. Thus it determines whether a DAC is ful
 - DAC without any DAC fields or with only unbound DAC fields is considered fully unbound.
 - DAC marked with `PX.Data.PXVirtualAttribute` is always considered fully unbound even if it has DB bound fields,
 - DAC marked with `PX.Data.PXProjectionAttribute` or `PX.Data.PXAccumulatorAttribute` is always considered DB bound even if it has only unbound fields.
-- DAC with a DB bound `NoteID` field is considered fully unbound if `NoteID` is the only DB bound field in the DAC.
+- DAC with a DB bound `NoteID` field is considered fully unbound if `NoteID` is the only DB bound field in the DAC and there is more than one field in DAC.
 
 ## Code Fix Behavior
 

--- a/docs/diagnostics/PX1110.md
+++ b/docs/diagnostics/PX1110.md
@@ -24,12 +24,11 @@ The PX1110 diagnostic detects DACs that:
 There are some exceptions to the PX1110 diagnostic when a DAC does not require to support localization. The diagnostic will not be triggered in the following cases:
 
 - The DAC has the `PXAccumulator` attribute or an attribute derived from the `PXAccumulator` attribute. Such DACs are used for special accumulation scenarios and do not support localization.
-- The DAC is *fully unbound* from the database (a *virtual* DAC). Such DACs do not interact with the database directly and do not require localization support. Since Acuminator does not access the database, 
-  it determines whether a DAC is fully unbound based on the following rules:
-	- DAC without any DAC fields or with only unbound DAC fields is considered fully unbound.
-	- DAC marked with `PX.Data.PXVirtualAttribute` is always considered fully unbound even if it has DB bound fields,
-	- DAC marked with `PX.Data.PXProjectionAttribute` or `PX.Data.PXAccumulatorAttribute` is always considered DB bound even if it has only unbound fields.
-	- DAC with a DB bound `NoteID` field is considered fully unbound if `NoteID` is the only DB bound field in the DAC and there is more than one field in DAC.
+- The DAC is *fully unbound* from the database (a *virtual* DAC). Such DACs do not interact with the database directly and do not require localization support. Since Acuminator does not access the database, it determines whether a DAC is fully unbound based on the following rules:
+- A DAC without any DAC fields or with only unbound DAC fields is considered fully unbound.
+- A DAC marked with `PX.Data.PXVirtualAttribute` is always considered fully unbound even if it has DB bound fields.
+- A DAC marked with `PX.Data.PXProjectionAttribute` or `PX.Data.PXAccumulatorAttribute` is always considered DB bound even if it has only unbound fields.
+- A DAC with a DB bound `NoteID` field is considered fully unbound if `NoteID` is the only DB bound field in the DAC and all other fields in the DAC are unbound.
 
 ## Code Fix Behavior
 

--- a/docs/diagnostics/PX1110.md
+++ b/docs/diagnostics/PX1110.md
@@ -24,8 +24,8 @@ The PX1110 diagnostic detects DACs that:
 There are some exceptions to the PX1110 diagnostic when a DAC does not require to support localization. The diagnostic will not be triggered in the following cases:
 
 - The DAC has the `PXAccumulator` attribute or an attribute derived from the `PXAccumulator` attribute. Such DACs are used for special accumulation scenarios and do not support localization.
-- The DAC is *fully unbound* from the database (a *virtual* DAC). Such DACs do not interact with the database directly and do not require localization support. Acuminator does not access the database.
-  Thus it determines whether a DAC is fully unbound based on the following rules:
+- The DAC is *fully unbound* from the database (a *virtual* DAC). Such DACs do not interact with the database directly and do not require localization support. Since Acuminator does not access the database, 
+  it determines whether a DAC is fully unbound based on the following rules:
 	- DAC without any DAC fields or with only unbound DAC fields is considered fully unbound.
 	- DAC marked with `PX.Data.PXVirtualAttribute` is always considered fully unbound even if it has DB bound fields,
 	- DAC marked with `PX.Data.PXProjectionAttribute` or `PX.Data.PXAccumulatorAttribute` is always considered DB bound even if it has only unbound fields.

--- a/docs/diagnostics/PX1110.md
+++ b/docs/diagnostics/PX1110.md
@@ -24,8 +24,12 @@ The PX1110 diagnostic detects DACs that:
 There are some exceptions to the PX1110 diagnostic when a DAC does not require to support localization. The diagnostic will not be triggered in the following cases:
 
 - The DAC has the `PXAccumulator` attribute or an attribute derived from the `PXAccumulator` attribute. Such DACs are used for special accumulation scenarios and do not support localization.
-- The DAC is fully unbound from the database (a *virtual* DAC). Such DACs do not interact with the database directly and do not require localization support.
-- The DAC does not declare any DAC fields. Empty DACs are considered to be virtual in this context.
+- The DAC is *fully unbound* from the database (a *virtual* DAC). Such DACs do not interact with the database directly and do not require localization support. Acuminator does not access the database.
+  Thus it determines whether a DAC is fully unbound based on the following rules:
+	- DAC without any DAC fields or with only unbound DAC fields is considered fully unbound.
+	- DAC marked with `PX.Data.PXVirtualAttribute` is always considered fully unbound even if it has DB bound fields,
+	- DAC marked with `PX.Data.PXProjectionAttribute` or `PX.Data.PXAccumulatorAttribute` is always considered DB bound even if it has only unbound fields.
+	- DAC with a DB bound `NoteID` field is considered fully unbound if `NoteID` is the only DB bound field in the DAC.
 
 ## Code Fix Behavior
 

--- a/docs/diagnostics/PX1110.md
+++ b/docs/diagnostics/PX1110.md
@@ -29,7 +29,7 @@ There are some exceptions to the PX1110 diagnostic when a DAC does not require t
 	- DAC without any DAC fields or with only unbound DAC fields is considered fully unbound.
 	- DAC marked with `PX.Data.PXVirtualAttribute` is always considered fully unbound even if it has DB bound fields,
 	- DAC marked with `PX.Data.PXProjectionAttribute` or `PX.Data.PXAccumulatorAttribute` is always considered DB bound even if it has only unbound fields.
-	- DAC with a DB bound `NoteID` field is considered fully unbound if `NoteID` is the only DB bound field in the DAC.
+	- DAC with a DB bound `NoteID` field is considered fully unbound if `NoteID` is the only DB bound field in the DAC and there is more than one field in DAC.
 
 ## Code Fix Behavior
 

--- a/docs/diagnostics/PX1110.md
+++ b/docs/diagnostics/PX1110.md
@@ -27,7 +27,7 @@ There are some exceptions to the PX1110 diagnostic when a DAC does not require t
 - The DAC is *fully unbound* from the database (a *virtual* DAC). Such DACs do not interact with the database directly and do not require localization support. Since Acuminator does not access the database, it determines whether a DAC is fully unbound based on the following rules:
 - A DAC without any DAC fields or with only unbound DAC fields is considered fully unbound.
 - A DAC marked with `PX.Data.PXVirtualAttribute` is always considered fully unbound even if it has DB bound fields.
-- A DAC marked with `PX.Data.PXProjectionAttribute` or `PX.Data.PXAccumulatorAttribute` is always considered DB bound even if it has only unbound fields.
+- A DAC marked with `PX.Data.PXProjectionAttribute`, `PX.Data.PXAccumulatorAttribute` or any other attribute derived from `PX.Data.PXDBInterceptorAttribute` is always considered DB bound even if it has only unbound fields.
 - A DAC with a DB bound `NoteID` field is considered fully unbound if `NoteID` is the only DB bound field in the DAC and all other fields in the DAC are unbound.
 
 ## Code Fix Behavior

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/MissingMandatoryDacFields/MissingMandatoryDacFieldsTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/MissingMandatoryDacFields/MissingMandatoryDacFieldsTests.cs
@@ -51,7 +51,17 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.MissingMandatoryDacFields
 
 		[Theory]
 		[EmbeddedFileData("UnboundDac.cs")]
-		public async Task UnboundDac_NoDiagnostic(string source) =>
+		public async Task UnboundDac_Regular_NoDiagnostic(string source) =>
+			await VerifyCSharpDiagnosticAsync(source);
+
+		[Theory]
+		[EmbeddedFileData("UnboundDac_WithNoteID.cs")]
+		public async Task UnboundDac_WithNoteID_NoDiagnostic(string source) =>
+			await VerifyCSharpDiagnosticAsync(source);
+
+		[Theory]
+		[EmbeddedFileData("UnboundDac_WithPXVirtualAttribute.cs")]
+		public async Task UnboundDac_WithPXVirtualAttribute_NoDiagnostic(string source) =>
 			await VerifyCSharpDiagnosticAsync(source);
 
 		[Theory]

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/MissingMandatoryDacFields/Sources/UnboundDac_WithNoteID.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/MissingMandatoryDacFields/Sources/UnboundDac_WithNoteID.cs
@@ -1,0 +1,31 @@
+#nullable enable
+using System;
+
+using PX.Data;
+
+namespace Acuminator.Tests.Sources
+{
+	/// <exclude/>
+	[PXCacheName("Unbound DAC - should not be checked")]
+	public class UnboundDac : PXBqlTable, IBqlTable
+	{
+		#region DacId
+		[PXInt(IsKey = true)]
+		public virtual int? DacId { get; set; }
+		public abstract class dacId : PX.Data.BQL.BqlInt.Field<dacId> { }
+		#endregion
+
+		#region Description
+		[PXString(255)]
+		public virtual string? Description { get; set; }
+		public abstract class description : PX.Data.BQL.BqlString.Field<description> { }
+		#endregion
+
+		#region NoteID
+		public abstract class noteID : PX.Data.BQL.BqlGuid.Field<noteID> { }
+
+		[PXNote]
+		public virtual Guid? NoteID { get; set; }
+		#endregion
+	}
+}

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/MissingMandatoryDacFields/Sources/UnboundDac_WithPXVirtualAttribute.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/MissingMandatoryDacFields/Sources/UnboundDac_WithPXVirtualAttribute.cs
@@ -1,0 +1,23 @@
+#nullable enable
+using PX.Data;
+
+namespace Acuminator.Tests.Sources
+{
+	/// <exclude/>
+	[PXVirtual]
+	[PXCacheName("Unbound DAC - should not be checked")]
+	public class UnboundDac : PXBqlTable, IBqlTable
+	{
+		#region DacId
+		[PXDBInt(IsKey = true)]
+		public virtual int? DacId { get; set; }
+		public abstract class dacId : PX.Data.BQL.BqlInt.Field<dacId> { }
+		#endregion
+
+		#region Description
+		[PXDBString(255)]
+		public virtual string? Description { get; set; }
+		public abstract class description : PX.Data.BQL.BqlString.Field<description> { }
+		#endregion
+	}
+}

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Constants/TypeFullNames.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Constants/TypeFullNames.cs
@@ -186,6 +186,7 @@
 		public const string PXAccumulatorAttribute 		 = "PX.Data.PXAccumulatorAttribute";
 		public const string PXNoteAttribute 			 = "PX.Data.PXNoteAttribute";
 		public const string PXVirtualAttribute			 = "PX.Data.PXVirtualAttribute";
+		public const string PXDBInterceptorAttribute	 = "PX.Data.PXDBInterceptorAttribute";
 
 		public const string PXView = "PX.Data.PXView";
 

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Constants/TypeFullNames.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Constants/TypeFullNames.cs
@@ -185,6 +185,7 @@
 		public const string PXDBDefaultAttribute 		 = "PX.Data.PXDBDefaultAttribute";
 		public const string PXAccumulatorAttribute 		 = "PX.Data.PXAccumulatorAttribute";
 		public const string PXNoteAttribute 			 = "PX.Data.PXNoteAttribute";
+		public const string PXVirtualAttribute			 = "PX.Data.PXVirtualAttribute";
 
 		public const string PXView = "PX.Data.PXView";
 

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/Attribute/Infos/DacAttributeInfo.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/Attribute/Infos/DacAttributeInfo.cs
@@ -1,11 +1,9 @@
-﻿#nullable enable
-
-using System.ComponentModel;
+﻿using System;
 using System.Linq;
 
 using Microsoft.CodeAnalysis;
 
-using static Acuminator.Utilities.Roslyn.Constants.PropertyNames;
+using AttributeFlags = (bool IsDbInterceptorAttribute, bool IsProjection, bool IsPXCacheName, bool IsPXHidden, bool IsPXAccumulator);
 
 namespace Acuminator.Utilities.Roslyn.Semantic.Attribute
 {
@@ -41,31 +39,44 @@ namespace Acuminator.Utilities.Roslyn.Semantic.Attribute
 		/// </summary>
 		public bool IsPXAccumulatorAttribute { get; }
 
+		/// <summary>
+		/// An indicator of whether the attribute is a PXDBInterceptorAttribute attribute.
+		/// </summary>
+		public bool IsDbInterceptorAttribute { get; }
+
 		public DacAttributeInfo(PXContext pxContext, AttributeData attributeData, int declarationOrder) : base(attributeData, declarationOrder)
 		{
 			if (AttributeType != null)
 			{
 				IsDefaultNavigation = AttributeType.IsDefaultNavigation(pxContext);
-				(IsPXProjection, IsPXCacheName, IsPXHidden, IsPXAccumulatorAttribute) = GetAttributeFlags(AttributeType, pxContext);
+				(IsDbInterceptorAttribute, IsPXProjection, IsPXCacheName, IsPXHidden, IsPXAccumulatorAttribute) = 
+					GetAttributeFlags(AttributeType, pxContext);
 			}
 		}
 
-		private static (bool IsProjection, bool IsPXCacheName, bool IsPXHidden, bool IsPXAccumulator) GetAttributeFlags(INamedTypeSymbol attributeType, 
-																														PXContext pxContext)
+		private static AttributeFlags GetAttributeFlags(INamedTypeSymbol attributeType, PXContext pxContext)
 		{
-			var projectionAttribute    = pxContext.AttributeTypes.PXProjectionAttribute;
+			var dbInterceptorAttribute = pxContext.AttributeTypes.PXDBInterceptorAttribute;
+			var projectionAttribute	   = pxContext.AttributeTypes.PXProjectionAttribute;
 			var pxCacheNameAttribute   = pxContext.AttributeTypes.PXCacheNameAttribute;
 			var pxHiddenAttribute 	   = pxContext.AttributeTypes.PXHiddenAttribute;
 			var pxAccumulatorAttribute = pxContext.AttributeTypes.PXAccumulatorAttribute;
 
-			bool isPXProjection  = attributeType.Equals(projectionAttribute, SymbolEqualityComparer.Default);
-			bool isPXCacheName 	 = attributeType.Equals(pxCacheNameAttribute, SymbolEqualityComparer.Default);
-			bool isPXHidden 	 = attributeType.Equals(pxHiddenAttribute, SymbolEqualityComparer.Default);
-			bool isPXAccumulator = attributeType.Equals(pxAccumulatorAttribute, SymbolEqualityComparer.Default);
+			// This is a hot path optimization to not get base attributes if possible by manually performing the first iteration
+			// PXProjection and PXAccumulator are already DB interceptors, and PXDBInterceptorAttribute is an abstract attribute.
+			// So, most likely, it won't be declared directly.
+			bool isPXProjection  		  = attributeType.Equals(projectionAttribute, SymbolEqualityComparer.Default);
+			bool isPXAccumulator 		  = !isPXProjection && attributeType.Equals(pxAccumulatorAttribute, SymbolEqualityComparer.Default);
+			bool isDbInterceptorAttribute = isPXProjection || isPXAccumulator || 
+											attributeType.Equals(dbInterceptorAttribute, SymbolEqualityComparer.Default);
 
-			if (isPXProjection || isPXCacheName || isPXHidden || isPXAccumulator)
-				return (isPXProjection, isPXCacheName, isPXHidden, isPXAccumulator);
+			bool isPXCacheName = !isDbInterceptorAttribute && attributeType.Equals(pxCacheNameAttribute, SymbolEqualityComparer.Default);
+			bool isPXHidden	   = !isDbInterceptorAttribute && attributeType.Equals(pxHiddenAttribute, SymbolEqualityComparer.Default);
 
+			if (isDbInterceptorAttribute || isPXCacheName || isPXHidden)
+				return (isDbInterceptorAttribute, isPXProjection, isPXCacheName, isPXHidden, isPXAccumulator);
+
+			// Get base attributes and check them
 			var attributeBaseTypes = attributeType.GetBaseTypes();
 
 			foreach (var baseType in attributeBaseTypes)
@@ -74,15 +85,26 @@ namespace Acuminator.Utilities.Roslyn.Semantic.Attribute
 					break;
 
 				isPXProjection 	= isPXProjection  || baseType.Equals(projectionAttribute, SymbolEqualityComparer.Default);
-				isPXCacheName  	= isPXCacheName   || baseType.Equals(pxCacheNameAttribute, SymbolEqualityComparer.Default);
-				isPXHidden	   	= isPXHidden 	  || baseType.Equals(pxHiddenAttribute, SymbolEqualityComparer.Default);
-				isPXAccumulator = isPXAccumulator || baseType.Equals(pxAccumulatorAttribute, SymbolEqualityComparer.Default);
+				isPXAccumulator = isPXAccumulator || (!isPXProjection && baseType.Equals(pxAccumulatorAttribute, SymbolEqualityComparer.Default));
+				isDbInterceptorAttribute = isDbInterceptorAttribute || isPXProjection || isPXAccumulator || 
+										   baseType.Equals(dbInterceptorAttribute, SymbolEqualityComparer.Default);
+				
+				if (isDbInterceptorAttribute)
+				{
+					isPXCacheName = false;
+					isPXHidden	  = false;
+				}
+				else
+				{
+					isPXCacheName = isPXCacheName || baseType.Equals(pxCacheNameAttribute, SymbolEqualityComparer.Default);
+					isPXHidden	  = isPXHidden || baseType.Equals(pxHiddenAttribute, SymbolEqualityComparer.Default);
+				}
 
-				if (isPXProjection || isPXCacheName || isPXHidden || isPXAccumulator)
-					return (isPXProjection, isPXCacheName, isPXHidden, isPXAccumulator);
+				if (isDbInterceptorAttribute || isPXCacheName || isPXHidden)
+					return (isDbInterceptorAttribute, isPXProjection, isPXCacheName, isPXHidden, isPXAccumulator);
 			}
 
-			return (isPXProjection, isPXCacheName, isPXHidden, isPXAccumulator);
+			return (isDbInterceptorAttribute, isPXProjection, isPXCacheName, isPXHidden, isPXAccumulator);
 		}
 	}
 }

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/Dac/DacSemanticModel.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/Dac/DacSemanticModel.cs
@@ -105,6 +105,11 @@ namespace Acuminator.Utilities.Roslyn.Semantic.Dac
 		public ImmutableArray<DacAttributeInfo> Attributes { get; }
 
 		/// <summary>
+		/// The PXDBInterceptorAttribute attributes declared on a DAC or a DAC extension.
+		/// </summary>
+		public ImmutableArray<DacAttributeInfo> DBInterceptorAttributes { get; }
+
+		/// <summary>
 		/// The PXAccumulator-derived attribute if there is any declared on a DAC.
 		/// </summary>
 		public DacAttributeInfo? AccumulatorAttribute { get; }
@@ -130,11 +135,12 @@ namespace Acuminator.Utilities.Roslyn.Semantic.Dac
 			_cancellation = cancellation;
 			IsMappedCacheExtension = Symbol.InheritsFromOrEquals(PXContext.PXMappedCacheExtensionType);
 
-			Attributes		  = GetDacAttributes();
-			BqlFieldsByNames  = GetDacBqlFields();
-			PropertiesByNames = GetDacProperties(BqlFieldsByNames);
-			DacFieldsByNames  = DacFieldsCollector.CollectDacFieldsFromDacPropertiesAndBqlFields(DacOrDacExtInfo, PXContext,
-																								 BqlFieldsByNames, PropertiesByNames);
+			Attributes		  		= GetDacAttributes();
+			DBInterceptorAttributes = Attributes.Where(attr => attr.IsDbInterceptorAttribute).ToImmutableArray();
+			BqlFieldsByNames  		= GetDacBqlFields();
+			PropertiesByNames 		= GetDacProperties(BqlFieldsByNames);
+			DacFieldsByNames  		= DacFieldsCollector.CollectDacFieldsFromDacPropertiesAndBqlFields(DacOrDacExtInfo, PXContext,
+																									   BqlFieldsByNames, PropertiesByNames);
 			IsActiveMethodInfo = GetIsActiveMethodInfo();
 
 			IsProjectionDac = CheckIfDacIsProjection();
@@ -239,18 +245,18 @@ namespace Acuminator.Utilities.Roslyn.Semantic.Dac
 
 		protected bool CheckIfDacIsProjection()
 		{
-			if (DacType != DacType.Dac || Attributes.IsDefaultOrEmpty)
+			if (DacType != DacType.Dac || DBInterceptorAttributes.IsDefaultOrEmpty)
 				return false;
 
-			return Attributes.Any(attrInfo => attrInfo.IsPXProjection);
+			return DBInterceptorAttributes.Any(attrInfo => attrInfo.IsPXProjection);
 		}
 
 		protected DacAttributeInfo? GetPXAccumulatorAttribute()
 		{
-			if (DacType != DacType.Dac || Attributes.IsDefaultOrEmpty)
+			if (DacType != DacType.Dac || DBInterceptorAttributes.IsDefaultOrEmpty)
 				return null;
 
-			return Attributes.FirstOrDefault(attr => attr.IsPXAccumulatorAttribute);
+			return DBInterceptorAttributes.FirstOrDefault(attr => attr.IsPXAccumulatorAttribute);
 		}
 
 		protected bool IsFullyUnboundDac()
@@ -258,8 +264,8 @@ namespace Acuminator.Utilities.Roslyn.Semantic.Dac
 			if (DacFieldsByNames.Count == 0)
 				return true;
 
-			// Heuristic - Accumulator and Projection DACs should be DB bound.
-			if (HasAccumulatorAttribute || IsProjectionDac)
+			// Heuristic - DACs with PXDBInterceptorAttribute should be DB bound.
+			if (!DBInterceptorAttributes.IsDefaultOrEmpty)
 				return false;
 
 			if (!Attributes.IsDefaultOrEmpty)

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/Dac/DacSemanticModel.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/Dac/DacSemanticModel.cs
@@ -256,6 +256,10 @@ namespace Acuminator.Utilities.Roslyn.Semantic.Dac
 		protected bool IsFullyUnboundDac()
 		{
 			if (DacFieldsByNames.Count == 0)
+				return true;
+
+			// Heuristic - Accumulator and Projection DACs should be DB bound.
+			if (HasAccumulatorAttribute || IsProjectionDac)
 				return false;
 
 			if (!Attributes.IsDefaultOrEmpty)

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/Dac/DacSemanticModel.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/Dac/DacSemanticModel.cs
@@ -136,9 +136,9 @@ namespace Acuminator.Utilities.Roslyn.Semantic.Dac
 																								 BqlFieldsByNames, PropertiesByNames);
 			IsActiveMethodInfo = GetIsActiveMethodInfo();
 
-			IsFullyUnbound  = DacFieldPropertiesWithAcumaticaAttributes.All(p => p.EffectiveDbBoundness is DbBoundnessType.Unbound or DbBoundnessType.NotDefined);
 			IsProjectionDac = CheckIfDacIsProjection();
 			AccumulatorAttribute = GetPXAccumulatorAttribute();
+			IsFullyUnbound = IsFullyUnboundDac();
 		}
 
 		/// <summary>
@@ -250,6 +250,28 @@ namespace Acuminator.Utilities.Roslyn.Semantic.Dac
 				return null;
 
 			return Attributes.FirstOrDefault(attr => attr.IsPXAccumulatorAttribute);
+		}
+
+		protected bool IsFullyUnboundDac()
+		{
+			if (DacFieldsByNames.Count == 0)
+				return false;
+
+			if (!Attributes.IsDefaultOrEmpty)
+			{
+				var pxVirtualAttribute = PXContext.AttributeTypes.PXVirtualAttribute;
+
+				if (Attributes.Any(aInfo => pxVirtualAttribute.Equals(aInfo.AttributeType, SymbolEqualityComparer.Default)))
+					return true;
+			}
+
+			bool allFieldsAreUnbound = DacFieldPropertiesWithAcumaticaAttributes.All(p => p.EffectiveDbBoundness is DbBoundnessType.Unbound or 
+																													DbBoundnessType.NotDefined);
+			if (allFieldsAreUnbound)
+				return true;
+
+
+			return allFieldsAreUnbound;
 		}
 	}
 }

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/Dac/DacSemanticModel.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/Dac/DacSemanticModel.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading;
 
 using Acuminator.Utilities.Common;
+using Acuminator.Utilities.Roslyn.Constants;
 using Acuminator.Utilities.Roslyn.PXFieldAttributes;
 using Acuminator.Utilities.Roslyn.Semantic.Attribute;
 using Acuminator.Utilities.Roslyn.Semantic.Shared;
@@ -265,13 +266,31 @@ namespace Acuminator.Utilities.Roslyn.Semantic.Dac
 					return true;
 			}
 
-			bool allFieldsAreUnbound = DacFieldPropertiesWithAcumaticaAttributes.All(p => p.EffectiveDbBoundness is DbBoundnessType.Unbound or 
-																													DbBoundnessType.NotDefined);
-			if (allFieldsAreUnbound)
-				return true;
+			int unboundFieldsCount = 0;
+			int boundFieldsCount = 0;
 
+			foreach (DacPropertyInfo property in DacFieldPropertiesWithAcumaticaAttributes)
+			{
+				if (property.EffectiveDbBoundness is DbBoundnessType.Unbound or DbBoundnessType.NotDefined)
+					unboundFieldsCount++;
+				else
+					boundFieldsCount++;
+			}
 
-			return allFieldsAreUnbound;
+			switch (boundFieldsCount)
+			{
+				case 0:
+					return true;
+				case 1:
+					// Heuristic for NoteID - if NoteID is the only bound field and there is more than one field, then consider the DAC as fully unbound.
+					// This is required because there is no good way to configure an unbound NoteID field.
+					if (unboundFieldsCount == 0 || !PropertiesByNames.TryGetValue(DacFieldNames.System.NoteID, out var noteIdProperty))
+						return false;
+
+					return noteIdProperty.EffectiveDbBoundness == DbBoundnessType.DbBound;
+				default:
+					return false;
+			}
 		}
 	}
 }

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/Symbols/Attributes/AttributeSymbols.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/Symbols/Attributes/AttributeSymbols.cs
@@ -34,6 +34,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic.Symbols
 		public INamedTypeSymbol? PXProtectedAccessAttribute  => Compilation.GetTypeByMetadataName(TypeFullNames.PXProtectedAccessAttribute);
 		public INamedTypeSymbol PXAccumulatorAttribute		 => Compilation.GetTypeByMetadataName(TypeFullNames.PXAccumulatorAttribute)!;
 		public INamedTypeSymbol PXNoteAttribute				 => Compilation.GetTypeByMetadataName(TypeFullNames.PXNoteAttribute)!;
+		public INamedTypeSymbol PXVirtualAttribute			 => Compilation.GetTypeByMetadataName(TypeFullNames.PXVirtualAttribute)!;
 
 		private readonly Lazy<PXUIFieldAttributeSymbols> _pxUiFieldAttribute;
 		public PXUIFieldAttributeSymbols PXUIFieldAttribute => _pxUiFieldAttribute.Value;

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/Symbols/Attributes/AttributeSymbols.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/Symbols/Attributes/AttributeSymbols.cs
@@ -35,6 +35,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic.Symbols
 		public INamedTypeSymbol PXAccumulatorAttribute		 => Compilation.GetTypeByMetadataName(TypeFullNames.PXAccumulatorAttribute)!;
 		public INamedTypeSymbol PXNoteAttribute				 => Compilation.GetTypeByMetadataName(TypeFullNames.PXNoteAttribute)!;
 		public INamedTypeSymbol PXVirtualAttribute			 => Compilation.GetTypeByMetadataName(TypeFullNames.PXVirtualAttribute)!;
+		public INamedTypeSymbol PXDBInterceptorAttribute	 => Compilation.GetTypeByMetadataName(TypeFullNames.PXDBInterceptorAttribute)!;
 
 		private readonly Lazy<PXUIFieldAttributeSymbols> _pxUiFieldAttribute;
 		public PXUIFieldAttributeSymbols PXUIFieldAttribute => _pxUiFieldAttribute.Value;


### PR DESCRIPTION
### Changes Overview
- Added `IsDbInterceptor` flag to attribute info and changed the algorithm calculating the attribute flags.
- Added new DB interceptor attributes collection property to the DAC semantic model. Integrated the new property into the calculation of semantic model properties to optimize it.
- Changed the calculation of whether the DAC is fully unbound from the DB. New calculation supports several new rules in addition to the "all DAC fields are unbound" rule:
   - DAC marked with `PX.Data.PXVirtualAttribute` is always considered fully unbound even if it has DB bound fields,
   - DAC marked with `PX.Data.PXProjectionAttribute`,`PX.Data.PXAccumulatorAttribute`, or any other attribute derived from `PX.Data.PXDBInterceptorAttributes` is always considered DB bound even if it has only unbound fields.
   - DAC with a DB bound `NoteID` field is considered fully unbound if `NoteID` is the only DB bound field in the DAC and there is more than one field in DAC. 
- Added unit tests for the new rules
- Updated docs for the PX1036, PX1069, and PX1110 diagnostics that used "fully unbound DAC" term