### PR TITLE
Bugfix/atr 933 dev px1096 false alert for pxoverride methods from pxgraph

### DIFF
--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXOverride/PXOverrideMismatchTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXOverride/PXOverrideMismatchTests.cs
@@ -153,6 +153,10 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.PXOverride
 		public Task BaseTypeImplementsPxGraphExtension(string source) => VerifyCSharpDiagnosticAsync(source);
 
 		[Theory]
+		[EmbeddedFileData(@"SignatureMismatch\PXOverrideOfMethodFromBasePXGraph.cs")]
+		public Task PXOverride_OfMethod_FromBasePXGraph(string source) => VerifyCSharpDiagnosticAsync(source);
+
+		[Theory]
 		[EmbeddedFileData(@"SignatureMismatch\BaseTypeImplementsPxGraphExtensionSignatureIsWrong.cs")]
 		public Task BaseTypeImplementsPxGraphExtensionSignatureIsWrong(string source)
 		{

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXOverride/Sources/SignatureMismatch/PXOverrideOfMethodFromBasePXGraph.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXOverride/Sources/SignatureMismatch/PXOverrideOfMethodFromBasePXGraph.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using PX.Data;
+
+namespace Acuminator.Tests.Sources
+{
+	// Acuminator disable once PX1016 ExtensionDoesNotDeclareIsActiveMethod extension should be constantly active
+	public class BaseExtension : PXGraphExtension<MyGraph>
+	{
+		/// Overrides <seealso cref="PXGraph.Persist()"/>
+		[PXOverride]
+		public void Persist(Action base_Persist)
+		{
+			base_Persist();
+		}
+
+		/// Overrides <seealso cref="PXGraph.Clear()"/>
+		[PXOverride]
+		public void Clear(Action base_Clear)
+		{
+			base_Clear();
+		}
+	}
+
+	public class MyGraph : PXGraph<MyGraph> 
+	{
+	}
+}

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/PXGraph/Infos/PXOverride/PXOverrideInfo.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/PXGraph/Infos/PXOverride/PXOverrideInfo.cs
@@ -31,7 +31,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic.PXGraph
 			BaseMethod = baseMethod;
 		}
 
-		internal static IEnumerable<PXOverrideInfo> GetDeclaredPXOverrides(GraphOrGraphExtInfoBase graphExtensionInfo, PXContext context, 
+		internal static IEnumerable<PXOverrideInfo> GetDeclaredPXOverrides(GraphExtensionInfo graphExtensionInfo, PXContext context, 
 																		   CancellationToken cancellation)
 		{
 			cancellation.ThrowIfCancellationRequested();

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/PXGraph/Infos/PXOverride/PXOverrideInfo.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/PXGraph/Infos/PXOverride/PXOverrideInfo.cs
@@ -46,7 +46,15 @@ namespace Acuminator.Utilities.Roslyn.Semantic.PXGraph
 																	.Select(info => info.Symbol)
 																	.Distinct<ITypeSymbol>(SymbolEqualityComparer.Default)
 																	.Where(baseType => !directBaseTypesAndThis.Contains(baseType, SymbolEqualityComparer.Default))
-																	.ToList(capacity: 4);
+																	.ToList(capacity: 8);
+			if (graphExtensionInfo.BaseGraph != null)
+			{
+				// To recognize methods from the base PXGraph we must also include base graph types
+				var baseGraphTypes = graphExtensionInfo.BaseGraph.Symbol.GetBaseTypesAndThis()
+																		.SkipWhile(baseType => !baseType.IsGraphBaseType())
+																		.TakeWhile(baseType => baseType.SpecialType != SpecialType.System_Object);
+				graphAndGraphExtensionBaseTypes.AddRange(baseGraphTypes);
+			}
 
 			var declaredMethods = graphExtensionInfo.Symbol.GetMethods();
 			int declarationOrder = 0;

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/PXGraph/PXGraphSemanticModel.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/PXGraph/PXGraphSemanticModel.cs
@@ -409,8 +409,13 @@ namespace Acuminator.Utilities.Roslyn.Semantic.PXGraph
 
 		protected ImmutableArray<PXOverrideInfo> GetDeclaredPXOverrideInfos()
 		{
-			var pxOverrides = PXOverrideInfo.GetDeclaredPXOverrides(GraphOrGraphExtInfo, PXContext, _cancellation);
-			return pxOverrides.ToImmutableArray();
+			if (GraphOrGraphExtInfo is GraphExtensionInfo graphExtensionInfo)
+			{
+				var pxOverrides = PXOverrideInfo.GetDeclaredPXOverrides(graphExtensionInfo, PXContext, _cancellation);
+				return pxOverrides.ToImmutableArray();
+			}
+			else
+				return ImmutableArray<PXOverrideInfo>.Empty;
 		}
 
 		protected bool IsPXProtectedAccessAttributeDeclared() =>


### PR DESCRIPTION
## Changes Overview:
- updated signature of `GetDeclaredPXOverrides` method to accept only graph extensions
- fixed search of base method for the patch method by adding base graph types to the list of searched types
- implemented unit test for PX1096 for `PXOverride` of methods of base `PXGraph`