### PR TITLE
Bugfix/atr 941 dev px1098 false alert

### DIFF
--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXOverride/Helpers/BaseMethodReferenceInXmlDocComment.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXOverride/Helpers/BaseMethodReferenceInXmlDocComment.cs
@@ -10,6 +10,7 @@ using Acuminator.Utilities.Roslyn.Syntax;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.FindSymbols;
 
 namespace Acuminator.Analyzers.StaticAnalysis.PXOverride
 {
@@ -66,8 +67,8 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXOverride
 			return false;
 		} 
 
-		private static bool IsSeeAlsoWithCrefAttributeToBaseMethod(SemanticModel semanticModel, XmlNodeSyntax xmlNode, IMethodSymbol baseMethod, 
-																	CancellationToken cancellation)
+		private static bool IsSeeAlsoWithCrefAttributeToBaseMethod(SemanticModel semanticModel, XmlNodeSyntax xmlNode,
+																   IMethodSymbol baseMethod, CancellationToken cancellation)
 		{
 			const string seeAlsoName = "seealso";
 			string? elementName = xmlNode.GetDocTagName().NullIfWhiteSpace();
@@ -92,17 +93,29 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXOverride
 
 				var referencedSymbol = semanticModel.GetSymbolOrFirstCandidate(crefAttribute.Cref, cancellation);
 
-				if (referencedSymbol is not IMethodSymbol referencedMethod)
-					continue;
-
-				if (SymbolEqualityComparer.Default.Equals(referencedMethod, baseMethod) ||
-					SymbolEqualityComparer.Default.Equals(referencedMethod.OriginalDefinition, baseMethod.OriginalDefinition))
-				{
+				if (DoesReferencedSymbolPointToBaseMethod(referencedSymbol, baseMethod))
 					return true;
-				}
 			}
 
 			return false;
+		}
+
+		private static bool DoesReferencedSymbolPointToBaseMethod(ISymbol? referencedSymbol, IMethodSymbol baseMethod)
+		{
+			var referencedMethod = (referencedSymbol, baseMethod.MethodKind) switch
+			{
+				(IMethodSymbol methodSymbol, _)							 => methodSymbol,
+				(IPropertySymbol propertySymbol, MethodKind.PropertyGet) => propertySymbol.GetMethod,
+				(IPropertySymbol propertySymbol, MethodKind.PropertySet) => propertySymbol.SetMethod,
+				(IEventSymbol eventSymbol, MethodKind.EventAdd)			 => eventSymbol.AddMethod,
+				(IEventSymbol eventSymbol, MethodKind.EventRemove)		 => eventSymbol.RemoveMethod,
+				(IEventSymbol eventSymbol, MethodKind.EventRaise)		 => eventSymbol.RaiseMethod,
+				_														 => null
+			};
+
+			return referencedMethod != null &&
+				  (referencedMethod.Equals(baseMethod, SymbolEqualityComparer.Default) ||
+				   referencedMethod.OriginalDefinition.Equals(baseMethod.OriginalDefinition, SymbolEqualityComparer.Default));
 		}
 
 		private static bool HasOverridesPrefix(XmlTextSyntax previousText)

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXOverride/PXOverrideAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXOverride/PXOverrideAnalyzer.cs
@@ -218,7 +218,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXOverride
 
 			var location = patchMethodNode.Identifier.GetLocation().NullIfLocationKindIsNone() ?? 
 						   pxOverrideInfo.Symbol.Locations.FirstOrDefault();
-			var baseMethodDocCommentID = GetPreparedReferenceToMethodText(pxOverrideInfo.BaseMethod);
+			var baseMethodDocCommentID = GetPreparedTextWithReferenceToBaseAPI(pxOverrideInfo.BaseMethod);
 			var diagnosticProperties = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase)
 			{
 				{ PXOverrideDiagnosticProperties.BaseMethodDocCommentId, baseMethodDocCommentID }
@@ -230,15 +230,23 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXOverride
 			context.ReportDiagnosticWithSuppressionCheck(diagnostic, pxContext.CodeAnalysisSettings);
 		}
 
-		private static string? GetPreparedReferenceToMethodText(IMethodSymbol method)
+		private static string? GetPreparedTextWithReferenceToBaseAPI(IMethodSymbol method)
 		{
-			string? methodDocCommentID = method.GetDocumentationCommentId().NullIfWhiteSpace();
-			methodDocCommentID = methodDocCommentID?.Length > 2
-				? methodDocCommentID.Substring(2)						 // Remove "M:" prefix
+			ISymbol? symbolToGetDocID = method.MethodKind switch
+			{
+				MethodKind.ReducedExtension 					 					   => method.ReducedFrom,
+				MethodKind.PropertyGet or MethodKind.PropertySet 					   => method.AssociatedSymbol,
+				MethodKind.EventAdd or MethodKind.EventRemove or MethodKind.EventRaise => method.AssociatedSymbol,
+				_ 																	   => method
+			};
+
+			string? docCommentID = symbolToGetDocID?.GetDocumentationCommentId().NullIfWhiteSpace();
+			docCommentID = docCommentID?.Length > 2
+				? docCommentID.Substring(2)				// Remove "M:" and other API type prefixes
 				: null;
 
-			return methodDocCommentID != null
-				? methodDocCommentID.Replace(",", ", ")		// make parameters list more readable and look like the one VS inserts
+			return docCommentID != null
+				? docCommentID.Replace(",", ", ")		// make parameters list more readable and look like the one VS inserts
 				: null;
 		}
 	}

--- a/src/Acuminator/Acuminator.Runner.NetFramework/Acuminator.Runner.NetFramework.csproj
+++ b/src/Acuminator/Acuminator.Runner.NetFramework/Acuminator.Runner.NetFramework.csproj
@@ -51,6 +51,10 @@
 		<PackageReference Include="Microsoft.Build" ExcludeAssets="runtime" />
 		<PackageReference Include="Microsoft.Build.Framework" ExcludeAssets="runtime" />
 		<PackageReference Include="Microsoft.Build.Utilities.Core" ExcludeAssets="runtime" />
+		
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.0.0" />
+		<PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="5.0.0" />
+		<PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="5.0.0" />
 		<PackageReference Include="PolySharp" Version="1.15.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Acuminator/Acuminator.Runner.NetFramework/Acuminator.Runner.NetFramework.csproj
+++ b/src/Acuminator/Acuminator.Runner.NetFramework/Acuminator.Runner.NetFramework.csproj
@@ -46,7 +46,7 @@
 	<ItemGroup>
 		<PackageReference Include="CommandLineParser" Version="2.9.1" />
 		<PackageReference Include="Microsoft.Build.Locator" Version="1.11.2" />
-		<!--Prevent MSBuild assemblies from being distributed with the app explicitly by exluding assets for "runtime"
+		<!--Prevent MSBuild assemblies from being distributed with the app explicitly by excluding assets for "runtime"
 			See this for details: https://github.com/microsoft/MSBuildLocator/blob/55ff263d5a99f91a215c9ca5fbba8ccfa3371fe5/docs/diagnostics/MSBL001.md -->
 		<PackageReference Include="Microsoft.Build" ExcludeAssets="runtime" />
 		<PackageReference Include="Microsoft.Build.Framework" ExcludeAssets="runtime" />

--- a/src/Acuminator/Acuminator.Runner.NetFramework/Acuminator.Runner.NetFramework.csproj
+++ b/src/Acuminator/Acuminator.Runner.NetFramework/Acuminator.Runner.NetFramework.csproj
@@ -45,10 +45,12 @@
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="CommandLineParser" Version="2.9.1" />
-		<PackageReference Include="Microsoft.Build.Locator" Version="1.9.1" />
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.13.0" />
-		<PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.13.0" />
-		<PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.13.0" />
+		<PackageReference Include="Microsoft.Build.Locator" Version="1.11.2" />
+		<!--Prevent MSBuild assemblies from being distributed with the app explicitly by exluding assets for "runtime"
+			See this for details: https://github.com/microsoft/MSBuildLocator/blob/55ff263d5a99f91a215c9ca5fbba8ccfa3371fe5/docs/diagnostics/MSBL001.md -->
+		<PackageReference Include="Microsoft.Build" ExcludeAssets="runtime" />
+		<PackageReference Include="Microsoft.Build.Framework" ExcludeAssets="runtime" />
+		<PackageReference Include="Microsoft.Build.Utilities.Core" ExcludeAssets="runtime" />
 		<PackageReference Include="PolySharp" Version="1.15.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXOverride/PXOverrideWithoutXmlCommentTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXOverride/PXOverrideWithoutXmlCommentTests.cs
@@ -47,9 +47,20 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.PXOverride
 			VerifyCSharpDiagnosticAsync(source);
 
 		[Theory]
+		[EmbeddedFileData(@"XmlComment\PXOverrideOfPropertyFromBasePXGraphWithoutXmlComment_Expected.cs")]
+		public Task PXOverride_Property_WithoutXmlDocComment_AfterCodeFix(string source) =>
+			VerifyCSharpDiagnosticAsync(source);
+
+		[Theory]
 		[EmbeddedFileData(@"XmlComment\PXOverrideWithoutXmlComment.cs",
 						  @"XmlComment\PXOverrideWithoutXmlComment_Expected.cs")]
-		public Task PXOverrides_WithoutXmlDocComment_CodeFix(string actual, string expected) =>
+		public Task PXOverride_Methods_WithoutXmlDocComment_CodeFix(string actual, string expected) =>
+			VerifyCSharpFixAsync(actual, expected);
+
+		[Theory]
+		[EmbeddedFileData(@"XmlComment\PXOverrideOfPropertyFromBasePXGraphWithoutXmlComment.cs",
+						  @"XmlComment\PXOverrideOfPropertyFromBasePXGraphWithoutXmlComment_Expected.cs")]
+		public Task PXOverride_Property_WithoutXmlDocComment_CodeFix(string actual, string expected) =>
 			VerifyCSharpFixAsync(actual, expected);
 
 		private sealed class PXOverrideAnalyzerForMissingXmlCommentTests : PXOverrideAnalyzer

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXOverride/PXOverrideWithoutXmlCommentTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXOverride/PXOverrideWithoutXmlCommentTests.cs
@@ -42,6 +42,12 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.PXOverride
 				Descriptors.PX1098_PXOverrideMethodWithoutXmlDocComment.CreateFor(62, 15));
 
 		[Theory]
+		[EmbeddedFileData(@"XmlComment\PXOverrideOfPropertyFromBasePXGraphWithoutXmlComment.cs")]
+		public Task PXOverride_Property_WithoutXmlDocComment(string source) =>
+			VerifyCSharpDiagnosticAsync(source,
+				Descriptors.PX1098_PXOverrideMethodWithoutXmlDocComment.CreateFor(14, 15));
+
+		[Theory]
 		[EmbeddedFileData(@"XmlComment\PXOverrideWithoutXmlComment_Expected.cs")]
 		public Task PXOverrides_WithoutXmlDocComment_AfterCodeFix(string source) =>
 			VerifyCSharpDiagnosticAsync(source);

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXOverride/Sources/SignatureMismatch/PXOverrideOfMethodFromBasePXGraph.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXOverride/Sources/SignatureMismatch/PXOverrideOfMethodFromBasePXGraph.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
+
 using PX.Data;
 
 namespace Acuminator.Tests.Sources
@@ -19,9 +21,19 @@ namespace Acuminator.Tests.Sources
 		{
 			base_Clear();
 		}
+
+		/// Overrides <seealso cref="PXGraph.PrimaryItemType"/>
+		[PXOverride]
+		[SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "Test sources")]
+		public Type get_PrimaryItemType(Func<Type> base_PrimaryItemType) => typeof(MyDac);
 	}
 
 	public class MyGraph : PXGraph<MyGraph> 
+	{
+	}
+
+	[PXHidden]
+	public class MyDac : PXBqlTable, IBqlTable
 	{
 	}
 }

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXOverride/Sources/XmlComment/PXOverrideOfPropertyFromBasePXGraphWithoutXmlComment.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXOverride/Sources/XmlComment/PXOverrideOfPropertyFromBasePXGraphWithoutXmlComment.cs
@@ -8,6 +8,7 @@ namespace Acuminator.Tests.Sources
 	// Acuminator disable once PX1016 ExtensionDoesNotDeclareIsActiveMethod extension should be constantly active
 	public class BaseExtension : PXGraphExtension<MyGraph>
 	{
+
 		[PXOverride]
 		[SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "Test sources")]
 		public Type get_PrimaryItemType(Func<Type> base_PrimaryItemType) => typeof(MyDac);

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXOverride/Sources/XmlComment/PXOverrideOfPropertyFromBasePXGraphWithoutXmlComment.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXOverride/Sources/XmlComment/PXOverrideOfPropertyFromBasePXGraphWithoutXmlComment.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+
+using PX.Data;
+
+namespace Acuminator.Tests.Sources
+{
+	// Acuminator disable once PX1016 ExtensionDoesNotDeclareIsActiveMethod extension should be constantly active
+	public class BaseExtension : PXGraphExtension<MyGraph>
+	{
+		[PXOverride]
+		[SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "Test sources")]
+		public Type get_PrimaryItemType(Func<Type> base_PrimaryItemType) => typeof(MyDac);
+	}
+
+	public class MyGraph : PXGraph<MyGraph> 
+	{
+	}
+
+	[PXHidden]
+	public class MyDac : PXBqlTable, IBqlTable
+	{
+	}
+}

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXOverride/Sources/XmlComment/PXOverrideOfPropertyFromBasePXGraphWithoutXmlComment_Expected.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXOverride/Sources/XmlComment/PXOverrideOfPropertyFromBasePXGraphWithoutXmlComment_Expected.cs
@@ -8,6 +8,7 @@ namespace Acuminator.Tests.Sources
 	// Acuminator disable once PX1016 ExtensionDoesNotDeclareIsActiveMethod extension should be constantly active
 	public class BaseExtension : PXGraphExtension<MyGraph>
 	{
+
 		/// Overrides <seealso cref="PXGraph.PrimaryItemType"/>
 		[PXOverride]
 		[SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "Test sources")]

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXOverride/Sources/XmlComment/PXOverrideOfPropertyFromBasePXGraphWithoutXmlComment_Expected.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXOverride/Sources/XmlComment/PXOverrideOfPropertyFromBasePXGraphWithoutXmlComment_Expected.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+
+using PX.Data;
+
+namespace Acuminator.Tests.Sources
+{
+	// Acuminator disable once PX1016 ExtensionDoesNotDeclareIsActiveMethod extension should be constantly active
+	public class BaseExtension : PXGraphExtension<MyGraph>
+	{
+		/// Overrides <seealso cref="PXGraph.PrimaryItemType"/>
+		[PXOverride]
+		[SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "Test sources")]
+		public Type get_PrimaryItemType(Func<Type> base_PrimaryItemType) => typeof(MyDac);
+	}
+
+	public class MyGraph : PXGraph<MyGraph> 
+	{
+	}
+
+	[PXHidden]
+	public class MyDac : PXBqlTable, IBqlTable
+	{
+	}
+}

--- a/src/Acuminator/Acuminator.Vsix/Acuminator.Vsix.csproj
+++ b/src/Acuminator/Acuminator.Vsix/Acuminator.Vsix.csproj
@@ -289,17 +289,14 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>VSIXResource.resx</DependentUpon>
     </Compile>
-
     <Compile Remove="Settings\UI\GeneralOptionsPage.cs" />
     <Compile Include="Settings\UI\GeneralOptionsPage.cs">
       <SubType>Component</SubType>
     </Compile>
-
     <Compile Remove="Settings\UI\CodeMapOptionsPage.cs" />
     <Compile Include="Settings\UI\CodeMapOptionsPage.cs">
       <SubType>Component</SubType>
     </Compile>
-
     <Compile Remove="Coloriser\Regex\Test\*.cs" />
     <EmbeddedResource Include="Coloriser\Regex\Test\*.cs" />
     <EmbeddedResource Include="Resources\VSIXResource.resx">
@@ -363,7 +360,7 @@
       <Version>16.10.31321.278</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VSSDK.BuildTools">
-      <Version>17.11.435</Version>
+      <Version>17.14.2120</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
## Changes Overview

### Diagnostic
- Added to PX1098 recognition of accessor methods from base properties and events overridden via `PXOverride` mechanism
- Fixed PX1098 code fix to correctly generate XML doc comment for accessor methods from base properties and events
- Added unit tests for PX1098 diagnostic and code fix for an overridden property
- Updated unit tests for PX1096 with a scenario with an overridden property

### Fixed Acuminator Dependencies
- Updated MSBuiId locator nuget package in the console runner and fixed issue with a potential redistribution of MSBuild DLLs with the app
- Updated Roslyn workspace packages in the console runner to recognize code sources using features from the latest version of C#
- Updated build tools nuget package in VSIX project