### PR TITLE
Bugfix/atr 939 dev px1098 code fix handle out and ref parameters

### DIFF
--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXOverride/PXOverrideAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXOverride/PXOverrideAnalyzer.cs
@@ -222,7 +222,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXOverride
 
 			var location = patchMethodNode.Identifier.GetLocation().NullIfLocationKindIsNone() ?? 
 						   pxOverrideInfo.Symbol.Locations.FirstOrDefault();
-			var baseMethodDocCommentID = GetPreparedTextWithReferenceToBaseAPI(pxOverrideInfo.BaseMethod);
+			var baseMethodDocCommentID = GetPreparedTextWithReferenceToBaseAPI(pxOverrideInfo.BaseMethod, pxOverrideInfo);
 			ImmutableDictionary<string, string?> diagnosticProperties;
 
 			if (baseMethodDocCommentID != null)
@@ -240,24 +240,96 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXOverride
 			context.ReportDiagnosticWithSuppressionCheck(diagnostic, pxContext.CodeAnalysisSettings);
 		}
 
-		private static string? GetPreparedTextWithReferenceToBaseAPI(IMethodSymbol method)
+		private static string? GetPreparedTextWithReferenceToBaseAPI(IMethodSymbol baseMethod, PXOverrideInfo pxOverrideInfo)
 		{
-			ISymbol? symbolToGetDocID = method.MethodKind switch
+			ISymbol? symbolToGetDocID = baseMethod.MethodKind switch
 			{
-				MethodKind.ReducedExtension 					 					   => method.ReducedFrom,
-				MethodKind.PropertyGet or MethodKind.PropertySet 					   => method.AssociatedSymbol,
-				MethodKind.EventAdd or MethodKind.EventRemove or MethodKind.EventRaise => method.AssociatedSymbol,
-				_ 																	   => method
+				MethodKind.ReducedExtension 					 					   => baseMethod.ReducedFrom,
+				MethodKind.PropertyGet or MethodKind.PropertySet 					   => baseMethod.AssociatedSymbol,
+				MethodKind.EventAdd or MethodKind.EventRemove or MethodKind.EventRaise => baseMethod.AssociatedSymbol,
+				_ 																	   => baseMethod
 			};
 
 			string? docCommentID = symbolToGetDocID?.GetDocumentationCommentId().NullIfWhiteSpace();
 			docCommentID = docCommentID?.Length > 2
-				? docCommentID.Substring(2)				// Remove "M:" and other API type prefixes
+				? docCommentID.Substring(2)							// Remove "M:" and other API type prefixes
 				: null;
 
-			return docCommentID != null
-				? docCommentID.Replace(",", ", ")		// make parameters list more readable and look like the one VS inserts
-				: null;
+			if (docCommentID == null)
+				return null;
+
+			if (pxOverrideInfo.SignatureHasNonTrivialRefKind)
+				docCommentID = ProcessParametersWithNonTrivialRefKindInText(baseMethod, docCommentID);
+
+			docCommentID = docCommentID.Replace(",", ", ");			// make parameters list more readable and look like the one VS inserts
+			return docCommentID;
+		}
+
+		private static string ProcessParametersWithNonTrivialRefKindInText(IMethodSymbol baseMethod, string docCommentID)
+		{
+			var patchMethodParameters = baseMethod.Parameters;
+			docCommentID = docCommentID.Replace("@", "");			// replace ref kind indicators for parameters
+
+			if (patchMethodParameters.IsDefaultOrEmpty)
+				return docCommentID;
+
+			int openBraceIndex  = docCommentID.IndexOf('(');
+			int closeBraceIndex = docCommentID.LastIndexOf(')');
+
+			if (openBraceIndex < 0 || closeBraceIndex < openBraceIndex)
+				return docCommentID;
+
+			int parameterIndex = patchMethodParameters.Length - 1;
+			IParameterSymbol? currentParameter = patchMethodParameters[parameterIndex];
+
+			// Go from the last parameter to first for the simplicity of docCommentID modification
+			for (int i = closeBraceIndex - 1; i >= openBraceIndex; i--)
+			{
+				char c = docCommentID[i];
+
+				switch (c)
+				{
+					case '(':
+						docCommentID = InsertParameterModifierText(i + 1);
+						continue;
+
+					case ',':
+						docCommentID = InsertParameterModifierText(i + 1);
+						parameterIndex--;
+						currentParameter = parameterIndex >= 0
+							? patchMethodParameters[parameterIndex]
+							: null;
+
+						continue;
+					default:
+						continue;
+				}
+			}
+
+			return docCommentID;
+
+			//------------------------------------------------Local Function------------------------------------------------------------------
+			string InsertParameterModifierText(int indexToInsertAt)
+			{
+				const int RefReadOnlyParameterValue = 4;
+				string? parameterModifierText = currentParameter?.RefKind switch
+				{
+					RefKind.Ref => "ref ",
+					RefKind.Out => "out ",
+					RefKind.In 	=> "in ",
+					null 		=> null,
+
+					// TODO RefReadOnlyParameter enum is present in the newer versions of Roslyn but not in 3.11.
+					// Therefore, we define its value here manually. In the future after migration to a newer Roslyn version this should be removed
+					_ 			=> ((int)currentParameter.RefKind) == RefReadOnlyParameterValue
+										? "ref readonly "
+										: null
+				};
+
+				return parameterModifierText != null
+					? docCommentID.Insert(indexToInsertAt, parameterModifierText)
+					: docCommentID;
+			}
 		}
 	}
 }

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXOverride/PXOverrideWithoutXmlCommentTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXOverride/PXOverrideWithoutXmlCommentTests.cs
@@ -31,6 +31,14 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.PXOverride
 		protected override CodeFixProvider GetCSharpCodeFixProvider() => new AddXmlDocCommentWithReferenceToBaseMethodFix();
 
 		[Theory]
+		[EmbeddedFileData(@"XmlComment\PXOverrideRefAndOutParametersWithoutXmlComment.cs")]
+		public Task PXOverride_Methods_WithRefAndOutParameters_WithoutXmlDocComment(string source) =>
+			VerifyCSharpDiagnosticAsync(source,
+				Descriptors.PX1098_PXOverrideMethodWithoutXmlDocComment.CreateFor(15, 15),
+				Descriptors.PX1098_PXOverrideMethodWithoutXmlDocComment.CreateFor(24, 15),
+				Descriptors.PX1098_PXOverrideMethodWithoutXmlDocComment.CreateFor(33, 28));
+
+		[Theory]
 		[EmbeddedFileData(@"XmlComment\PXOverrideWithoutXmlComment.cs")]
 		public Task PXOverrides_WithoutXmlDocComment(string source) =>
 			VerifyCSharpDiagnosticAsync(source,
@@ -58,6 +66,11 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.PXOverride
 			VerifyCSharpDiagnosticAsync(source);
 
 		[Theory]
+		[EmbeddedFileData(@"XmlComment\PXOverrideRefAndOutParametersWithoutXmlComment_Expected.cs")]
+		public Task PXOverride_Methods_WithRefAndOutParameters_WithoutXmlDocComment_AfterCodeFix(string source) =>
+			VerifyCSharpDiagnosticAsync(source);
+
+		[Theory]
 		[EmbeddedFileData(@"XmlComment\PXOverrideWithoutXmlComment.cs",
 						  @"XmlComment\PXOverrideWithoutXmlComment_Expected.cs")]
 		public Task PXOverride_Methods_WithoutXmlDocComment_CodeFix(string actual, string expected) =>
@@ -67,6 +80,12 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.PXOverride
 		[EmbeddedFileData(@"XmlComment\PXOverrideOfPropertyFromBasePXGraphWithoutXmlComment.cs",
 						  @"XmlComment\PXOverrideOfPropertyFromBasePXGraphWithoutXmlComment_Expected.cs")]
 		public Task PXOverride_Property_WithoutXmlDocComment_CodeFix(string actual, string expected) =>
+			VerifyCSharpFixAsync(actual, expected);
+
+		[Theory]
+		[EmbeddedFileData(@"XmlComment\PXOverrideRefAndOutParametersWithoutXmlComment.cs",
+						  @"XmlComment\PXOverrideRefAndOutParametersWithoutXmlComment_Expected.cs")]
+		public Task PXOverride_Methods_WithRefAndOutParameters_WithoutXmlDocComment_CodeFix(string actual, string expected) =>
 			VerifyCSharpFixAsync(actual, expected);
 
 		private sealed class PXOverrideAnalyzerForMissingXmlCommentTests : PXOverrideAnalyzer

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXOverride/Sources/XmlComment/PXOverrideRefAndOutParametersWithoutXmlComment.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXOverride/Sources/XmlComment/PXOverrideRefAndOutParametersWithoutXmlComment.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using PX.Data;
+
+namespace Acuminator.Tests.Sources
+{
+	// Acuminator disable once PX1016 ExtensionDoesNotDeclareIsActiveMethod extension should be constantly active
+	public class APReleaseProcessDatasourceExt : PXGraphExtension<MyGraph>
+	{
+		public delegate void DoSomething1DelegateType(ref MyDac doc, bool isPrebooking, out List<MyDac> inDocs);
+
+		[PXOverride]
+		public void DoSomething1(ref MyDac doc, bool isPrebooking, out List<MyDac> inDocs, DoSomething1DelegateType base_DoSomething1)
+		{
+			inDocs = new List<MyDac>();
+			base_DoSomething1(ref doc, isPrebooking, out inDocs);
+		}
+
+		public delegate void DoSomething2DelegateType(ref MyDac doc, bool isPrebooking, out List<MyDac> inDocs);
+
+		[PXOverride]
+		public void DoSomething2(ref MyDac doc, bool isPrebooking, out List<MyDac> inDocs, DoSomething2DelegateType base_DoSomething2)
+		{
+			inDocs = new List<MyDac>();
+			base_DoSomething2(ref doc, isPrebooking, out inDocs);
+		}
+
+		public delegate ref readonly bool DoSomething3DelegateType(MyDac doc);
+
+		[PXOverride]
+		public ref readonly bool DoSomething3(MyDac doc, DoSomething3DelegateType base_DoSomething3) =>
+			 ref base_DoSomething3(doc);
+	}
+
+	public class MyGraph : PXGraph<MyGraph>
+	{
+		private readonly bool _field = true;
+
+		protected virtual void DoSomething1(ref MyDac doc, bool isPrebooking, out List<MyDac> inDocs)
+		{
+			inDocs = new List<MyDac>();
+		}
+
+		protected virtual void DoSomething2(ref MyDac doc, bool isPrebooking, out List<MyDac> inDocs)
+		{
+			inDocs = new List<MyDac>();
+		}
+
+		protected virtual ref readonly bool DoSomething3(MyDac doc)
+		{
+			return ref _field;
+		}
+	}
+
+	[PXHidden]
+	public class MyDac : PXBqlTable, IBqlTable
+	{
+	}
+}

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXOverride/Sources/XmlComment/PXOverrideRefAndOutParametersWithoutXmlComment_Expected.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXOverride/Sources/XmlComment/PXOverrideRefAndOutParametersWithoutXmlComment_Expected.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using PX.Data;
+
+namespace Acuminator.Tests.Sources
+{
+	// Acuminator disable once PX1016 ExtensionDoesNotDeclareIsActiveMethod extension should be constantly active
+	public class APReleaseProcessDatasourceExt : PXGraphExtension<MyGraph>
+	{
+		public delegate void DoSomething1DelegateType(ref MyDac doc, bool isPrebooking, out List<MyDac> inDocs);
+
+		/// Overrides <seealso cref="MyGraph.DoSomething1(ref MyDac, bool, out List{MyDac})"/>
+		[PXOverride]
+		public void DoSomething1(ref MyDac doc, bool isPrebooking, out List<MyDac> inDocs, DoSomething1DelegateType base_DoSomething1)
+		{
+			inDocs = new List<MyDac>();
+			base_DoSomething1(ref doc, isPrebooking, out inDocs);
+		}
+
+		public delegate void DoSomething2DelegateType(ref MyDac doc, bool isPrebooking, out List<MyDac> inDocs);
+
+		/// Overrides <seealso cref="MyGraph.DoSomething2(ref MyDac, bool, out List{MyDac})"/>
+		[PXOverride]
+		public void DoSomething2(ref MyDac doc, bool isPrebooking, out List<MyDac> inDocs, DoSomething2DelegateType base_DoSomething2)
+		{
+			inDocs = new List<MyDac>();
+			base_DoSomething2(ref doc, isPrebooking, out inDocs);
+		}
+
+		public delegate ref readonly bool DoSomething3DelegateType(MyDac doc);
+
+		/// Overrides <seealso cref="MyGraph.DoSomething3(MyDac)"/>
+		[PXOverride]
+		public ref readonly bool DoSomething3(MyDac doc, DoSomething3DelegateType base_DoSomething3) =>
+			 ref base_DoSomething3(doc);
+	}
+
+	public class MyGraph : PXGraph<MyGraph>
+	{
+		private readonly bool _field = true;
+
+		protected virtual void DoSomething1(ref MyDac doc, bool isPrebooking, out List<MyDac> inDocs)
+		{
+			inDocs = new List<MyDac>();
+		}
+
+		protected virtual void DoSomething2(ref MyDac doc, bool isPrebooking, out List<MyDac> inDocs)
+		{
+			inDocs = new List<MyDac>();
+		}
+
+		protected virtual ref readonly bool DoSomething3(MyDac doc)
+		{
+			return ref _field;
+		}
+	}
+
+	[PXHidden]
+	public class MyDac : PXBqlTable, IBqlTable
+	{
+	}
+}

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/AcumaticaOverridesHelper.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/AcumaticaOverridesHelper.cs
@@ -31,7 +31,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic
 			var methodsCompatibility = GetMethodsCompatibility(baseMethod.Parameters.Length, pxOverrideMethod.Parameters.Length);
 
 			if (methodsCompatibility == MethodsCompatibility.NotCompatible ||
-				!baseMethod.CanBeOverriden() || !baseMethod.IsAccessibleOutsideOfAssembly())
+				!baseMethod.CanBeOverridden() || !baseMethod.IsAccessibleOutsideOfAssembly())
 			{
 				return false;
 			}

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/IMethodSymbolExtensions.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/IMethodSymbolExtensions.cs
@@ -190,7 +190,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic
 		/// </summary>
 		/// <param name="method">The method to act on.</param>
 		/// <returns>True if <paramref name="method"/> </returns>
-		public static bool CanBeOverriden(this IMethodSymbol method) =>
+		public static bool CanBeOverridden(this IMethodSymbol method) =>
 			method.CheckIfNull().IsVirtual || method.IsOverride || method.IsAbstract;
 
 		/// <summary>

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/PXGraph/Utils/GraphSymbolUtils.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModel/PXGraph/Utils/GraphSymbolUtils.cs
@@ -79,8 +79,13 @@ namespace Acuminator.Utilities.Roslyn.Semantic.PXGraph
 			method.ThrowOnNull();
 			pxContext.ThrowOnNull();
 
-			return method.ReturnType.Equals(pxContext.SystemTypes.IEnumerable, SymbolEqualityComparer.Default) &&
-				   method.Parameters.All(p => p.RefKind != RefKind.Ref);
+			if (!method.ReturnType.Equals(pxContext.SystemTypes.IEnumerable, SymbolEqualityComparer.Default))
+				return false;
+
+			var parameters = method.Parameters;
+
+			// Check that all view delegate parameters are either regular or passed by ref with a ref keyword (the second, very rare case of view delegates)
+			return parameters.All(p => p.RefKind == RefKind.None) || parameters.All(p => p.RefKind == RefKind.Ref);
 		}
 
 		public static bool IsValidInitializeMethod(this IMethodSymbol method) =>


### PR DESCRIPTION
## Changes Overview
- fixed handling of `ref`/`out`/`in`/`ref readonly` parameters by introducing a replacement algorithm to add required ref modifiers to the generated doc ID for the method
- fixed view delegates recognition to correctly find regular view delegates and rare view delegates with `ref` parameters
- added unit test for PX1098 for methods with `ref`, `out`, `in`, and `ref readonly` modifiers in the signature
- minor refactoring