### PR TITLE
Bugfix/atr 934 dev px1102 false alert for property override

### DIFF
--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXOverride/PXOverrideAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXOverride/PXOverrideAnalyzer.cs
@@ -113,13 +113,14 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXOverride
 			Location? location;
 			BaseDelegateParameterFixMode fixMode;
 			bool registerCodeFix;
+			string properNameOfDelegateParameter = GetProperNameOfDelegateParameter(pxOverrideInfo);
 
 			switch (pxOverrideInfo.OverrideType)
 			{
 				case PXOverrideType.WithoutBaseDelegate:
-					descriptor = Descriptors.PX1079_PXOverrideWithoutDelegateParameter;
-					location = pxOverrideInfo.Symbol.Locations.FirstOrDefault();
-					fixMode = BaseDelegateParameterFixMode.AddDelegateParameter;
+					descriptor 		= Descriptors.PX1079_PXOverrideWithoutDelegateParameter;
+					location 		= pxOverrideInfo.Symbol.Locations.FirstOrDefault();
+					fixMode 		= BaseDelegateParameterFixMode.AddDelegateParameter;
 					registerCodeFix = !pxOverrideInfo.SignatureHasNonTrivialRefKind;
 					break;
 
@@ -131,7 +132,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXOverride
 					break;
 
 				case PXOverrideType.WithValidBaseDelegate
-				when !IsCorrectDelegateParameterName(pxOverrideInfo.Symbol):
+				when !IsCorrectDelegateParameterName(pxOverrideInfo.Symbol, properNameOfDelegateParameter):
 					descriptor = Descriptors.PX1102_PXOverrideInvalidNameOfDelegateParameter;
 					location = GetLocationForDelegateParameterWithIncorrectName(pxOverrideInfo.Symbol, context.CancellationToken);
 					fixMode = BaseDelegateParameterFixMode.RenameDelegateParameter;
@@ -145,7 +146,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXOverride
 			var diagnosticProperties = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase)
 			{
 				{ DiagnosticProperty.RegisterCodeFix, registerCodeFix.ToString() },
-				{ PXOverrideDiagnosticProperties.PatchMethodName, pxOverrideInfo.Symbol.Name },
+				{ PXOverrideDiagnosticProperties.PatchMethodName, properNameOfDelegateParameter },
 				{ PXOverrideDiagnosticProperties.DelegateParameterFixMode, fixMode.ToString() }
 			}
 			.ToImmutableDictionary();
@@ -171,15 +172,43 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXOverride
 				   patchMethodWithPXOverride.Locations.FirstOrDefault();
 		}
 
-		private bool IsCorrectDelegateParameterName(IMethodSymbol patchMethodWithPXOverride)
+		private bool IsCorrectDelegateParameterName(IMethodSymbol patchMethod, string properMethodName)
 		{
-			if (patchMethodWithPXOverride.Parameters.IsDefaultOrEmpty)
+			var patchMethodParameters = patchMethod.Parameters;
+
+			if (patchMethodParameters.IsDefaultOrEmpty)
 				return true;
 
-			var lastParameter = patchMethodWithPXOverride.Parameters[^1];
-			string properName = $"base_{patchMethodWithPXOverride.Name}";
+			var lastParameter = patchMethodParameters[^1];
+			string properParameterName = $"base_{properMethodName}";
 
-			return lastParameter.Name.Equals(properName, StringComparison.OrdinalIgnoreCase);
+			return lastParameter.Name.Equals(properParameterName, StringComparison.OrdinalIgnoreCase);
+		}
+
+		private static string GetProperNameOfDelegateParameter(PXOverrideInfo pxOverrideInfo)
+		{
+			if (pxOverrideInfo.BaseMethod is IMethodSymbol baseMethod)
+			{
+				string baseMethodName = baseMethod.AssociatedSymbol?.Name.NullIfWhiteSpace() ?? baseMethod.Name;
+				return baseMethodName;
+			}
+			else
+			{
+				string methodName = pxOverrideInfo.Symbol.Name;
+
+				if (methodName.StartsWith("get_", StringComparison.OrdinalIgnoreCase) ||
+					methodName.StartsWith("set_", StringComparison.OrdinalIgnoreCase) ||
+					methodName.StartsWith("add_", StringComparison.OrdinalIgnoreCase))
+				{
+					methodName = methodName.Substring(4);
+				}
+				else if (methodName.StartsWith("remove_", StringComparison.OrdinalIgnoreCase))
+				{
+					methodName = methodName.Substring(7);
+				}
+
+				return methodName;
+			}
 		}
 
 		private Location? GetLocationForDelegateParameterWithIncorrectName(IMethodSymbol patchMethodWithPXOverride, CancellationToken cancellation)
@@ -244,10 +273,13 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXOverride
 		{
 			ISymbol? symbolToGetDocID = baseMethod.MethodKind switch
 			{
-				MethodKind.ReducedExtension 					 					   => baseMethod.ReducedFrom,
-				MethodKind.PropertyGet or MethodKind.PropertySet 					   => baseMethod.AssociatedSymbol,
-				MethodKind.EventAdd or MethodKind.EventRemove or MethodKind.EventRaise => baseMethod.AssociatedSymbol,
-				_ 																	   => baseMethod
+				MethodKind.PropertyGet or
+				MethodKind.PropertySet or
+				MethodKind.EventAdd    or
+				MethodKind.EventRemove or
+				MethodKind.EventRaise		=> baseMethod.AssociatedSymbol,
+				MethodKind.ReducedExtension => baseMethod.ReducedFrom,
+				_							=> baseMethod
 			};
 
 			string? docCommentID = symbolToGetDocID?.GetDocumentationCommentId().NullIfWhiteSpace();

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXOverride/PXOverrideWithIncorrectDelegateParameterNameTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXOverride/PXOverrideWithIncorrectDelegateParameterNameTests.cs
@@ -31,6 +31,12 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.PXOverride
 		protected override CodeFixProvider GetCSharpCodeFixProvider() => new AddOrReplaceOrRenameBaseDelegateParameterFix();
 
 		[Theory]
+		[EmbeddedFileData(@"BaseDelegateParameter\InvalidParameterName\PXOverrideOfPropertyFromBasePXGraphWithIncorrectDelegateParameterName.cs")]
+		public Task PXOverride_OfProperty_WithIncorrect_BaseDelegateParameter_Name(string source) =>
+			VerifyCSharpDiagnosticAsync(source,
+				Descriptors.PX1102_PXOverrideInvalidNameOfDelegateParameter.CreateFor(15, 46));
+
+		[Theory]
 		[EmbeddedFileData(@"BaseDelegateParameter\InvalidParameterName\PXOverrideRefAndOutParametersWithIncorrectDelegateParameterName.cs")]
 		public Task PXOverrides_WithRefAndOutParameters_And_Incorrect_BaseDelegateParameter_Name(string source) =>
 			VerifyCSharpDiagnosticAsync(source,
@@ -58,6 +64,11 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.PXOverride
 			VerifyCSharpDiagnosticAsync(source);
 
 		[Theory]
+		[EmbeddedFileData(@"BaseDelegateParameter\InvalidParameterName\PXOverrideOfPropertyFromBasePXGraphWithIncorrectDelegateParameterName_Expected.cs")]
+		public Task PXOverride_OfProperty_WithIncorrect_BaseDelegateParameter_Name_AfterCodeFix(string source) =>
+			VerifyCSharpDiagnosticAsync(source);
+
+		[Theory]
 		[EmbeddedFileData(@"BaseDelegateParameter\InvalidParameterName\PXOverrideWithIncorrectDelegateParameterName.cs",
 						  @"BaseDelegateParameter\InvalidParameterName\PXOverrideWithIncorrectDelegateParameterName_Expected.cs")]
 		public Task PXOverrides_With_Incorrect_BaseDelegateParameter_Name_CodeFix(string actual, string expected) =>
@@ -67,6 +78,12 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.PXOverride
 		[EmbeddedFileData(@"BaseDelegateParameter\InvalidParameterName\PXOverrideRefAndOutParametersWithIncorrectDelegateParameterName.cs",
 						  @"BaseDelegateParameter\InvalidParameterName\PXOverrideRefAndOutParametersWithIncorrectDelegateParameterName_Expected.cs")]
 		public Task PXOverrides_WithRefAndOutParameters_And_Incorrect_BaseDelegateParameter_Name_CodeFix(string actual, string expected) =>
+			VerifyCSharpFixAsync(actual, expected);
+
+		[Theory]
+		[EmbeddedFileData(@"BaseDelegateParameter\InvalidParameterName\PXOverrideOfPropertyFromBasePXGraphWithIncorrectDelegateParameterName.cs",
+						  @"BaseDelegateParameter\InvalidParameterName\PXOverrideOfPropertyFromBasePXGraphWithIncorrectDelegateParameterName_Expected.cs")]
+		public Task PXOverride_OfProperty_WithIncorrect_BaseDelegateParameter_Name_CodeFix(string actual, string expected) =>
 			VerifyCSharpFixAsync(actual, expected);
 
 		private sealed class PXOverrideAnalyzerForIncorrectDelegateParameterNameTests : PXOverrideAnalyzer

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXOverride/Sources/BaseDelegateParameter/InvalidParameterName/PXOverrideOfPropertyFromBasePXGraphWithIncorrectDelegateParameterName.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXOverride/Sources/BaseDelegateParameter/InvalidParameterName/PXOverrideOfPropertyFromBasePXGraphWithIncorrectDelegateParameterName.cs
@@ -15,7 +15,7 @@ namespace Acuminator.Tests.Sources
 		public Type get_PrimaryItemType(Func<Type> baseProperty) => typeof(MyDac);
 	}
 
-	public class MyGraph : PXGraph<MyGraph> 
+	public class MyGraph : PXGraph<MyGraph>
 	{
 	}
 

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXOverride/Sources/BaseDelegateParameter/InvalidParameterName/PXOverrideOfPropertyFromBasePXGraphWithIncorrectDelegateParameterName.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXOverride/Sources/BaseDelegateParameter/InvalidParameterName/PXOverrideOfPropertyFromBasePXGraphWithIncorrectDelegateParameterName.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+
+using PX.Data;
+
+namespace Acuminator.Tests.Sources
+{
+	// Acuminator disable once PX1016 ExtensionDoesNotDeclareIsActiveMethod extension should be constantly active
+	public class BaseExtension : PXGraphExtension<MyGraph>
+	{
+
+		/// Overrides <seealso cref="PXGraph.PrimaryItemType"/>
+		[PXOverride]
+		[SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "Test sources")]
+		public Type get_PrimaryItemType(Func<Type> baseProperty) => typeof(MyDac);
+	}
+
+	public class MyGraph : PXGraph<MyGraph> 
+	{
+	}
+
+	[PXHidden]
+	public class MyDac : PXBqlTable, IBqlTable
+	{
+	}
+}

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXOverride/Sources/BaseDelegateParameter/InvalidParameterName/PXOverrideOfPropertyFromBasePXGraphWithIncorrectDelegateParameterName_Expected.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/PXOverride/Sources/BaseDelegateParameter/InvalidParameterName/PXOverrideOfPropertyFromBasePXGraphWithIncorrectDelegateParameterName_Expected.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+
+using PX.Data;
+
+namespace Acuminator.Tests.Sources
+{
+	// Acuminator disable once PX1016 ExtensionDoesNotDeclareIsActiveMethod extension should be constantly active
+	public class BaseExtension : PXGraphExtension<MyGraph>
+	{
+
+		/// Overrides <seealso cref="PXGraph.PrimaryItemType"/>
+		[PXOverride]
+		[SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "Test sources")]
+		public Type get_PrimaryItemType(Func<Type> base_PrimaryItemType) => typeof(MyDac);
+	}
+
+	public class MyGraph : PXGraph<MyGraph>
+	{
+	}
+
+	[PXHidden]
+	public class MyDac : PXBqlTable, IBqlTable
+	{
+	}
+}


### PR DESCRIPTION
## Changes Overview
- fixed the check of the delegate parameter name + changed the parameter name passed to the code fix for PX1102
- added unit tests for PX1102 for the overridden property