### PR TITLE
Bugfix/atr 936 dev remove noise alerts for px1065

### DIFF
--- a/docs/diagnostics/PX1065.md
+++ b/docs/diagnostics/PX1065.md
@@ -19,8 +19,9 @@ For DAC extensions, the diagnostic checks whether the DAC field property has a c
  - The base DAC of the DAC extension and the DACs from which the base DAC has been derived
  - The lower-level DAC extensions to which the DAC extension is chained
 
-For DAC extensions and derived DACs which base DAC has a DAC field property without a corresponding BQL field the PX1065 diagnostic will report an error only if the property is overridden in the derived DAC or
-redeclared in the DAC extension.
+If a base DAC has a DAC field property without a corresponding BQL field, the PX1065 diagnostic will report an error only if the property is overridden in the derived DAC or redeclared in the DAC extension.
+
+
 
  ### Terminology
 

--- a/docs/diagnostics/PX1065.md
+++ b/docs/diagnostics/PX1065.md
@@ -3,20 +3,24 @@ This document describes the PX1065 diagnostic.
 
 ## Summary
 
-| Code   | Short Description                                                                         | Type                           | Code Fix    | 
-| ------ | ----------------------------------------------------------------------------------------- | ------------------------------ | ----------- | 
-| PX1065 | The DAC field property does not have a corresponding BQL field. | Error                          | Available   | 
+| Code   | Short Description                                               | Type  | Code Fix    | 
+| ------ | --------------------------------------------------------------- | ----- | ----------- | 
+| PX1065 | The DAC field property does not have a corresponding BQL field. | Error | Available   | 
 
 ## Diagnostic Description
 
-Acumatica Framework requires that all DAC field properties have a corresponding BQL field (a public abstract class) in the DAC. A missing BQL field may cause runtime errors or unexpected behavior in numerous places in the application code of Acumatica ERP. 
+Acumatica Framework requires that all DAC field properties have a corresponding BQL field (a public abstract class) in the DAC. A missing BQL field may cause runtime errors or unexpected behavior 
+in numerous places in the application code of Acumatica ERP. 
 
-The PX1065 diagnostic checks whether the DAC field property has a corresponding BQL field in the definition of the DAC or in its base DACs.
+The PX1065 diagnostic checks whether the declared DAC field property has a corresponding BQL field in the definition of the DAC or in its base DACs.
 
 For DAC extensions, the diagnostic checks whether the DAC field property has a corresponding BQL field in the following locations:
  - The DAC extension itself and the base DACs from which it is derived
  - The base DAC of the DAC extension and the DACs from which the base DAC has been derived
  - The lower-level DAC extensions to which the DAC extension is chained
+
+For DAC extensions and derived DACs which base DAC has a DAC field property without a corresponding BQL field the PX1065 diagnostic will report an error only if the property is overridden in the derived DAC or
+redeclared in the DAC extension.
 
  ### Terminology
 

--- a/docs/diagnostics/PX1080.md
+++ b/docs/diagnostics/PX1080.md
@@ -8,16 +8,16 @@ This document describes the PX1080 diagnostic.
 | PX1080 | Data view delegates should not start long-running operations. | Error | Unavailable |
 
 ## Diagnostic Description
-Data view delegates should not start long-running operations. A data view delegate is designed to prepare a data set to display it in the UI. If the results of the long-running operation are not awaited synchronously, 
-then the results of the data view delegate are returned before the end of the long-running operation. This scenario is not supported by the Acumatica Framework and may lead to unexpected behavior.
+Data view delegates should not start long-running operations. A data view delegate is designed to prepare a data set to display it in the UI. Typically, if the results of a long-running operation are not awaited synchronously (the operation is asynchronous), 
+the results of the data view delegate are returned before the end of the long-running operation. However, this scenario is not supported by the Acumatica Framework: If a data view delegate starts an asynchronous long-running operation, it may lead to unexpected behavior.
 
-However, even if the results of the long-running operation are awaited synchronously, starting a long-running operation from a data view delegate is still strongly discouraged due to the following reasons:
-- A synchronous wait until the data is loaded from the external service is bad for the user experience.
+If the results of the long-running operation are awaited synchronously, starting a long-running operation from a data view delegate is still strongly discouraged due to the following reasons:
+- A synchronous wait for the data from the external service negatively impacts the user experience.
 - The paging mechanisms of the Acumatica Framework may work incorrectly.
 - The approach does not scale well. There are no observable problems when there are only 10-50 records retrieved from the external service. However, the solution rapidly deteriorates when the amount of external 
-data grows to something like 50 000 - 100 000. Such cases were observed by Acumatica support.
-- Any disruption of the external service (for example, some trivial issues after OS upgrade on the server) will prevent the affected Acumatica screen from opening. Neither Acumatica, nor the customization authors 
-can guarantee the stability of the external service. Such situations take a lot of time and effort for investigation keeping the customer annoyed and frustrated with Acumatica even though the real problem was caused
+data grows to 50 000 - 100 000 records. Such cases were observed by Acumatica support.
+- Any disruption of the external service (for example, some trivial issues after OS upgrade on the server where the service is hosted) will prevent the affected Acumatica ERP screen from opening. Neither Acumatica, nor the customization authors 
+can guarantee the stability of the external service. Such situations take a lot of time and effort for investigation keeping the customer annoyed and frustrated with Acumatica ERP even though the real problem was caused
 by another service.
 
 Long-running operations are started by the following APIs:
@@ -28,9 +28,9 @@ Long-running operations are started by the following APIs:
 To prevent the error from occurring, you should remove the code that starts a long-running operation from the data view delegate and rework the related business logic. 
 
 The alternative approach recommended by the Acumatica ISV Support team:
-- If there is not much data to retrieve from the external service, then you can use a virtual DAC which is filled by clicking on an action.
-- If there is a lot of data to retrieve from the external service, then you keep the data locally in the database. You should obtain the updates in the external service's data with a click on an action, 
-and synchronize them with the locally stored data. The synchronization of data can be also done via the push notifications mechanism.
+- If there is a small amount of data to retrieve from the external service, then you can use a virtual DAC which is populated when a user clicks an action.
+- If there is a large amount of data to retrieve from the external service, then you should store the data locally in the database. You should obtain the data updates from the external service 
+and synchronize them with the locally stored data when a user clicks a specific action. The data synchronization can be also performed via the push notifications mechanism.
 
 ## Example of Incorrect Code
 

--- a/docs/diagnostics/PX1080.md
+++ b/docs/diagnostics/PX1080.md
@@ -8,7 +8,17 @@ This document describes the PX1080 diagnostic.
 | PX1080 | Data view delegates should not start long-running operations. | Error | Unavailable |
 
 ## Diagnostic Description
-Data view delegates should not start long-running operations. A data view delegate is designed to prepare a data set to display it in the UI. The result of the data view delegate is returned before the end of the long-running operation.
+Data view delegates should not start long-running operations. A data view delegate is designed to prepare a data set to display it in the UI. If the results of the long-running operation are not awaited synchronously, 
+then the results of the data view delegate are returned before the end of the long-running operation. This scenario is not supported by the Acumatica Framework and may lead to unexpected behavior.
+
+However, even if the results of the long-running operation are awaited synchronously, starting a long-running operation from a data view delegate is still strongly discouraged due to the following reasons:
+- A synchronous wait until the data is loaded from the external service is bad for the user experience.
+- The paging mechanisms of the Acumatica Framework may work incorrectly.
+- The approach does not scale well. There are no observable problems when there are only 10-50 records retrieved from the external service. However, the solution rapidly deteriorates when the amount of external 
+data grows to something like 50 000 - 100 000. Such cases were observed by Acumatica support.
+- Any disruption of the external service (for example, some trivial issues after OS upgrade on the server) will prevent the affected Acumatica screen from opening. Neither Acumatica, nor the customization authors 
+can guarantee the stability of the external service. Such situations take a lot of time and effort for investigation keeping the customer annoyed and frustrated with Acumatica even though the real problem was caused
+by another service.
 
 Long-running operations are started by the following APIs:
 - `PXLongOperation.StartOperation` methods
@@ -16,6 +26,11 @@ Long-running operations are started by the following APIs:
 - `IGraphLongOperationManager.StartOperation` and `IGraphLongOperationManager.StartAsyncOperation` methods
 
 To prevent the error from occurring, you should remove the code that starts a long-running operation from the data view delegate and rework the related business logic. 
+
+The alternative approach recommended by the Acumatica ISV Support team:
+- If there is not much data to retrieve from the external service, then you can use a virtual DAC which is filled by clicking on an action.
+- If there is a lot of data to retrieve from the external service, then you keep the data locally in the database. You should obtain the updates in the external service's data with a click on an action, 
+and synchronize them with the locally stored data. The synchronization of data can be also done via the push notifications mechanism.
 
 ## Example of Incorrect Code
 

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/NoBqlFieldForDacFieldProperty/NoBqlFieldForDacFieldAnalyzerFix.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/NoBqlFieldForDacFieldProperty/NoBqlFieldForDacFieldAnalyzerFix.cs
@@ -34,7 +34,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.NoBqlFieldForDacFieldProperty
 		{
 			context.CancellationToken.ThrowIfCancellationRequested();
 
-			if (!diagnostic.IsRegisteredForCodeFix() ||
+			if (!diagnostic.IsRegisteredForCodeFix(considerRegisteredByDefault: false) ||
 				!diagnostic.TryGetPropertyValue(DiagnosticProperty.DacFieldName, out string? dacFieldName) ||
 				dacFieldName.IsNullOrWhiteSpace())
 			{

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/NoBqlFieldForDacFieldProperty/NoBqlFieldForDacFieldPropertyAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/NoBqlFieldForDacFieldProperty/NoBqlFieldForDacFieldPropertyAnalyzer.cs
@@ -82,7 +82,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.NoBqlFieldForDacFieldProperty
 			//
 			// The second scenario only makes sense for DACs, because DAC extensions can't have derived types, 
 			// and it makes little sense to redeclare existing BQL field in the chained DAC extension.
-			if (declaredDacField.HasBqlFieldEffective && dacOrDacExt.DacType != DacType.Dac)
+			if (declaredDacField.HasBqlFieldEffective && dacOrDacExt.DacType == DacType.DacExtension)
 				return;
 
 			var declaredBqlFieldsWithTypo = FindBqlFieldInfosWithinTypoDistance(declaredDacField.Name, dacOrDacExt, declaredBqlFieldsWithWithoutProperty,
@@ -100,20 +100,20 @@ namespace Acuminator.Analyzers.StaticAnalysis.NoBqlFieldForDacFieldProperty
 		private void AnalyzeDacPropertyDeclaredInBaseTypes(SymbolAnalysisContext symbolContext, PXContext pxContext, DacSemanticModel dacOrDacExt,
 														   DacFieldInfo dacPropertyInBaseTypes, List<DacBqlFieldInfo> declaredBqlFieldsWithWithoutProperty)
 		{
-			// If the property is declared in based types and does not have a BQL field then report DAC field with PX1065 as missing BQL field
-			if (!dacPropertyInBaseTypes.HasBqlFieldEffective)
-				ReportDacPropertyWithoutBqlField(symbolContext, pxContext, dacOrDacExt, dacPropertyInBaseTypes);
+			// If the property is declared in base types and does not have a corresponding BQL field at all then
+			// Acuminator should not report the PX1065 diagnostic for the missing BQL field because there will be a lot of noise in DAC extensions and derived DACs.
+			// Even if the base DAC is located in the source code, it's unlikely that the extension authors will be able to fix the base DAC.
 
-			// Now check declared BQL fields without corresponding properties for ones with names close to the "dacPropertyInBaseTypes" name.
+			// Now check BQL fields declared in this DAC without a corresponding property for ones with names close to the "dacPropertyInBaseTypes" name.
 			// 
 			// Since the DAC field "dacPropertyInBaseTypes" is declared in dacOrDacExt base types we need to support a scenario 
-			// when BQL field with a typo is declared in the dacOrDacExt DAC and there is a DAC field with correct name in the base types.
+			// when BQL field with a typo is declared in the dacOrDacExt DAC under the validation and there is a property with correct name in the base types.
 			// It does not matter if that field has a BQL field or not - it is in base types, and checked bql fields are in derived types, 
 			// so they would be hiding base BQL field anyway.
 			//
 			// This scenario only makes sense for DACs, because DAC extensions can't have derived types, 
 			// and it makes little sense to redeclare existing BQL field in the chained DAC extension
-			if (dacOrDacExt.DacType != DacType.Dac)
+			if (dacOrDacExt.DacType == DacType.DacExtension)
 				return;
 			
 			var declaredBqlFieldsWithTypo = FindBqlFieldInfosWithinTypoDistance(dacPropertyInBaseTypes.Name, dacOrDacExt, declaredBqlFieldsWithWithoutProperty,

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/NoBqlFieldForDacFieldProperty/NoBqlFieldForDacFieldPropertyAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/NoBqlFieldForDacFieldProperty/NoBqlFieldForDacFieldPropertyAnalyzer.cs
@@ -184,21 +184,19 @@ namespace Acuminator.Analyzers.StaticAnalysis.NoBqlFieldForDacFieldProperty
 			if (location == null)
 				return;
 
-			var properties = ImmutableDictionary<string, string?>.Empty;
 			string? propertyTypeName = dacFieldWithoutBqlField.PropertyTypeUnwrappedNullable?.GetSimplifiedName();
+			var properties = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase)
+			{
+				{ DiagnosticProperty.RegisterCodeFix, registerCodeFix.ToString() },
+				{ DiagnosticProperty.DacFieldName,	  dacFieldWithoutBqlField.Name }
+			};
 
 			if (registerCodeFix && propertyTypeName != null)
-			{
-				properties = new Dictionary<string, string?>
-				{
-					{ DiagnosticProperty.RegisterCodeFix, bool.TrueString },
-					{ DiagnosticProperty.DacFieldName,	  dacFieldWithoutBqlField.Name },
-					{ DiagnosticProperty.PropertyType,	  propertyTypeName }
-				}
-				.ToImmutableDictionary(StringComparer.OrdinalIgnoreCase);
-			}
+				properties.Add(DiagnosticProperty.PropertyType, propertyTypeName);
 
-			var diagnostic = Diagnostic.Create(Descriptors.PX1065_NoBqlFieldForDacFieldProperty, location, properties, dacFieldWithoutBqlField.Name);
+			var diagnostic = Diagnostic.Create(Descriptors.PX1065_NoBqlFieldForDacFieldProperty, location, 
+											   properties.ToImmutableDictionary(StringComparer.OrdinalIgnoreCase), 
+											   dacFieldWithoutBqlField.Name);
 			symbolContext.ReportDiagnosticWithSuppressionCheck(diagnostic, pxContext.CodeAnalysisSettings);
 		}
 
@@ -207,10 +205,9 @@ namespace Acuminator.Analyzers.StaticAnalysis.NoBqlFieldForDacFieldProperty
 			if (dacField.PropertyInfo?.IsInSource == true && dacField.IsDeclaredInType(dac.Symbol))
 			{
 				var location = dacField.PropertyInfo.Node.Identifier.GetLocation().NullIfLocationKindIsNone() ??
-							   dacField.PropertyInfo.Node.GetLocation() ??
-							   dac.Node!.Identifier.GetLocation().NullIfLocationKindIsNone();
+							   dacField.PropertyInfo.Node.GetLocation();
 
-				return (location, RegisterCodeFix: true);
+				return (location, RegisterCodeFix: location != null);
 			}
 
 			// Node is not null because aggregated DAC analysis runs only on DACs from the source code

--- a/src/Acuminator/Acuminator.Tests/ExternalDependency/src/NoBqlFieldForDacFieldProperty/BaseDacWithoutBqlField.cs
+++ b/src/Acuminator/Acuminator.Tests/ExternalDependency/src/NoBqlFieldForDacFieldProperty/BaseDacWithoutBqlField.cs
@@ -19,5 +19,15 @@ namespace ExternalDependency.NoBqlFieldForDacFieldProperty
 		public virtual int? ShipmentNbr { get; set; }
 
 		public virtual string? ExtraData { get; set; }
+
+		#region Amount
+		[PXDBDecimal]
+		[PXUIField(DisplayName = "Amount")]
+		public decimal? Amount              // PX1065 should be reported here because the property does not have a BQL field
+		{
+			get;
+			set;
+		}
+		#endregion
 	}
 }

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/NoBqlFieldForDacFieldProperty/NoBqlFieldForDacFieldPropertyTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/NoBqlFieldForDacFieldProperty/NoBqlFieldForDacFieldPropertyTests.cs
@@ -60,13 +60,13 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.NoBqlFieldForDacFieldProperty
 		[Theory]
 		[EmbeddedFileData(@"MissingBqlField\DacWithBqlFieldMissingInExternalBaseDac.cs")]
 		public async Task DerivedDac_BasedDacInExternalDll_WithoutBqlFields(string actual) => await VerifyCSharpDiagnosticAsync(actual,
-			Descriptors.PX1065_NoBqlFieldForDacFieldProperty.CreateFor(8, 15, "ShipmentNbr"),
-			Descriptors.PX1065_NoBqlFieldForDacFieldProperty.CreateFor(12, 25, "OrderNbr"));
+			Descriptors.PX1065_NoBqlFieldForDacFieldProperty.CreateFor(13, 25, "OrderNbr"),
+			Descriptors.PX1065_NoBqlFieldForDacFieldProperty.CreateFor(22, 19, "Amount"));
 
 		[Theory]
 		[EmbeddedFileData(@"MissingBqlField\DacExtensionWithBqlFieldMissingInExternalBaseDac.cs")]
 		public async Task DacExtension_BasedDacInExternalDll_WithoutBqlFields(string actual) => await VerifyCSharpDiagnosticAsync(actual,
-			Descriptors.PX1065_NoBqlFieldForDacFieldProperty.CreateFor(11, 22, "ShipmentNbr"));
+			Descriptors.PX1065_NoBqlFieldForDacFieldProperty.CreateFor(21, 19, "Amount"));
 
 		[Theory]
 		[EmbeddedFileData(@"MissingBqlField\DacWithoutBqlFields.cs", @"MissingBqlField\DacWithoutBqlFields_Expected.cs")]

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/NoBqlFieldForDacFieldProperty/NoBqlFieldForDacFieldPropertyTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/NoBqlFieldForDacFieldProperty/NoBqlFieldForDacFieldPropertyTests.cs
@@ -47,15 +47,17 @@ namespace Acuminator.Tests.Tests.StaticAnalysis.NoBqlFieldForDacFieldProperty
 		[Theory]
 		[EmbeddedFileData(@"MissingBqlField\DacWithBqlFieldMissingInBaseDac.cs")]
 		public async Task DerivedDac_BasedDac_WithoutBqlFields(string actual) => await VerifyCSharpDiagnosticAsync(actual,
-			Descriptors.PX1065_NoBqlFieldForDacFieldProperty.CreateFor(8, 15, "ShipmentNbr"),
-			Descriptors.PX1065_NoBqlFieldForDacFieldProperty.CreateFor(23, 23, "ShipmentNbr"));
+			Descriptors.PX1065_NoBqlFieldForDacFieldProperty.CreateFor(19, 28, "Amount"),
+			Descriptors.PX1065_NoBqlFieldForDacFieldProperty.CreateFor(36, 23, "ShipmentNbr"),
+			Descriptors.PX1065_NoBqlFieldForDacFieldProperty.CreateFor(43, 27, "Amount"));
 
 		[Theory]
 		[EmbeddedFileData(@"MissingBqlField\DacExtensionWithBqlFieldMissingInBaseDac.cs")]
 		public async Task DacExtension_BasedDac_WithoutBqlFields(string actual) => await VerifyCSharpDiagnosticAsync(actual,
-			Descriptors.PX1065_NoBqlFieldForDacFieldProperty.CreateFor(9, 22, "ShipmentNbr"),
-			Descriptors.PX1065_NoBqlFieldForDacFieldProperty.CreateFor(18, 16, "Selected"),
-			Descriptors.PX1065_NoBqlFieldForDacFieldProperty.CreateFor(34, 23, "ShipmentNbr"));
+			Descriptors.PX1065_NoBqlFieldForDacFieldProperty.CreateFor(20, 16, "Selected"),
+			Descriptors.PX1065_NoBqlFieldForDacFieldProperty.CreateFor(30, 19, "Amount"),
+			Descriptors.PX1065_NoBqlFieldForDacFieldProperty.CreateFor(47, 23, "ShipmentNbr"),
+			Descriptors.PX1065_NoBqlFieldForDacFieldProperty.CreateFor(54, 19, "Amount"));
 
 		[Theory]
 		[EmbeddedFileData(@"MissingBqlField\DacWithBqlFieldMissingInExternalBaseDac.cs")]

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/NoBqlFieldForDacFieldProperty/Sources/MissingBqlField/DacExtensionWithBqlFieldMissingInBaseDac.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/NoBqlFieldForDacFieldProperty/Sources/MissingBqlField/DacExtensionWithBqlFieldMissingInBaseDac.cs
@@ -1,16 +1,18 @@
 ﻿using System;
 
 using PX.Data;
+using PX.Data.BQL;
 
 namespace PX.Analyzers.Test.Sources
 {
+	/// <exclude/>
 	// Acuminator disable once PX1016 ExtensionDoesNotDeclareIsActiveMethod extension should be constantly active
 	[PXHidden]
-	public sealed class DacExtension : PXCacheExtension<BaseDac>
+	public sealed class DacExtension : PXCacheExtension<BaseDac>        // PX1065 for ShipmentNbr should not be reported here because it is not declared in the extension
 	{
 		[PXString]
 		[PXUIField(DisplayName = "Status")]
-		public string Status { get; set; }
+		public string? Status { get; set; }
 
 		#region Selected
 		[PXBool]
@@ -21,8 +23,19 @@ namespace PX.Analyzers.Test.Sources
 			set;
 		}
 		#endregion
+
+		#region Amount
+		[PXDBDecimal]
+		[PXUIField(DisplayName = "Customized Amount")]
+		public decimal? Amount                  // PX1065 should be reported here because the base property without a BQL field is declared in the extension 
+		{
+			get;
+			set;
+		}
+		#endregion
 	}
 
+	// Acuminator disable once PX1069 MissingMandatoryDacFields [Justification]
 	[PXHidden]
 	public class BaseDac : PXBqlTable, IBqlTable
 	{
@@ -33,6 +46,16 @@ namespace PX.Analyzers.Test.Sources
 		[PXInt]
 		public virtual int? ShipmentNbr { get; set; }
 
-		public virtual string ExtraData { get; set; }
+		public virtual string? ExtraData { get; set; }
+
+		#region Amount
+		[PXDBDecimal]
+		[PXUIField(DisplayName = "Amount")]
+		public decimal? Amount              // PX1065 should be reported here because the property does not have a BQL field
+		{
+			get;
+			set;
+		}
+		#endregion
 	}
 }

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/NoBqlFieldForDacFieldProperty/Sources/MissingBqlField/DacExtensionWithBqlFieldMissingInBaseDac_Expected.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/NoBqlFieldForDacFieldProperty/Sources/MissingBqlField/DacExtensionWithBqlFieldMissingInBaseDac_Expected.cs
@@ -1,16 +1,18 @@
 ﻿using System;
 
 using PX.Data;
+using PX.Data.BQL;
 
 namespace PX.Analyzers.Test.Sources
 {
+	/// <exclude/>
 	// Acuminator disable once PX1016 ExtensionDoesNotDeclareIsActiveMethod extension should be constantly active
 	[PXHidden]
-	public sealed class DacExtension : PXCacheExtension<BaseDac>
+	public sealed class DacExtension : PXCacheExtension<BaseDac>        // PX1065 for ShipmentNbr should not be reported here because it is not declared in the extension
 	{
 		[PXString]
 		[PXUIField(DisplayName = "Status")]
-		public string Status { get; set; }
+		public string? Status { get; set; }
 		#region Selected
 		public abstract class selected : PX.Data.BQL.BqlBool.Field<selected> { }
 
@@ -22,8 +24,20 @@ namespace PX.Analyzers.Test.Sources
 			set;
 		}
 		#endregion
+		#region Amount
+		public abstract class amount : PX.Data.BQL.BqlDecimal.Field<amount> { }
+
+		[PXDBDecimal]
+		[PXUIField(DisplayName = "Customized Amount")]
+		public decimal? Amount                  // PX1065 should be reported here because the base property without a BQL field is declared in the extension 
+		{
+			get;
+			set;
+		}
+		#endregion
 	}
 
+	// Acuminator disable once PX1069 MissingMandatoryDacFields [Justification]
 	[PXHidden]
 	public class BaseDac : PXBqlTable, IBqlTable
 	{
@@ -35,6 +49,17 @@ namespace PX.Analyzers.Test.Sources
 		[PXInt]
 		public virtual int? ShipmentNbr { get; set; }
 
-		public virtual string ExtraData { get; set; }
+		public virtual string? ExtraData { get; set; }
+		#region Amount
+		public abstract class amount : PX.Data.BQL.BqlDecimal.Field<amount> { }
+
+		[PXDBDecimal]
+		[PXUIField(DisplayName = "Amount")]
+		public decimal? Amount              // PX1065 should be reported here because the property does not have a BQL field
+		{
+			get;
+			set;
+		}
+		#endregion
 	}
 }

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/NoBqlFieldForDacFieldProperty/Sources/MissingBqlField/DacExtensionWithBqlFieldMissingInExternalBaseDac.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/NoBqlFieldForDacFieldProperty/Sources/MissingBqlField/DacExtensionWithBqlFieldMissingInExternalBaseDac.cs
@@ -6,12 +6,23 @@ using ExternalDependency.NoBqlFieldForDacFieldProperty;
 
 namespace PX.Analyzers.Test.Sources
 {
+	/// <exclude/>
 	// Acuminator disable once PX1016 ExtensionDoesNotDeclareIsActiveMethod extension should be constantly active
 	[PXHidden]
-	public sealed class DacExtensionOnExternalDac : PXCacheExtension<BaseDacWithoutBqlField>
+	public sealed class DacExtensionOnExternalDac : PXCacheExtension<BaseDacWithoutBqlField>    // No PX1065 should be reported here because ShipmentNbr is not declared in the extension
 	{
 		[PXString]
 		[PXUIField(DisplayName = "Status")]
-		public string Status { get; set; }
+		public string? Status { get; set; }
+
+		#region Amount
+		[PXDBDecimal]
+		[PXUIField(DisplayName = "Customized Amount")]
+		public decimal? Amount                  // PX1065 should be reported here because the base property without a BQL field is declared in the extension 
+		{
+			get;
+			set;
+		}
+		#endregion
 	}
 }

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/NoBqlFieldForDacFieldProperty/Sources/MissingBqlField/DacWithBqlFieldMissingInBaseDac.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/NoBqlFieldForDacFieldProperty/Sources/MissingBqlField/DacWithBqlFieldMissingInBaseDac.cs
@@ -4,14 +4,27 @@ using PX.Data;
 
 namespace PX.Analyzers.Test.Sources
 {
+#pragma warning disable CS0108 // Member hides inherited member; missing new keyword
+	// Acuminator disable once PX1069 MissingMandatoryDacFields [Justification]
 	[PXHidden]
-	public class DerivedDac : BaseDac
+	public class DerivedDac : BaseDac             // PX1065 for ShipmentNbr should not be reported here because it is not declared in the extension
 	{
 		[PXString]
 		[PXUIField(DisplayName = "Status")]
-		public string Status { get; set; }
+		public string? Status { get; set; }
+
+		#region Amount
+		[PXDBDecimal]
+		[PXUIField(DisplayName = "Customized Amount")]
+		public override decimal? Amount                  // PX1065 should be reported here because the base property without a BQL field is declared in the extension 
+		{
+			get;
+			set;
+		}
+		#endregion
 	}
 
+	// Acuminator disable once PX1069 MissingMandatoryDacFields [Justification]
 	[PXHidden]
 	public class BaseDac : PXBqlTable, IBqlTable
 	{
@@ -22,6 +35,17 @@ namespace PX.Analyzers.Test.Sources
 		[PXInt]
 		public virtual int? ShipmentNbr { get; set; }
 
-		public virtual string ExtraData { get; set; }
+		public virtual string? ExtraData { get; set; }
+
+		#region Amount
+		[PXDBDecimal]
+		[PXUIField(DisplayName = "Amount")]
+		public virtual decimal? Amount              // PX1065 should be reported here because the property does not have a BQL field
+		{
+			get;
+			set;
+		}
+		#endregion
 	}
+#pragma warning restore CS0108 // Member hides inherited member; missing new keyword
 }

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/NoBqlFieldForDacFieldProperty/Sources/MissingBqlField/DacWithBqlFieldMissingInBaseDac_Expected.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/NoBqlFieldForDacFieldProperty/Sources/MissingBqlField/DacWithBqlFieldMissingInBaseDac_Expected.cs
@@ -4,14 +4,28 @@ using PX.Data;
 
 namespace PX.Analyzers.Test.Sources
 {
+#pragma warning disable CS0108 // Member hides inherited member; missing new keyword
+	// Acuminator disable once PX1069 MissingMandatoryDacFields [Justification]
 	[PXHidden]
-	public class DerivedDac : BaseDac
+	public class DerivedDac : BaseDac             // PX1065 for ShipmentNbr should not be reported here because it is not declared in the extension
 	{
 		[PXString]
 		[PXUIField(DisplayName = "Status")]
-		public string Status { get; set; }
+		public string? Status { get; set; }
+		#region Amount
+		public abstract class amount : PX.Data.BQL.BqlDecimal.Field<amount> { }
+
+		[PXDBDecimal]
+		[PXUIField(DisplayName = "Customized Amount")]
+		public override decimal? Amount                  // PX1065 should be reported here because the base property without a BQL field is declared in the extension 
+		{
+			get;
+			set;
+		}
+		#endregion
 	}
 
+	// Acuminator disable once PX1069 MissingMandatoryDacFields [Justification]
 	[PXHidden]
 	public class BaseDac : PXBqlTable, IBqlTable
 	{
@@ -23,6 +37,18 @@ namespace PX.Analyzers.Test.Sources
 		[PXInt]
 		public virtual int? ShipmentNbr { get; set; }
 
-		public virtual string ExtraData { get; set; }
+		public virtual string? ExtraData { get; set; }
+		#region Amount
+		public abstract class amount : PX.Data.BQL.BqlDecimal.Field<amount> { }
+
+		[PXDBDecimal]
+		[PXUIField(DisplayName = "Amount")]
+		public virtual decimal? Amount              // PX1065 should be reported here because the property does not have a BQL field
+		{
+			get;
+			set;
+		}
+		#endregion
 	}
+#pragma warning restore CS0108 // Member hides inherited member; missing new keyword
 }

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/NoBqlFieldForDacFieldProperty/Sources/MissingBqlField/DacWithBqlFieldMissingInExternalBaseDac.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/NoBqlFieldForDacFieldProperty/Sources/MissingBqlField/DacWithBqlFieldMissingInExternalBaseDac.cs
@@ -4,6 +4,7 @@ using PX.Data;
 
 namespace PX.Analyzers.Test.Sources
 {
+	// Acuminator disable once PX1069 MissingMandatoryDacFields [Justification]
 	[PXHidden]
 	public class DerivedDac : ExternalDependency.NoBqlFieldForDacFieldProperty.BaseDacWithoutBqlField
 	{
@@ -13,6 +14,16 @@ namespace PX.Analyzers.Test.Sources
 
 		[PXString]
 		[PXUIField(DisplayName = "Status")]
-		public string Status { get; set; }
+		public string? Status { get; set; }
+
+		#region Amount
+		[PXDBDecimal]
+		[PXUIField(DisplayName = "Customized Amount")]
+		public decimal? Amount                  // PX1065 should be reported here because the base property without a BQL field is declared in the extension 
+		{
+			get;
+			set;
+		}
+		#endregion
 	}
 }


### PR DESCRIPTION
## Changes Overview
- removed reporting of PX1065 for DAC properties from base DACs
- fixed code fix registration logic for PX1065
- updated unit tests for PX1065 for scenarios when property without a BQL field is in base DACs
- updated PX1065 and PX1080 docs