### PR TITLE
Feature/atr 944 dev add diagnostic to forbid px namespaces

### DIFF
--- a/docs/Summary.md
+++ b/docs/Summary.md
@@ -48,7 +48,7 @@ Acuminator does not perform static analysis of projects whose names contain `Tes
 | [PX1036](diagnostics/PX1036.md) | The DAC must have one primary key which should be named `PK`. The class containing DAC foreign keys should be named `FK`. The single unique key in the DAC should be named `UK`. All unique keys in the DAC should be declared in a public static class named `UK`.  | Warning (ISV Level 3: Informational) | Available | 
 | [PX1037](diagnostics/PX1037.md) | An unbound DAC field cannot be used in a key declaration. | Error (ISV Level 3: Informational) | Unavailable | 
 | [PX1038](diagnostics/PX1038.md) | Async void methods, lambdas, and anonymous methods should not be used with the Acumatica Framework. | Error | Unavailable | 
-| [PX1039](diagnostics/PX1039.md) | The use of the `PX` namespace and its sub-namespaces is prohibited. They are reserved for use by Acumatica. | Warning | Unavailable | 
+| [PX1039](diagnostics/PX1039.md) | The use of the `PX` namespace and its sub-namespaces is prohibited. These namespaces are reserved for use by Acumatica. | Warning | Unavailable | 
 | [PX1040](diagnostics/PX1040.md) | Instance constructors in BLC extensions are strictly prohibited. You should use the `Initialize()` method instead. | Error | Available |
 | [PX1041](diagnostics/PX1041.md) | Classic graph event handlers which rely on naming conventions can be converted to generic graph event handlers which have a strongly typed generic signature. | Information | Available |
 | [PX1042](diagnostics/PX1042.md) | In a `RowSelecting` handler, BQL statements and other database queries must be executed only inside a separate connection scope. In Acumatica ERP 2023 R1 and later versions, this diagnostic is disabled. | Error | Available |

--- a/docs/Summary.md
+++ b/docs/Summary.md
@@ -48,6 +48,7 @@ Acuminator does not perform static analysis of projects whose names contain `Tes
 | [PX1036](diagnostics/PX1036.md) | The DAC must have one primary key which should be named `PK`. The class containing DAC foreign keys should be named `FK`. The single unique key in the DAC should be named `UK`. All unique keys in the DAC should be declared in a public static class named `UK`.  | Warning (ISV Level 3: Informational) | Available | 
 | [PX1037](diagnostics/PX1037.md) | An unbound DAC field cannot be used in a key declaration. | Error (ISV Level 3: Informational) | Unavailable | 
 | [PX1038](diagnostics/PX1038.md) | Async void methods, lambdas, and anonymous methods should not be used with the Acumatica Framework. | Error | Unavailable | 
+| [PX1039](diagnostics/PX1039.md) | The use of the `PX` namespace and its sub-namespaces is prohibited. They are reserved for use by Acumatica. | Warning | Unavailable | 
 | [PX1040](diagnostics/PX1040.md) | Instance constructors in BLC extensions are strictly prohibited. You should use the `Initialize()` method instead. | Error | Available |
 | [PX1041](diagnostics/PX1041.md) | Classic graph event handlers which rely on naming conventions can be converted to generic graph event handlers which have a strongly typed generic signature. | Information | Available |
 | [PX1042](diagnostics/PX1042.md) | In a `RowSelecting` handler, BQL statements and other database queries must be executed only inside a separate connection scope. In Acumatica ERP 2023 R1 and later versions, this diagnostic is disabled. | Error | Available |

--- a/docs/diagnostics/PX1039.md
+++ b/docs/diagnostics/PX1039.md
@@ -13,7 +13,7 @@ The `PX` namespace and all its sub-namespaces (such as `PX.Data`, `PX.Objects`, 
 must not declare custom namespaces that start with `PX` or create types within these reserved namespaces. Using the reserved `PX` namespace hierarchy can lead to naming conflicts with current or future 
 Acumatica Framework types.
 
-The PX1039 diagnostic validates namespace declarations and reports an error if any of the following conditions are met:
+The PX1039 diagnostic validates namespace declarations and reports a warning if any of the following conditions are met:
 - The namespace is exactly `PX` (case-insensitive)
 - The namespace starts with `PX.` (case-insensitive), such as `PX.CustomModule`, `PX.Extensions`, etc.
 

--- a/docs/diagnostics/PX1039.md
+++ b/docs/diagnostics/PX1039.md
@@ -5,17 +5,17 @@ This document describes the PX1039 diagnostic.
 
 | Code   | Short Description                                                                                           |  Type   | Code Fix    | 
 | ------ | ------------------------------------------------------------------------------------------------------------| ------- | ----------- | 
-| PX1039 | The use of the `PX` namespace and its sub-namespaces is prohibited. They are reserved for use by Acumatica. | Warning | Unavailable | 
+| PX1039 | The use of the `PX` namespace and its sub-namespaces is prohibited. These namespaces are reserved for use by Acumatica. | Warning | Unavailable | 
 
 ## Diagnostic Description
 
-The `PX` namespace and all its sub-namespaces (such as `PX.Data`, `PX.Objects`, `PX.Common`, etc.) are reserved exclusively for use by the Acumatica Framework. Independent Software Vendors (ISVs) and partners 
-must not declare custom namespaces that start with `PX` or create types within these reserved namespaces. Using the reserved `PX` namespace hierarchy can lead to naming conflicts with current or future 
+The `PX` namespace and all its sub-namespaces (such as `PX.Data`, `PX.Objects`, `PX.Common`) are reserved exclusively for use by the Acumatica Framework. Independent Software Vendors (ISVs) and partners 
+must not declare custom namespaces that start with `PX` or create types within these reserved namespaces. Using the reserved `PX` namespace hierarchy can lead to naming conflicts with the current or future 
 Acumatica Framework types.
 
 The PX1039 diagnostic validates namespace declarations and reports a warning if any of the following conditions are met:
-- The namespace is exactly `PX` (case-insensitive)
-- The namespace starts with `PX.` (case-insensitive), such as `PX.CustomModule`, `PX.Extensions`, etc.
+- The namespace is exactly `PX` (case-insensitive).
+- The namespace starts with `PX.` (case-insensitive), such as `PX.CustomModule` or `PX.Extensions`.
 
 The PX1039 diagnostic is designed to be used by ISVs, OEMs, partners, and other external developers. It is active only when the **ISV Mode** is enabled in Acuminator settings in Visual Studio options 
 (`Tools > Options > Acuminator > General > Enable additional diagnostics for ISV Solution Certification`).

--- a/docs/diagnostics/PX1039.md
+++ b/docs/diagnostics/PX1039.md
@@ -1,0 +1,68 @@
+# PX1039
+This document describes the PX1039 diagnostic.
+
+## Summary
+
+| Code   | Short Description                                                                                           |  Type   | Code Fix    | 
+| ------ | ------------------------------------------------------------------------------------------------------------| ------- | ----------- | 
+| PX1039 | The use of the `PX` namespace and its sub-namespaces is prohibited. They are reserved for use by Acumatica. | Warning | Unavailable | 
+
+## Diagnostic Description
+
+The `PX` namespace and all its sub-namespaces (such as `PX.Data`, `PX.Objects`, `PX.Common`, etc.) are reserved exclusively for use by the Acumatica Framework. Independent Software Vendors (ISVs) and partners 
+must not declare custom namespaces that start with `PX` or create types within these reserved namespaces. Using the reserved `PX` namespace hierarchy can lead to naming conflicts with current or future 
+Acumatica Framework types.
+
+The PX1039 diagnostic validates namespace declarations and reports an error if any of the following conditions are met:
+- The namespace is exactly `PX` (case-insensitive)
+- The namespace starts with `PX.` (case-insensitive), such as `PX.CustomModule`, `PX.Extensions`, etc.
+
+The PX1039 diagnostic is designed to be used by ISVs, OEMs, partners, and other external developers. It is active only when the **ISV Mode** is enabled in Acuminator settings in Visual Studio options 
+(`Tools > Options > Acuminator > General > Enable additional diagnostics for ISV Solution Certification`).
+
+## Example of Incorrect Code
+
+### Regular Namespace Declarations
+
+```C#
+using System;
+using PX.Data;
+
+namespace PX						// Error: Direct use of the reserved PX namespace
+{
+	public class CustomOrderEntry : PXGraph<CustomOrderEntry>
+	{
+		// Custom implementation
+	}
+
+	namespace CustomModule			// Error: Nested namespace is still within the reserved PX namespace
+	{
+		public class CustomEntry : PXGraph<CustomEntry>
+		{
+			// Custom implementation
+		}
+	}
+}
+
+namespace PX.SomeOtherNamespace		// Error: Use of PX as a prefix for a sub-namespace
+{
+	public class SomeOrderEntry : PXGraph<SomeOrderEntry>
+	{
+		// Custom implementation
+	}
+}
+```
+
+### File-Scoped Namespace Declaration (C# 10+)
+
+```C#
+using System;
+using PX.Data;
+
+namespace PX.SomeModule;		// Error: File-scoped namespace using the reserved PX namespace
+
+public class CustomOrderEntry : PXGraph<CustomOrderEntry>
+{
+	// Custom implementation
+}
+```

--- a/src/Acuminator/Acuminator.Analyzers/DiagnosticsShortName.Designer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/DiagnosticsShortName.Designer.cs
@@ -475,6 +475,15 @@ namespace Acuminator.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to UseOfNamespaceReservedByAcumatica.
+        /// </summary>
+        public static string PX1039 {
+            get {
+                return ResourceManager.GetString("PX1039", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to ConstructorInGraphExtension.
         /// </summary>
         public static string PX1040 {

--- a/src/Acuminator/Acuminator.Analyzers/DiagnosticsShortName.resx
+++ b/src/Acuminator/Acuminator.Analyzers/DiagnosticsShortName.resx
@@ -255,6 +255,9 @@
   <data name="PX1038" xml:space="preserve">
     <value>AsyncVoidMethodsAndLambdas</value>
   </data>
+  <data name="PX1039" xml:space="preserve">
+    <value>UseOfNamespaceReservedByAcumatica</value>
+  </data>
   <data name="PX1040" xml:space="preserve">
     <value>ConstructorInGraphExtension</value>
   </data>

--- a/src/Acuminator/Acuminator.Analyzers/Resources.Designer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/Resources.Designer.cs
@@ -1042,7 +1042,7 @@ namespace Acuminator.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The use of the PX namespace is prohibited. This namespace is reserved for use only by Acumatica..
+        ///   Looks up a localized string similar to The use of the PX namespace is prohibited. This namespace is reserved for use by Acumatica..
         /// </summary>
         public static string PX1039Title {
             get {

--- a/src/Acuminator/Acuminator.Analyzers/Resources.Designer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/Resources.Designer.cs
@@ -1042,6 +1042,15 @@ namespace Acuminator.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The use of the PX namespace is prohibited. This namespace is reserved for use only by Acumatica..
+        /// </summary>
+        public static string PX1039Title {
+            get {
+                return ResourceManager.GetString("PX1039Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Move the code to the Initialize() method.
         /// </summary>
         public static string PX1040Fix {

--- a/src/Acuminator/Acuminator.Analyzers/Resources.resx
+++ b/src/Acuminator/Acuminator.Analyzers/Resources.resx
@@ -451,7 +451,7 @@ public virtual int? SomeDacField{ get; set; }</value>
     <value>Async void methods are forbidden in Acumatica Framework</value>
   </data>
   <data name="PX1039Title" xml:space="preserve">
-    <value>The use of the PX namespace is prohibited. This namespace is reserved for use only by Acumatica.</value>
+    <value>The use of the PX namespace is prohibited. This namespace is reserved for use by Acumatica.</value>
   </data>
   <data name="PX1040Fix" xml:space="preserve">
     <value>Move the code to the Initialize() method</value>

--- a/src/Acuminator/Acuminator.Analyzers/Resources.resx
+++ b/src/Acuminator/Acuminator.Analyzers/Resources.resx
@@ -450,6 +450,9 @@ public virtual int? SomeDacField{ get; set; }</value>
   <data name="PX1038TitleMethods" xml:space="preserve">
     <value>Async void methods are forbidden in Acumatica Framework</value>
   </data>
+  <data name="PX1039Title" xml:space="preserve">
+    <value>The use of the PX namespace is prohibited. This namespace is reserved for use only by Acumatica.</value>
+  </data>
   <data name="PX1040Fix" xml:space="preserve">
     <value>Move the code to the Initialize() method</value>
   </data>

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/Descriptors.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/Descriptors.cs
@@ -257,6 +257,10 @@ namespace Acuminator.Analyzers.StaticAnalysis
 			Rule("PX1038", nameof(Resources.PX1038TitleLambdas).GetLocalized(), Category.Acuminator, DiagnosticSeverity.Error,
 				DiagnosticsShortName.PX1038);
 
+		public static DiagnosticDescriptor PX1039_UseOfNamespaceReservedByAcumatica { get; } =
+			Rule("PX1039", nameof(Resources.PX1039Title).GetLocalized(), Category.Acuminator, DiagnosticSeverity.Warning,
+				DiagnosticsShortName.PX1039);
+
 		public static DiagnosticDescriptor PX1040_ConstructorInGraphExtension { get; } =
 			Rule("PX1040", nameof(Resources.PX1040Title).GetLocalized(), Category.Acuminator, DiagnosticSeverity.Error,
 				DiagnosticsShortName.PX1040);

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/UseOfNamespaceReservedByAcumatica/UseOfNamespaceReservedByAcumaticaAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/UseOfNamespaceReservedByAcumatica/UseOfNamespaceReservedByAcumaticaAnalyzer.cs
@@ -1,9 +1,12 @@
-﻿using System.Collections.Immutable;
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 
 using Acuminator.Utilities;
 using Acuminator.Utilities.Common;
 using Acuminator.Utilities.DiagnosticSuppression;
+using Acuminator.Utilities.Roslyn.Constants;
 using Acuminator.Utilities.Roslyn.Semantic;
 using Acuminator.Utilities.Roslyn.Syntax;
 
@@ -47,10 +50,16 @@ public class UseOfNamespaceReservedByAcumaticaAnalyzer : PXDiagnosticAnalyzer
 	{
 		syntaxContext.CancellationToken.ThrowIfCancellationRequested();
 		
-		if (IsAcumaticaNamespaceUsed(pxContext, syntaxContext.Node))
+		var namespaceNameNode = GetNamespaceNameNodeToCheck(syntaxContext.Node);
+		string? namespaceName = namespaceNameNode?.ToString().NullIfWhiteSpace();
+
+		if (namespaceName.IsNullOrWhiteSpace())
+			return;
+
+		if (namespaceName.Equals(NamespaceNames.AcumaticaRootNamespace, StringComparison.OrdinalIgnoreCase) ||
+			namespaceName.StartsWith(NamespaceNames.AcumaticaRootNamespaceWithDot, StringComparison.OrdinalIgnoreCase))
 		{
-			var identifier = syntaxContext.Node.ChildNodes().OfType<QualifiedNameSyntax>().FirstOrDefault<SyntaxNode>() ??
-							 syntaxContext.Node.ChildNodes().OfType<IdentifierNameSyntax>().FirstOrDefault<SyntaxNode>();
+			var identifier = syntaxContext.Node.ChildNodes().OfType<NameSyntax>().FirstOrDefault();
 			var location = identifier?.GetLocation();
 
 			syntaxContext.ReportDiagnosticWithSuppressionCheck(
@@ -59,17 +68,31 @@ public class UseOfNamespaceReservedByAcumaticaAnalyzer : PXDiagnosticAnalyzer
 		}
 	}
 
-	private bool IsAcumaticaNamespaceUsed(PXContext pxContext, SyntaxNode nodeToCheck)
+	private NameSyntax? GetNamespaceNameNodeToCheck(SyntaxNode nodeToCheck)
 	{
 		if (nodeToCheck is NamespaceDeclarationSyntax namespaceDeclaration)
 		{
-			bool hasContainingNamespaces = namespaceDeclaration.Con
+			var containingNamespaces = namespaceDeclaration.GetContainingNamespaces()
+														   .ToList(capacity: 4);
+			if (containingNamespaces.Count == 0)
+				return namespaceDeclaration.Name;
+			else
+			{
+				var outmostNamespace = containingNamespaces[^1];
+				return outmostNamespace is NamespaceDeclarationSyntax outmostNamespaceDeclaration
+					? outmostNamespaceDeclaration.Name
+					: outmostNamespace.ChildNodes()
+									  .OfType<NameSyntax>()
+									  .FirstOrDefault();
+			}
 		}
 		else if (nodeToCheck.RawKind == SharedConstants.FileScopedNamespaceDeclarationKind)
 		{
-
+			return nodeToCheck.ChildNodes()
+							  .OfType<NameSyntax>()
+							  .FirstOrDefault();
 		}
 		else
-			return false;
+			return null;
 	}
 }

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/UseOfNamespaceReservedByAcumatica/UseOfNamespaceReservedByAcumaticaAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/UseOfNamespaceReservedByAcumatica/UseOfNamespaceReservedByAcumaticaAnalyzer.cs
@@ -1,0 +1,75 @@
+﻿using System.Collections.Immutable;
+using System.Linq;
+
+using Acuminator.Utilities;
+using Acuminator.Utilities.Common;
+using Acuminator.Utilities.DiagnosticSuppression;
+using Acuminator.Utilities.Roslyn.Semantic;
+using Acuminator.Utilities.Roslyn.Syntax;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Acuminator.Analyzers.StaticAnalysis.UseOfNamespaceReservedByAcumatica;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class UseOfNamespaceReservedByAcumaticaAnalyzer : PXDiagnosticAnalyzer
+{
+	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+		ImmutableArray.Create
+		(
+			Descriptors.PX1039_UseOfNamespaceReservedByAcumatica
+		);
+
+	public UseOfNamespaceReservedByAcumaticaAnalyzer() : base() { }
+
+	/// <summary>
+	/// Constructor accepting code analysis settings for tests.
+	/// </summary>
+	/// <param name="codeAnalysisSettings">The code analysis settings.</param>
+	public UseOfNamespaceReservedByAcumaticaAnalyzer(CodeAnalysisSettings codeAnalysisSettings) : base(codeAnalysisSettings)
+	{
+	}
+
+	protected override bool ShouldAnalyze(PXContext pxContext) => 
+		base.ShouldAnalyze(pxContext) && pxContext.CodeAnalysisSettings.IsvSpecificAnalyzersEnabled;
+
+	protected override void AnalyzeCompilation(CompilationStartAnalysisContext compilationStartContext, PXContext pxContext)
+	{
+		var fileScopedNamespaceDeclaration = (SyntaxKind)SharedConstants.FileScopedNamespaceDeclarationKind;
+		compilationStartContext.RegisterSyntaxNodeAction(syntaxContext => AnalyzeNamespaceDeclaration(syntaxContext, pxContext),
+														 SyntaxKind.NamespaceDeclaration, fileScopedNamespaceDeclaration);
+	}
+
+	private void AnalyzeNamespaceDeclaration(SyntaxNodeAnalysisContext syntaxContext, PXContext pxContext)
+	{
+		syntaxContext.CancellationToken.ThrowIfCancellationRequested();
+		
+		if (IsAcumaticaNamespaceUsed(pxContext, syntaxContext.Node))
+		{
+			var identifier = syntaxContext.Node.ChildNodes().OfType<QualifiedNameSyntax>().FirstOrDefault<SyntaxNode>() ??
+							 syntaxContext.Node.ChildNodes().OfType<IdentifierNameSyntax>().FirstOrDefault<SyntaxNode>();
+			var location = identifier?.GetLocation();
+
+			syntaxContext.ReportDiagnosticWithSuppressionCheck(
+				Diagnostic.Create(Descriptors.PX1039_UseOfNamespaceReservedByAcumatica, location),
+				pxContext.CodeAnalysisSettings);
+		}
+	}
+
+	private bool IsAcumaticaNamespaceUsed(PXContext pxContext, SyntaxNode nodeToCheck)
+	{
+		if (nodeToCheck is NamespaceDeclarationSyntax namespaceDeclaration)
+		{
+			bool hasContainingNamespaces = namespaceDeclaration.Con
+		}
+		else if (nodeToCheck.RawKind == SharedConstants.FileScopedNamespaceDeclarationKind)
+		{
+
+		}
+		else
+			return false;
+	}
+}

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/UseOfNamespaceReservedByAcumatica/Sources/CorrectFileScopedNamespaceDeclaration.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/UseOfNamespaceReservedByAcumatica/Sources/CorrectFileScopedNamespaceDeclaration.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections;
+using PX.Data;
+
+namespace GoodNamespace;
+
+public class POCustomOrderEntry : PXGraph<POCustomOrderEntry>
+{
+		
+}

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/UseOfNamespaceReservedByAcumatica/Sources/CorrectNamespaceDeclarations.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/UseOfNamespaceReservedByAcumatica/Sources/CorrectNamespaceDeclarations.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections;
+using PX.Data;
+
+namespace GoodNamespace
+{
+	public class POCustomOrderEntry : PXGraph<POCustomOrderEntry>
+    {
+		
+	}
+
+
+	namespace InnerNamespace
+	{
+		public class SomeOrderEntry : PXGraph<SomeOrderEntry>
+		{
+
+		}
+	}
+}

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/UseOfNamespaceReservedByAcumatica/Sources/InvalidFileScopedNamespaceDeclaration.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/UseOfNamespaceReservedByAcumatica/Sources/InvalidFileScopedNamespaceDeclaration.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections;
+using PX.Data;
+
+namespace PX.SomeModule;
+
+public class POCustomOrderEntry : PXGraph<POCustomOrderEntry>
+{
+		
+}

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/UseOfNamespaceReservedByAcumatica/Sources/InvalidNamespaceDeclarations.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/UseOfNamespaceReservedByAcumatica/Sources/InvalidNamespaceDeclarations.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections;
+using PX.Data;
+
+namespace PX
+{
+	public class POCustomOrderEntry : PXGraph<POCustomOrderEntry>
+    {
+		
+	}
+
+
+	namespace SomeNamespace
+	{
+		public class SomeOrderEntry : PXGraph<SomeOrderEntry>
+		{
+
+		}
+	}
+}
+
+
+namespace PX.SomeOtherNamespace
+{
+	public class SomeOrderEntry : PXGraph<SomeOrderEntry>
+	{
+
+	}
+}

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/UseOfNamespaceReservedByAcumatica/UseOfNamespaceReservedByAcumaticaTests_ISV.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/UseOfNamespaceReservedByAcumatica/UseOfNamespaceReservedByAcumaticaTests_ISV.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Threading.Tasks;
+
+using Acuminator.Analyzers.StaticAnalysis;
+using Acuminator.Analyzers.StaticAnalysis.UseOfNamespaceReservedByAcumatica;
+using Acuminator.Utilities;
+using Acuminator.Tests.Helpers;
+using Acuminator.Tests.Verification;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Xunit;
+
+namespace Acuminator.Tests.Tests.StaticAnalysis.UseOfNamespaceReservedByAcumatica
+{
+	public class UseOfNamespaceReservedByAcumaticaTests_ISV : DiagnosticVerifier
+	{
+		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer() =>
+			new UseOfNamespaceReservedByAcumaticaAnalyzer(
+							CodeAnalysisSettings.Default
+												.WithStaticAnalysisEnabled()
+												.WithSuppressionMechanismDisabled()
+												.WithIsvSpecificAnalyzersEnabled());
+
+		[Theory]
+		[EmbeddedFileData("InvalidFileScopedNamespaceDeclaration.cs")] 
+		public virtual Task Invalid_FileScoped_Namespace(string source) =>
+			VerifyCSharpDiagnosticAsync(source,
+				Descriptors.PX1039_UseOfNamespaceReservedByAcumatica.CreateFor(5, 11));
+
+		[Theory]
+		[EmbeddedFileData("InvalidNamespaceDeclarations.cs")]
+		public virtual Task Invalid_NestedNamespaces(string source) =>
+			VerifyCSharpDiagnosticAsync(source,
+				Descriptors.PX1039_UseOfNamespaceReservedByAcumatica.CreateFor(5, 11),
+				Descriptors.PX1039_UseOfNamespaceReservedByAcumatica.CreateFor(13, 12),
+				Descriptors.PX1039_UseOfNamespaceReservedByAcumatica.CreateFor(23, 11));
+
+		[Theory]
+		[EmbeddedFileData("CorrectFileScopedNamespaceDeclaration.cs")]
+		public virtual Task Correct_FileScoped_Namespace(string source) =>
+			VerifyCSharpDiagnosticAsync(source);
+
+		[Theory]
+		[EmbeddedFileData("CorrectNamespaceDeclarations.cs")]
+		public virtual Task Correct_NestedNamespaces(string source) =>
+			VerifyCSharpDiagnosticAsync(source);
+	}
+}

--- a/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/UseOfNamespaceReservedByAcumatica/UseOfNamespaceReservedByAcumaticaTests_NonISV.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/StaticAnalysis/UseOfNamespaceReservedByAcumatica/UseOfNamespaceReservedByAcumaticaTests_NonISV.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Threading.Tasks;
+
+using Acuminator.Analyzers.StaticAnalysis;
+using Acuminator.Analyzers.StaticAnalysis.UseOfNamespaceReservedByAcumatica;
+using Acuminator.Utilities;
+using Acuminator.Tests.Helpers;
+using Acuminator.Tests.Verification;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Xunit;
+
+namespace Acuminator.Tests.Tests.StaticAnalysis.UseOfNamespaceReservedByAcumatica
+{
+	public class UseOfNamespaceReservedByAcumaticaTests_NonISV : DiagnosticVerifier
+	{
+		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer() =>
+			new UseOfNamespaceReservedByAcumaticaAnalyzer(
+							CodeAnalysisSettings.Default
+												.WithStaticAnalysisEnabled()
+												.WithSuppressionMechanismDisabled()
+												.WithIsvSpecificAnalyzersDisabled());
+
+		[Theory]
+		[EmbeddedFileData("InvalidFileScopedNamespaceDeclaration.cs")] 
+		public virtual Task Invalid_FileScoped_Namespace(string source) =>
+			VerifyCSharpDiagnosticAsync(source);
+
+		[Theory]
+		[EmbeddedFileData("InvalidNamespaceDeclarations.cs")]
+		public virtual Task Invalid_NestedNamespaces(string source) =>
+			VerifyCSharpDiagnosticAsync(source);
+
+		[Theory]
+		[EmbeddedFileData("CorrectFileScopedNamespaceDeclaration.cs")]
+		public virtual Task Correct_FileScoped_Namespace(string source) =>
+			VerifyCSharpDiagnosticAsync(source);
+
+		[Theory]
+		[EmbeddedFileData("CorrectNamespaceDeclarations.cs")]
+		public virtual Task Correct_NestedNamespaces(string source) =>
+			VerifyCSharpDiagnosticAsync(source);
+	}
+}

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Syntax/SyntaxTreeUtils.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Syntax/SyntaxTreeUtils.cs
@@ -1,8 +1,10 @@
-﻿#nullable enable
-
+﻿using System.Collections.Generic;
 using System.Runtime.CompilerServices;
+
 using Acuminator.Utilities.Common;
+
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Acuminator.Utilities.Roslyn.Syntax
 {
@@ -184,6 +186,29 @@ namespace Acuminator.Utilities.Roslyn.Syntax
 			}
 
 			return currentX;
+		}
+
+		/// <summary>
+		/// Get the syntax nodes representing the namespaces containing the <paramref name="node"/>.
+		/// </summary>
+		/// <param name="node">The node to act on.</param>
+		/// <returns/>
+		public static IEnumerable<SyntaxNode> GetContainingNamespaces(this SyntaxNode node) =>
+			GetContainingNamespacesImpl(node.CheckIfNull(), includeThis: false);
+
+		private static IEnumerable<SyntaxNode> GetContainingNamespacesImpl(SyntaxNode node, bool includeThis)
+		{
+			var currentNode = includeThis
+				? node
+				: node.Parent;
+			
+			while (currentNode != null)
+			{
+				if (currentNode is NamespaceDeclarationSyntax || currentNode.RawKind == SharedConstants.FileScopedNamespaceDeclarationKind)
+					yield return currentNode;
+
+				currentNode = currentNode.Parent;
+			}
 		}
 	}
 }

--- a/src/Acuminator/Acuminator.Utilities/SharedConstants.cs
+++ b/src/Acuminator/Acuminator.Utilities/SharedConstants.cs
@@ -28,7 +28,7 @@ namespace Acuminator
 		public const string SuppressionFileXmlSchemaFileName = "SuppressionFileSchema.xsd";
 
 		/// <summary>
-		/// The file scoped namespace declaration syntax kind. The version of Roslyn ued by Acuminator is too old to have this in the SyntaxKind enum.
+		/// The file scoped namespace declaration syntax kind. The version of Roslyn used by Acuminator is too old to have this in the SyntaxKind enum.
 		/// </summary>
 		/// <remarks>
 		/// TODO fix after upgrading to a newer Roslyn version. 

--- a/src/Acuminator/Acuminator.Utilities/SharedConstants.cs
+++ b/src/Acuminator/Acuminator.Utilities/SharedConstants.cs
@@ -26,5 +26,13 @@ namespace Acuminator
 		/// Filename of the suppression file XML schema.
 		/// </summary>
 		public const string SuppressionFileXmlSchemaFileName = "SuppressionFileSchema.xsd";
+
+		/// <summary>
+		/// The file scoped namespace declaration syntax kind. The version of Roslyn ued by Acuminator is too old to have this in the SyntaxKind enum.
+		/// </summary>
+		/// <remarks>
+		/// TODO fix after upgrading to a newer Roslyn version. 
+		/// </remarks>
+		public const int FileScopedNamespaceDeclarationKind = 8845;
 	}
 }


### PR DESCRIPTION
## Changes Overview
- Implemented new simple diagnostic to forbid the use of `PX` namespace and its sub-namespaces
- Added helper to get namespace nodes containing the given syntax node
- Implemented unit tests for PX1039
- Added documentation for PX1039