### PR TITLE
ATR-955: Added severity to the output

### DIFF
--- a/src/Acuminator/Acuminator.Runner.NetFramework/Output/Data/Line.cs
+++ b/src/Acuminator/Acuminator.Runner.NetFramework/Output/Data/Line.cs
@@ -28,6 +28,15 @@ namespace Acuminator.Runner.Output.Data
 			Spans = [span1, span2, span3];
 		}
 
+		public Line(string severity, string idPart1, string messagePart, string locationPart)
+		{
+			var span1 = new LineSpan(severity.CheckIfNull());
+			var span2 = new LineSpan(idPart1.CheckIfNull());
+			var span3 = new LineSpan(messagePart.CheckIfNull());
+			var span4 = new LineSpan(locationPart.CheckIfNull());
+			Spans = [span1, span2, span3, span4];
+		}
+
 		public Line(IReadOnlyCollection<string> spans)
         {
 			Spans = spans.CheckIfNull()
@@ -41,6 +50,7 @@ namespace Acuminator.Runner.Output.Data
 			1 => Spans[0].ToString(),
 			2 => $"{Spans[0].ToString()} {Spans[1].ToString()}",
 			3 => $"{Spans[0].ToString()} {Spans[1].ToString()} {Spans[2].ToString()}",
+			4 => $"{Spans[0].ToString()} {Spans[1].ToString()} {Spans[2].ToString()} {Spans[3].ToString()}",
 			_ => string.Join(" ", Spans)
 		};
 

--- a/src/Acuminator/Acuminator.Runner.NetFramework/Output/Grouping/Base/GroupLinesBase.cs
+++ b/src/Acuminator/Acuminator.Runner.NetFramework/Output/Grouping/Base/GroupLinesBase.cs
@@ -55,7 +55,7 @@ namespace Acuminator.Runner.Output.Grouping
 																		   Location: GetPrettyLocation(d, projectDirectory, analysisContext)));
 
 			var sortedDiagnosticInfos = GetSortedDiagnosticInfos(sortByDiagnosticId, sortBySourceFile, unsortedDiagnosticInfos);
-			var reportLines	= sortedDiagnosticInfos.Select(d  => new Line(d.Diagnostic.Id, d.Message, d.Location));
+			var reportLines	= sortedDiagnosticInfos.Select(d  => new Line(d.Diagnostic.Severity.ToString(), d.Diagnostic.Id, d.Message, d.Location));
 
 			return reportLines;
 		}

--- a/src/Acuminator/Acuminator.Runner.NetFramework/Output/Json/Converters/LineConverter.cs
+++ b/src/Acuminator/Acuminator.Runner.NetFramework/Output/Json/Converters/LineConverter.cs
@@ -14,6 +14,8 @@ namespace Acuminator.Runner.Output.Json
 	/// </summary>
 	internal class LineConverter : JsonConverter<Line>
 	{
+		protected const string LinePartsSeparator = ": ";
+		protected const string SeverityTemplate = "[{0}] ";
 		public override Line Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) =>
 			throw new NotSupportedException();
 
@@ -35,7 +37,15 @@ namespace Acuminator.Runner.Output.Json
 					{
 						var (diagnosticId, diagnosticMessage, location) = (line.Spans[0].ToString(), line.Spans[1].ToString(), line.Spans[2].ToString());
 
-						writer.WriteStringValue($"{diagnosticId}: {diagnosticMessage}: {location}");
+						writer.WriteStringValue($"{diagnosticId}{LinePartsSeparator}{diagnosticMessage}{LinePartsSeparator}{location}");
+						return;
+					}
+
+				case 4:
+					{
+						var (severity, diagnosticId, diagnosticMessage, location) = (line.Spans[0].ToString(), line.Spans[1].ToString(), line.Spans[2].ToString(), line.Spans[3].ToString());
+
+						writer.WriteStringValue($"{string.Format(SeverityTemplate,severity)}{diagnosticId}{LinePartsSeparator}{diagnosticMessage}{LinePartsSeparator}{location}");
 						return;
 					}
 

--- a/src/Acuminator/Acuminator.Runner.NetFramework/Output/PlainText/PlainTextReportOutputterBase.cs
+++ b/src/Acuminator/Acuminator.Runner.NetFramework/Output/PlainText/PlainTextReportOutputterBase.cs
@@ -18,6 +18,10 @@ namespace Acuminator.Runner.Output.PlainText
 	internal abstract class PlainTextReportOutputterBase : IReportOutputter
 	{
 		protected const string LinePartsSeparator = ": ";
+		protected const string SeverityTemplate = "[{0}] ";
+		protected const string SeverityError = "Error";
+		protected const string SeverityWarning = "Warning";
+		protected const string SeverityInfo = "Info";
 
 		public abstract void Dispose();
 

--- a/src/Acuminator/Acuminator.Runner.NetFramework/Output/PlainText/PlainTextReportOutputterBase.cs
+++ b/src/Acuminator/Acuminator.Runner.NetFramework/Output/PlainText/PlainTextReportOutputterBase.cs
@@ -19,9 +19,9 @@ namespace Acuminator.Runner.Output.PlainText
 	{
 		protected const string LinePartsSeparator = ": ";
 		protected const string SeverityTemplate = "[{0}] ";
-		protected const string SeverityError = "Error";
-		protected const string SeverityWarning = "Warning";
-		protected const string SeverityInfo = "Info";
+		protected const string SeverityError = "ERROR";
+		protected const string SeverityWarning = "WARNING";
+		protected const string SeverityInfo = "INFO";
 
 		public abstract void Dispose();
 

--- a/src/Acuminator/Acuminator.Runner.NetFramework/Output/PlainText/PlainTextReportOutputterConsole.cs
+++ b/src/Acuminator/Acuminator.Runner.NetFramework/Output/PlainText/PlainTextReportOutputterConsole.cs
@@ -60,7 +60,12 @@ namespace Acuminator.Runner.Output.PlainText
 												diagnosticMessage: line.Spans[1].ToString(),
 												location: line.Spans[2].ToString());
 					return;
-					
+				case 4:
+					WriteDiagnosticWithLocation(indentationLevel, diagnosticId: line.Spans[1].ToString(),
+												diagnosticMessage: line.Spans[2].ToString(),
+												location: line.Spans[3].ToString(),
+												severity: line.Spans[0].ToString());
+					return;
 				case 1:
 				default:
 					string padding = GetPadding(indentationLevel);
@@ -69,12 +74,18 @@ namespace Acuminator.Runner.Output.PlainText
 			}
 		}
 
-		private void WriteDiagnosticWithLocation(int indentationLevel, string diagnosticId, string diagnosticMessage, string location)
+		private void WriteDiagnosticWithLocation(int indentationLevel, string diagnosticId, string diagnosticMessage, string location, string? severity = null)
 		{ 
 			string padding = GetPadding(indentationLevel);
 			var oldColor   = Console.ForegroundColor;
 
-			WriteStringPartWithColor(padding + diagnosticId, ConsoleColor.White);
+			Console.Write(padding);
+			if (!string.IsNullOrEmpty(severity))
+			{
+				WriteStringPartWithColor(String.Format(SeverityTemplate, severity), GetSeverityColor(severity!));
+			}
+
+			WriteStringPartWithColor(diagnosticId, ConsoleColor.White);
 			Console.Write(LinePartsSeparator);
 			Console.Write(diagnosticMessage + LinePartsSeparator);
 			WriteStringPartWithColor(location, ConsoleColor.Yellow);
@@ -92,6 +103,21 @@ namespace Acuminator.Runner.Output.PlainText
 				finally
 				{
 					Console.ForegroundColor = oldColor;
+				}
+			}
+
+			static ConsoleColor GetSeverityColor(string severity)
+			{
+				switch(severity)
+				{
+					case SeverityError:
+						return ConsoleColor.Red;
+					case SeverityWarning:
+						return ConsoleColor.Yellow;
+					case SeverityInfo:
+						return ConsoleColor.Cyan;
+					default:
+						return Console.ForegroundColor;
 				}
 			}
 		}

--- a/src/Acuminator/Acuminator.Runner.NetFramework/Output/PlainText/PlainTextReportOutputterConsole.cs
+++ b/src/Acuminator/Acuminator.Runner.NetFramework/Output/PlainText/PlainTextReportOutputterConsole.cs
@@ -78,7 +78,6 @@ namespace Acuminator.Runner.Output.PlainText
 		private void WriteDiagnosticWithLocation(int indentationLevel, string diagnosticId, string diagnosticMessage, string location, string? severity)
 		{ 
 			string padding = GetPadding(indentationLevel);
-			var oldColor   = Console.ForegroundColor;
 
 			Console.Write(padding);
 			if (!severity.IsNullOrEmpty())
@@ -107,20 +106,13 @@ namespace Acuminator.Runner.Output.PlainText
 				}
 			}
 
-			static ConsoleColor GetSeverityColor(string severity)
+			static ConsoleColor GetSeverityColor(string severity) => severity switch
 			{
-				switch(severity)
-				{
-					case SeverityError:
-						return ConsoleColor.Red;
-					case SeverityWarning:
-						return ConsoleColor.Yellow;
-					case SeverityInfo:
-						return ConsoleColor.Cyan;
-					default:
-						return Console.ForegroundColor;
-				}
-			}
+				SeverityError => ConsoleColor.Red,
+				SeverityWarning => ConsoleColor.Yellow,
+				SeverityInfo => ConsoleColor.Cyan,
+				_ => Console.ForegroundColor
+			};
 		}
 
 		protected override void WriteCodeSourceTitle(string codeSourceTitle) =>

--- a/src/Acuminator/Acuminator.Runner.NetFramework/Output/PlainText/PlainTextReportOutputterConsole.cs
+++ b/src/Acuminator/Acuminator.Runner.NetFramework/Output/PlainText/PlainTextReportOutputterConsole.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-
+using Acuminator.Utilities.Common;
 using Acuminator.Runner.Output.Data;
 using Acuminator.Runner.Resources;
 
@@ -58,7 +58,8 @@ namespace Acuminator.Runner.Output.PlainText
 				case 3:
 					WriteDiagnosticWithLocation(indentationLevel, diagnosticId: line.Spans[0].ToString(), 
 												diagnosticMessage: line.Spans[1].ToString(),
-												location: line.Spans[2].ToString());
+												location: line.Spans[2].ToString(),
+												severity: null);
 					return;
 				case 4:
 					WriteDiagnosticWithLocation(indentationLevel, diagnosticId: line.Spans[1].ToString(),
@@ -74,15 +75,15 @@ namespace Acuminator.Runner.Output.PlainText
 			}
 		}
 
-		private void WriteDiagnosticWithLocation(int indentationLevel, string diagnosticId, string diagnosticMessage, string location, string? severity = null)
+		private void WriteDiagnosticWithLocation(int indentationLevel, string diagnosticId, string diagnosticMessage, string location, string? severity)
 		{ 
 			string padding = GetPadding(indentationLevel);
 			var oldColor   = Console.ForegroundColor;
 
 			Console.Write(padding);
-			if (!string.IsNullOrEmpty(severity))
+			if (!severity.IsNullOrEmpty())
 			{
-				WriteStringPartWithColor(String.Format(SeverityTemplate, severity), GetSeverityColor(severity!));
+				WriteStringPartWithColor(String.Format(SeverityTemplate, severity), GetSeverityColor(severity));
 			}
 
 			WriteStringPartWithColor(diagnosticId, ConsoleColor.White);

--- a/src/Acuminator/Acuminator.Runner.NetFramework/Output/PlainText/PlainTextReportOutputterConsole.cs
+++ b/src/Acuminator/Acuminator.Runner.NetFramework/Output/PlainText/PlainTextReportOutputterConsole.cs
@@ -106,7 +106,7 @@ namespace Acuminator.Runner.Output.PlainText
 				}
 			}
 
-			static ConsoleColor GetSeverityColor(string severity) => severity switch
+			static ConsoleColor GetSeverityColor(string severity) => severity.ToUpperInvariant() switch
 			{
 				SeverityError => ConsoleColor.Red,
 				SeverityWarning => ConsoleColor.Yellow,

--- a/src/Acuminator/Acuminator.Runner.NetFramework/Output/PlainText/PlainTextReportOutputterFile.cs
+++ b/src/Acuminator/Acuminator.Runner.NetFramework/Output/PlainText/PlainTextReportOutputterFile.cs
@@ -85,15 +85,23 @@ namespace Acuminator.Runner.Output.PlainText
 			}
 
 			string padding = GetPadding(indentationLevel);
-
-			if (line.Spans.Length == 4)
+			if (line.Spans.Length == 3)
 			{
+				var (diagnosticId, diagnosticMessage, location) =
+					(line.Spans[0].ToString(), line.Spans[1].ToString(), line.Spans[2].ToString());
+				WriteLine($"{padding}{diagnosticId}{LinePartsSeparator}{diagnosticMessage}{LinePartsSeparator}{location}");
+			}
+			else if(line.Spans.Length == 4)
+			{ 
 				var (severity, diagnosticId, diagnosticMessage, location) = 
 					(line.Spans[0].ToString(), line.Spans[1].ToString(), line.Spans[2].ToString(), line.Spans[3].ToString());
-				WriteLine($"{padding}{severity} - {diagnosticId}{LinePartsSeparator}{diagnosticMessage}{LinePartsSeparator}{location}");
+				WriteLine($"{padding}{string.Format(SeverityTemplate, severity)}{diagnosticId}{LinePartsSeparator}{diagnosticMessage}{LinePartsSeparator}{location}");
+				return;			
 			}
 			else
+			{
 				WriteLine(padding + line.ToString());
+			}
 		}
 
 		protected override void WriteLine() => _streamWriter?.WriteLine();

--- a/src/Acuminator/Acuminator.Runner.NetFramework/Output/PlainText/PlainTextReportOutputterFile.cs
+++ b/src/Acuminator/Acuminator.Runner.NetFramework/Output/PlainText/PlainTextReportOutputterFile.cs
@@ -88,9 +88,9 @@ namespace Acuminator.Runner.Output.PlainText
 
 			if (line.Spans.Length == 3)
 			{
-				var (diagnosticId, diagnosticMessage, location) = 
-					(line.Spans[0].ToString(), line.Spans[1].ToString(), line.Spans[2].ToString());
-				WriteLine($"{padding}{diagnosticId}{LinePartsSeparator}{diagnosticMessage}{LinePartsSeparator}{location}");
+				var (severity, diagnosticId, diagnosticMessage, location) = 
+					(line.Spans[0].ToString(), line.Spans[1].ToString(), line.Spans[2].ToString(), line.Spans[3].ToString());
+				WriteLine($"{padding}{severity} - {diagnosticId}{LinePartsSeparator}{diagnosticMessage}{LinePartsSeparator}{location}");
 			}
 			else
 				WriteLine(padding + line.ToString());

--- a/src/Acuminator/Acuminator.Runner.NetFramework/Output/PlainText/PlainTextReportOutputterFile.cs
+++ b/src/Acuminator/Acuminator.Runner.NetFramework/Output/PlainText/PlainTextReportOutputterFile.cs
@@ -86,7 +86,7 @@ namespace Acuminator.Runner.Output.PlainText
 
 			string padding = GetPadding(indentationLevel);
 
-			if (line.Spans.Length == 3)
+			if (line.Spans.Length == 4)
 			{
 				var (severity, diagnosticId, diagnosticMessage, location) = 
 					(line.Spans[0].ToString(), line.Spans[1].ToString(), line.Spans[2].ToString(), line.Spans[3].ToString());


### PR DESCRIPTION
### Changes Overview
- Extend `Line` to support 4 spans (severity + id + message + location) and update `ToString()` for 4-span lines.
- Update grouping to populate severity when producing diagnostic report `Line`s.
- Update plain-text file formatting to print severity with the diagnostic line.