### PR TITLE
Significant performance improvement

### DIFF
--- a/src/.idea/.idea.Acuminator/.idea/.gitignore
+++ b/src/.idea/.idea.Acuminator/.idea/.gitignore
@@ -1,0 +1,15 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Rider ignored files
+/modules.xml
+/.idea.Acuminator.iml
+/contentModel.xml
+/projectSettingsUpdater.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Ignored default folder with query files
+/queries/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/src/.idea/.idea.Acuminator/.idea/.name
+++ b/src/.idea/.idea.Acuminator/.idea/.name
@@ -1,0 +1,1 @@
+Acuminator

--- a/src/.idea/.idea.Acuminator/.idea/indexLayout.xml
+++ b/src/.idea/.idea.Acuminator/.idea/indexLayout.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="UserContentModel">
+    <attachedFolders />
+    <explicitIncludes />
+    <explicitExcludes />
+  </component>
+</project>

--- a/src/.idea/.idea.Acuminator/.idea/vcs.xml
+++ b/src/.idea/.idea.Acuminator/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$/.." vcs="Git" />
+  </component>
+</project>

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/NestedInvocationWalker.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/NestedInvocationWalker.cs
@@ -210,8 +210,16 @@ namespace Acuminator.Utilities.Roslyn
 
 		public override void VisitMemberAccessExpression(MemberAccessExpressionSyntax node)
 		{
-			VisitPropertyOrIndexerAccessExpression(node);
-			base.VisitMemberAccessExpression(node);
+			if (node.Parent is InvocationExpressionSyntax invocation && invocation.Expression == node)
+			{
+				// we already visit this node by VisitInvocationExpression, so we just skip it here
+				base.VisitMemberAccessExpression(node);
+			}
+			else
+			{
+				VisitPropertyOrIndexerAccessExpression(node);
+				base.VisitMemberAccessExpression(node);
+			}
 		}
 
 		public override void VisitElementAccessExpression(ElementAccessExpressionSyntax node)

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/NestedInvocationWalker.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/NestedInvocationWalker.cs
@@ -53,6 +53,8 @@ namespace Acuminator.Utilities.Roslyn
 
 		private readonly ISet<(SyntaxNode, DiagnosticDescriptor)> _reportedDiagnostics = new HashSet<(SyntaxNode, DiagnosticDescriptor)>();
 
+		private readonly SymbolInfoCache _cache = new();
+
         /// <summary>
         /// Cancellation token
         /// </summary>
@@ -119,20 +121,22 @@ namespace Acuminator.Utilities.Roslyn
 		protected virtual T? GetSymbol<T>(ExpressionSyntax node)
 			where T : class, ISymbol
 		{
-			var semanticModel = GetSemanticModel(node.SyntaxTree);
-
-			if (semanticModel != null)
+			SymbolInfo? cached = _cache.GetOrCreate(node, () =>
 			{
-				var symbolInfo = semanticModel.GetSymbolInfo(node, CancellationToken);
+				SemanticModel? semanticModel = GetSemanticModel(node.SyntaxTree);
+				return semanticModel?.GetSymbolInfo(node, CancellationToken);
+			});
 
-				if (symbolInfo.Symbol is T symbol)
+			if (cached is not null)
+			{
+				if (cached.Value.Symbol is T symbol)
 				{
 					return symbol;
 				}
 
-				if (!symbolInfo.CandidateSymbols.IsEmpty)
+				if (!cached.Value.CandidateSymbols.IsEmpty)
 				{
-					return symbolInfo.CandidateSymbols.OfType<T>().FirstOrDefault();
+					return cached.Value.CandidateSymbols.OfType<T>().FirstOrDefault();
 				}
 			}
 

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/NestedInvocationWalker.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/NestedInvocationWalker.cs
@@ -53,7 +53,7 @@ namespace Acuminator.Utilities.Roslyn
 
 		private readonly ISet<(SyntaxNode, DiagnosticDescriptor)> _reportedDiagnostics = new HashSet<(SyntaxNode, DiagnosticDescriptor)>();
 
-		private readonly SymbolInfoCache _cache = new();
+		private readonly SymbolInfoCache _cache;
 
         /// <summary>
         /// Cancellation token
@@ -89,6 +89,8 @@ namespace Acuminator.Utilities.Roslyn
 
 			//Use lazy to avoid calling virtual methods inside the constructor
 			_typesToBypass = new Lazy<HashSet<INamedTypeSymbol>>(valueFactory: GetTypesToBypass, isThreadSafe: false);
+
+			_cache = new SymbolInfoCache(GetType());
 		}
 
 		/// <summary>

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/NestedInvocationWalker.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/NestedInvocationWalker.cs
@@ -53,7 +53,7 @@ namespace Acuminator.Utilities.Roslyn
 
 		private readonly ISet<(SyntaxNode, DiagnosticDescriptor)> _reportedDiagnostics = new HashSet<(SyntaxNode, DiagnosticDescriptor)>();
 
-		private readonly SymbolInfoCache _cache;
+		private readonly SymbolInfoCache _symbolsCache;
 
         /// <summary>
         /// Cancellation token
@@ -90,7 +90,7 @@ namespace Acuminator.Utilities.Roslyn
 			//Use lazy to avoid calling virtual methods inside the constructor
 			_typesToBypass = new Lazy<HashSet<INamedTypeSymbol>>(valueFactory: GetTypesToBypass, isThreadSafe: false);
 
-			_cache = new SymbolInfoCache(GetType());
+			_symbolsCache = new SymbolInfoCache();
 		}
 
 		/// <summary>
@@ -123,7 +123,7 @@ namespace Acuminator.Utilities.Roslyn
 		protected virtual T? GetSymbol<T>(ExpressionSyntax node)
 			where T : class, ISymbol
 		{
-			SymbolInfo? cached = _cache.GetOrCreate(node, () =>
+			SymbolInfo? cached = _symbolsCache.GetOrCreate(node, () =>
 			{
 				SemanticModel? semanticModel = GetSemanticModel(node.SyntaxTree);
 				return semanticModel?.GetSymbolInfo(node, CancellationToken);

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/SymbolInfoCache.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/SymbolInfoCache.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
@@ -11,135 +10,22 @@ namespace Acuminator.Utilities.Roslyn;
 /// </summary>
 public sealed class SymbolInfoCache
 {
-	private readonly Dictionary<ExpressionSyntax, SymbolInfo> _map = new();
-#if SYMBOL_INFO_CACHE_STATISTICS
-	private readonly SymbolInfoCacheStatistics _statistics;
-#endif
-
-	public SymbolInfoCache(Type owner)
-	{
-#if SYMBOL_INFO_CACHE_STATISTICS
-		_statistics = SymbolInfoCacheStatisticsContext.Register(owner);
-#endif
-	}
+	private readonly Dictionary<ExpressionSyntax, SymbolInfo?> _map = new();
 
 	/// <summary>
 	/// Gets the cached symbol information for the specified expression, or creates and stores it using the provided factory.
 	/// </summary>
 	public SymbolInfo? GetOrCreate(ExpressionSyntax key, Func<SymbolInfo?> factory)
 	{
-		if (_map.TryGetValue(key, out SymbolInfo cached))
+		if (_map.TryGetValue(key, out SymbolInfo? cached))
 		{
-#if SYMBOL_INFO_CACHE_STATISTICS
-			_statistics.Hit();
-#endif
 			return cached;
 		}
 
-#if SYMBOL_INFO_CACHE_STATISTICS
-		_statistics.Miss();
-#endif
-
 		SymbolInfo? potentialValue = factory();
-		if (potentialValue is not null)
-		{
-			_map[key] = potentialValue.Value;
-#if SYMBOL_INFO_CACHE_STATISTICS
-			_statistics.Set(key.GetType());
-#endif
-			return potentialValue;
-		}
+		_map[key] = potentialValue;
 
-		return null;
+		return potentialValue;
 	}
-
-#if SYMBOL_INFO_CACHE_STATISTICS
-	public sealed class SymbolInfoCacheStatistics
-	{
-		private readonly Dictionary<Type, long> _byTypeCounter = new();
-		private readonly Type _owner;
-		private readonly int _cacheId;
-
-		private long _hitsTotal;
-		private long _missesTotal;
-		private long _setsTotal;
-
-		public SymbolInfoCacheStatistics(int cacheId, Type owner)
-		{
-			_owner = owner;
-			_cacheId = cacheId;
-		}
-
-		public void Hit() => _hitsTotal++;
-
-		public void Miss() => _missesTotal++;
-
-		public void Set(Type type)
-		{
-			if (!_byTypeCounter.ContainsKey(type))
-			{
-				_byTypeCounter[type] = 1;
-			}
-			else
-			{
-				_byTypeCounter[type]++;
-			}
-			_setsTotal++;
-		}
-
-		public StatisticsSnapshot GetSnapshot()
-		{
-			var lookupsTotal = _hitsTotal + _missesTotal;
-			return new StatisticsSnapshot(
-				_cacheId,
-				_owner,
-				_hitsTotal,
-				_missesTotal,
-				_setsTotal,
-				_byTypeCounter,
-				CalcRatio(_hitsTotal, lookupsTotal),
-				CalcRatio(_missesTotal, lookupsTotal)
-			);
-		}
-		
-		private static double CalcRatio(long value, long total) => total == 0 ? 0 : (double)value / total;
-	}
-
-	public static class SymbolInfoCacheStatisticsContext
-	{
-		private static readonly object Gate = new();
-		private static readonly List<SymbolInfoCacheStatistics> Statistics = new();
-		private static int _nextCacheId;
-
-		internal static SymbolInfoCacheStatistics Register(Type owner)
-		{
-			var cacheId = Interlocked.Increment(ref _nextCacheId);
-			var statistics = new SymbolInfoCacheStatistics(cacheId, owner);
-
-			lock (Gate)
-			{
-				Statistics.Add(statistics);
-			}
-
-			return statistics;
-		}
-
-		public static StatisticsSnapshot[] GetStatistics()
-		{
-			lock (Gate)
-			{
-				var result = new StatisticsSnapshot[Statistics.Count];
-				for (var i = 0; i < Statistics.Count; i++)
-				{
-					result[i] = Statistics[i].GetSnapshot();
-				}
-				
-				return result;
-			}
-		}
-	}
-
-	public record StatisticsSnapshot(int CacheId, Type Owner, long HitsTotal, long MissesTotal, long SetsTotal, Dictionary<Type, long> ByTypeCounter, double HitRatio, double MissRatio);
-#endif
 }
 

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/SymbolInfoCache.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/SymbolInfoCache.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Acuminator.Utilities.Roslyn;
+
+/// <summary>
+/// Caches Roslyn symbol lookup results for expression syntax nodes visited by a syntax walker.
+/// </summary>
+internal sealed class SymbolInfoCache
+{
+	private readonly Dictionary<ExpressionSyntax, SymbolInfo> _map = new();
+
+	/// <summary>
+	/// Gets the cached symbol information for the specified expression, or creates and stores it using the provided factory.
+	/// </summary>
+	public SymbolInfo? GetOrCreate(ExpressionSyntax key, Func<SymbolInfo?> factory)
+	{
+		if (_map.TryGetValue(key, out SymbolInfo cached))
+		{
+			return cached;
+		}
+
+		SymbolInfo? potentialValue = factory();
+		if (potentialValue is not null)
+		{
+			_map[key] = potentialValue.Value;
+			return potentialValue;
+		}
+
+		return null;
+	}
+}

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/SymbolInfoCache.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/SymbolInfoCache.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
@@ -8,9 +9,19 @@ namespace Acuminator.Utilities.Roslyn;
 /// <summary>
 /// Caches Roslyn symbol lookup results for expression syntax nodes visited by a syntax walker.
 /// </summary>
-internal sealed class SymbolInfoCache
+public sealed class SymbolInfoCache
 {
 	private readonly Dictionary<ExpressionSyntax, SymbolInfo> _map = new();
+#if SYMBOL_INFO_CACHE_STATISTICS
+	private readonly SymbolInfoCacheStatistics _statistics;
+#endif
+
+	public SymbolInfoCache(Type owner)
+	{
+#if SYMBOL_INFO_CACHE_STATISTICS
+		_statistics = SymbolInfoCacheStatisticsContext.Register(owner);
+#endif
+	}
 
 	/// <summary>
 	/// Gets the cached symbol information for the specified expression, or creates and stores it using the provided factory.
@@ -19,16 +30,116 @@ internal sealed class SymbolInfoCache
 	{
 		if (_map.TryGetValue(key, out SymbolInfo cached))
 		{
+#if SYMBOL_INFO_CACHE_STATISTICS
+			_statistics.Hit();
+#endif
 			return cached;
 		}
+
+#if SYMBOL_INFO_CACHE_STATISTICS
+		_statistics.Miss();
+#endif
 
 		SymbolInfo? potentialValue = factory();
 		if (potentialValue is not null)
 		{
 			_map[key] = potentialValue.Value;
+#if SYMBOL_INFO_CACHE_STATISTICS
+			_statistics.Set(key.GetType());
+#endif
 			return potentialValue;
 		}
 
 		return null;
 	}
+
+#if SYMBOL_INFO_CACHE_STATISTICS
+	public sealed class SymbolInfoCacheStatistics
+	{
+		private readonly Dictionary<Type, long> _byTypeCounter = new();
+		private readonly Type _owner;
+		private readonly int _cacheId;
+
+		private long _hitsTotal;
+		private long _missesTotal;
+		private long _setsTotal;
+
+		public SymbolInfoCacheStatistics(int cacheId, Type owner)
+		{
+			_owner = owner;
+			_cacheId = cacheId;
+		}
+
+		public void Hit() => _hitsTotal++;
+
+		public void Miss() => _missesTotal++;
+
+		public void Set(Type type)
+		{
+			if (!_byTypeCounter.ContainsKey(type))
+			{
+				_byTypeCounter[type] = 1;
+			}
+			else
+			{
+				_byTypeCounter[type]++;
+			}
+			_setsTotal++;
+		}
+
+		public StatisticsSnapshot GetSnapshot()
+		{
+			var lookupsTotal = _hitsTotal + _missesTotal;
+			return new StatisticsSnapshot(
+				_cacheId,
+				_owner,
+				_hitsTotal,
+				_missesTotal,
+				_setsTotal,
+				_byTypeCounter,
+				CalcRatio(_hitsTotal, lookupsTotal),
+				CalcRatio(_missesTotal, lookupsTotal)
+			);
+		}
+		
+		private static double CalcRatio(long value, long total) => total == 0 ? 0 : (double)value / total;
+	}
+
+	public static class SymbolInfoCacheStatisticsContext
+	{
+		private static readonly object Gate = new();
+		private static readonly List<SymbolInfoCacheStatistics> Statistics = new();
+		private static int _nextCacheId;
+
+		internal static SymbolInfoCacheStatistics Register(Type owner)
+		{
+			var cacheId = Interlocked.Increment(ref _nextCacheId);
+			var statistics = new SymbolInfoCacheStatistics(cacheId, owner);
+
+			lock (Gate)
+			{
+				Statistics.Add(statistics);
+			}
+
+			return statistics;
+		}
+
+		public static StatisticsSnapshot[] GetStatistics()
+		{
+			lock (Gate)
+			{
+				var result = new StatisticsSnapshot[Statistics.Count];
+				for (var i = 0; i < Statistics.Count; i++)
+				{
+					result[i] = Statistics[i].GetSnapshot();
+				}
+				
+				return result;
+			}
+		}
+	}
+
+	public record StatisticsSnapshot(int CacheId, Type Owner, long HitsTotal, long MissesTotal, long SetsTotal, Dictionary<Type, long> ByTypeCounter, double HitRatio, double MissRatio);
+#endif
 }
+


### PR DESCRIPTION
### Proposed changes

1. `NestedInvocationWalker` now caches retrieved `ISymbol` instances using a new `SymbolInfoCache`.
2. Fixed a serious issue that was causing a large amount of redundant work: multiple call graph traversals, which in turn caused an excessive number of semantic queries to resolve `ISymbol`.

### Motivation

While profiling the analyzer, I noticed extremely high memory usage, and running solution analysis from the CLI took more than 40 minutes.
dotTrace pointed to `Acuminator.Utilities.Roslyn.NestedInvocationWalker.GetSymbol(ExpressionSyntax)` as a primary hotspot:
<img width="1274" height="496" alt="Screenshot 2026-05-06 201213" src="https://github.com/user-attachments/assets/1a13e7af-2ce7-490b-8893-12d09dd43a63" />
<img width="1639" height="527" alt="Screenshot 2026-05-06 201339" src="https://github.com/user-attachments/assets/27dfa200-0002-4a75-9796-e37a1fc8e4bb" />

Memory profiling confirmed the same method:
<img width="2042" height="906" alt="Screenshot 2026-05-06 204141" src="https://github.com/user-attachments/assets/f716b726-8d3c-401a-8c47-b0f6a70e4336" />

### Caching

As a load-reducing measure, I implemented caching. This significantly reduced both execution time and memory consumption.

Yes, caching is often a last-resort approach and ideally **shouldn't be** here. However, when implemented carefully it can also provide valuable diagnostic data that helps guide further optimization work.

### Cache statistics

`SymbolInfoCache` can optionally collect statistics. Enable it by defining the `SYMBOL_INFO_CACHE_STATISTICS` constant, then inspect `Acuminator.Utilities.Roslyn.SymbolInfoCache.SymbolInfoCacheStatisticsContext.GetStatistics` under the debugger.

I intentionally did not add any logging of it because the statistics can become very large. It's much more practical to analyze it interactively (e.g., via LINQ in a debug session).

While digging into the stats, I noticed something weird: the same expression was cached under two different key types: `InvocationExpressionSyntax` and `MemberAccessExpressionSyntax`. Debugging led to `VisitMemberAccessExpression`.

### `foo.Bar()` is both `MemberAccessExpressionSyntax` and `InvocationExpressionSyntax`

By filtering out redundant invocation processing inside `MemberAccessExpressionSyntax`, I added an additional fix. This change, similarly to caching, delivered a substantial improvement in both time and memory.

### Benchmarks

I measured the impact of each fix independently, as well as both together.

**Total runtime (wall-clock):**
<img width="826" height="324" alt="Screenshot 2026-05-06 211607" src="https://github.com/user-attachments/assets/cbdc9ef3-9cf8-4aa1-abac-8899a30b19d1" />

- Speedup ranges from **1.30x to 7.43x** (about **4x on average**)

**Memory allocation / GC pressure:**
<img width="1350" height="465" alt="Screenshot 2026-05-06 211648" src="https://github.com/user-attachments/assets/a7c993ec-8def-444a-83b0-705145b7d188" />

- Allocations reduced by **1.59x to 8.78x** (about **5x on average**)
- Significantly less GC overhead due to drastically fewer allocations

With both fixes applied, traces no longer show `GetSymbol` as a top hotspot; instead, the cache path (`GetOrCreate`) appears, and overall memory usage is dramatically improved.
<img width="1683" height="983" alt="Screenshot 2026-05-06 203630" src="https://github.com/user-attachments/assets/e13caf35-9ecb-45ec-b6dd-43ef57d339ac" />
<img width="2090" height="940" alt="Screenshot 2026-05-06 204713" src="https://github.com/user-attachments/assets/4842ca77-45da-4cb5-b599-4086053ffab3" />

### Conclusion

Even though caching contributes less after the second fix, I'd still like to keep it (at least for upcoming optimization work) as a way to collect detailed statistics. The goal is to reach a hit rate that is **0 or as close to 0 as possible** (i.e., eliminate the underlying redundant symbol queries altogether).

I plan to continue working on this area and believe we can achieve even more significant improvements.