### PR TITLE
Bugfix/atr 972 dev fix disappearing coloring

### DIFF
--- a/src/Acuminator/Acuminator.Vsix/Coloriser/AsyncTagging/BackgroundTagging.cs
+++ b/src/Acuminator/Acuminator.Vsix/Coloriser/AsyncTagging/BackgroundTagging.cs
@@ -80,7 +80,7 @@ namespace Acuminator.Vsix.Coloriser
 				return;
 
 			_isDisposed = true;
-			CancelTagging();
+			_cancellationTokenSource.Cancel();
 			_cancellationTokenSource.Dispose();
 		}
 

--- a/src/Acuminator/Acuminator.Vsix/Coloriser/AsyncTagging/BackgroundTagging.cs
+++ b/src/Acuminator/Acuminator.Vsix/Coloriser/AsyncTagging/BackgroundTagging.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 
 using Acuminator.Utilities.Common;
+using Acuminator.Vsix.Logger;
 
 using Shell = Microsoft.VisualStudio.Shell;
 
@@ -80,8 +81,32 @@ namespace Acuminator.Vsix.Coloriser
 				return;
 
 			_isDisposed = true;
-			_cancellationTokenSource.Cancel();
-			_cancellationTokenSource.Dispose();
+
+			try
+			{
+				_cancellationTokenSource.Cancel();
+			}
+			catch (OperationCanceledException)
+			{
+			}
+			catch (AggregateException aggregateException)
+			{
+				var flattened = aggregateException.Flatten();
+				var exceptionsToLog = flattened.InnerExceptions.Where(ex => ex is not OperationCanceledException);
+
+				foreach (var exception in exceptionsToLog)
+				{
+					AcuminatorVSPackage.Instance?.AcuminatorLogger?.LogException(exception, logOnlyFromAcuminatorAssemblies: false, LogMode.Warning);
+				}
+			}
+			catch (Exception ex)
+			{
+				AcuminatorVSPackage.Instance?.AcuminatorLogger?.LogException(ex, logOnlyFromAcuminatorAssemblies: false, LogMode.Warning);
+			}
+			finally
+			{
+				_cancellationTokenSource.Dispose();
+			}
 		}
 
 		private static Task AfterTaggingActionAsync(Task taggingTask, PXRoslynColorizerTagger tagger, CancellationToken cancellationToken)

--- a/src/Acuminator/Acuminator.Vsix/Coloriser/Base/PXTaggerBase.cs
+++ b/src/Acuminator/Acuminator.Vsix/Coloriser/Base/PXTaggerBase.cs
@@ -52,7 +52,7 @@ namespace Acuminator.Vsix.Coloriser
 			}
 
 			_disposedNotification = new TextDocumentDisposedNotification(textDocumentFactory, Buffer);
-			_disposedNotification.OnCurrentTextDocumentDisposed += CleanupOnTextDocumentDisposed;
+			_disposedNotification.CurrentTextDocumentDisposed += CleanupOnTextDocumentDisposed;
 		}
 
 		protected virtual void ColoringSettingChangedHandler(object sender, SettingChangedEventArgs e)
@@ -104,7 +104,7 @@ namespace Acuminator.Vsix.Coloriser
 		{
 			Type taggerType = GetType();
 			Buffer.Properties.RemoveProperty(taggerType);
-			_disposedNotification.OnCurrentTextDocumentDisposed -= CleanupOnTextDocumentDisposed;
+			_disposedNotification.CurrentTextDocumentDisposed -= CleanupOnTextDocumentDisposed;
 
 			if (!SubscribedToSettingsChanges)
 				return;

--- a/src/Acuminator/Acuminator.Vsix/Coloriser/Base/PXTaggerBase.cs
+++ b/src/Acuminator/Acuminator.Vsix/Coloriser/Base/PXTaggerBase.cs
@@ -14,8 +14,10 @@ using ThreadHelper = Microsoft.VisualStudio.Shell.ThreadHelper;
 
 namespace Acuminator.Vsix.Coloriser
 {
-	public abstract class PXTaggerBase : IDisposable
+	public abstract class PXTaggerBase
 	{
+		private readonly TextDocumentDisposedNotification _disposedNotification;
+
 #pragma warning disable CS0067
 		public event EventHandler<SnapshotSpanEventArgs>? TagsChanged;
 #pragma warning restore CS0067
@@ -32,7 +34,8 @@ namespace Acuminator.Vsix.Coloriser
 
 		protected bool CacheCheckingEnabled { get; }
 
-		protected PXTaggerBase(ITextBuffer buffer, bool subscribeToSettingsChanges, bool useCacheChecking)
+		protected PXTaggerBase(ITextBuffer buffer, ITextDocumentFactoryService textDocumentFactory, 
+							   bool subscribeToSettingsChanges, bool useCacheChecking)
 		{
 			Buffer = buffer.CheckIfNull();
 			SubscribedToSettingsChanges = subscribeToSettingsChanges;
@@ -47,6 +50,9 @@ namespace Acuminator.Vsix.Coloriser
 					genOptionsPage.ColoringSettingChanged += ColoringSettingChangedHandler;
 				}
 			}
+
+			_disposedNotification = new TextDocumentDisposedNotification(textDocumentFactory, Buffer);
+			_disposedNotification.OnCurrentTextDocumentDisposed += CleanupOnTextDocumentDisposed;
 		}
 
 		protected virtual void ColoringSettingChangedHandler(object sender, SettingChangedEventArgs e)
@@ -94,8 +100,12 @@ namespace Acuminator.Vsix.Coloriser
 			Snapshot = newSnapshotToCache;
 		}
 
-		public virtual void Dispose()
+		protected virtual void CleanupOnTextDocumentDisposed(object sender, EventArgs e)
 		{
+			Type taggerType = GetType();
+			Buffer.Properties.RemoveProperty(taggerType);
+			_disposedNotification.OnCurrentTextDocumentDisposed -= CleanupOnTextDocumentDisposed;
+
 			if (!SubscribedToSettingsChanges)
 				return;
 

--- a/src/Acuminator/Acuminator.Vsix/Coloriser/Outlining/PXOutliningTagger.cs
+++ b/src/Acuminator/Acuminator.Vsix/Coloriser/Outlining/PXOutliningTagger.cs
@@ -25,8 +25,9 @@ namespace Acuminator.Vsix.Coloriser
 		[MemberNotNullWhen(returnValue: true, nameof(ColorizerTagger))]
 		public override bool HasReferenceToAcumaticaPlatform => ColorizerTagger?.HasReferenceToAcumaticaPlatform ?? false;
 
-		public PXOutliningTagger(ITextBuffer buffer, bool subscribeToSettingsChanges, bool useCacheChecking) :
-							base(buffer, subscribeToSettingsChanges, useCacheChecking)
+		public PXOutliningTagger(ITextBuffer buffer, ITextDocumentFactoryService textDocumentFactory, bool subscribeToSettingsChanges, 
+								 bool useCacheChecking) :
+							base(buffer, textDocumentFactory, subscribeToSettingsChanges, useCacheChecking)
 		{
 		}
 
@@ -69,15 +70,15 @@ namespace Acuminator.Vsix.Coloriser
 			RaiseTagsChanged();
 		}
 
-		public override void Dispose()
+		protected override void CleanupOnTextDocumentDisposed(object sender, EventArgs e)
 		{
+			base.CleanupOnTextDocumentDisposed(sender, e);
+
 			if (Interlocked.Exchange(ref _isSubscribed, NOT_SUBSCRIBED) == SUBSCRIBED && ColorizerTagger != null)
 			{
 				ColorizerTagger.TagsChanged -= OnColorizingTaggerTagsChanged;
 				ColorizerTagger = null;
 			}
-
-			base.Dispose();
 		}
 	} 
 }

--- a/src/Acuminator/Acuminator.Vsix/Coloriser/Outlining/PXOutliningTaggerProvider.cs
+++ b/src/Acuminator/Acuminator.Vsix/Coloriser/Outlining/PXOutliningTaggerProvider.cs
@@ -1,5 +1,4 @@
 ﻿#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
@@ -7,30 +6,36 @@ using System.Linq;
 
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Text;
-using Microsoft.VisualStudio.Text.Classification;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text.Tagging;
 using Microsoft.VisualStudio.Utilities;
 
-namespace Acuminator.Vsix.Coloriser
+namespace Acuminator.Vsix.Coloriser;
+
+[ContentType("CSharp")]
+[TagType(typeof(IOutliningRegionTag))]
+[TextViewRole(PredefinedTextViewRoles.Document)]
+[Export(typeof(ITaggerProvider))]
+public class PXOutliningTaggerProvider : ITaggerProvider
 {
-	[ContentType("CSharp")]
-	[TagType(typeof(IOutliningRegionTag))]
-	[TextViewRole(PredefinedTextViewRoles.Document)]
-	[Export(typeof(ITaggerProvider))]
-	public class PXOutliningTaggerProvider : ITaggerProvider
+	private readonly ITextDocumentFactoryService _textDocumentFactory;
+
+	[ImportingConstructor]
+	public PXOutliningTaggerProvider(ITextDocumentFactoryService textDocumentFactory)
 	{
-		public ITagger<T>? CreateTagger<T>(ITextBuffer buffer) where T : ITag
+		_textDocumentFactory = textDocumentFactory;
+	}
+
+	public ITagger<T>? CreateTagger<T>(ITextBuffer buffer) where T : ITag
+	{
+		if (buffer == null || !ThreadHelper.CheckAccess())
+			return null;
+
+		PXOutliningTagger outliningTagger = buffer.Properties.GetOrCreateSingletonProperty(typeof(PXOutliningTagger), () =>
 		{
-			if (buffer == null || !ThreadHelper.CheckAccess())
-				return null;
+			return new PXOutliningTagger(buffer, _textDocumentFactory, subscribeToSettingsChanges: true, useCacheChecking: true);
+		});
 
-			PXOutliningTagger outliningTagger = buffer.Properties.GetOrCreateSingletonProperty(() =>
-			{
-				return new PXOutliningTagger(buffer, subscribeToSettingsChanges: true, useCacheChecking: true);
-			});
-
-			return outliningTagger as ITagger<T>;
-		}
+		return outliningTagger as ITagger<T>;
 	}
 }

--- a/src/Acuminator/Acuminator.Vsix/Coloriser/PXColorizerTaggerProvider.cs
+++ b/src/Acuminator/Acuminator.Vsix/Coloriser/PXColorizerTaggerProvider.cs
@@ -31,8 +31,7 @@ namespace Acuminator.Vsix.Coloriser
 		private readonly IClassificationTypeRegistryService _classificationRegistry;
 		private readonly IClassificationFormatMapService _classificationFormatMapService;
 
-		[Import]
-		internal IClassificationFormatMapService _classificationFormatMapService = null!;  //Set via MEF
+		internal ITextDocumentFactoryService TextDocumentFactory { get; }
 
 		private const string TextCategory = "text";
 		private static readonly object _syncRoot = new object();
@@ -76,6 +75,7 @@ namespace Acuminator.Vsix.Coloriser
 		{
 			_classificationRegistry = classificationRegistry;
 			_classificationFormatMapService = classificationFormatMapService;
+			TextDocumentFactory = textDocumentFactory;
 		}
 
 		public virtual ITagger<T>? CreateTagger<T>(ITextView textView, ITextBuffer textBuffer)

--- a/src/Acuminator/Acuminator.Vsix/Coloriser/PXColorizerTaggerProvider.cs
+++ b/src/Acuminator/Acuminator.Vsix/Coloriser/PXColorizerTaggerProvider.cs
@@ -3,16 +3,13 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Linq;
-using System.Threading;
 
 using Acuminator.Utilities.Roslyn;
 using Acuminator.Vsix.Utilities;
 
-using Microsoft.VisualStudio.Language.StandardClassification;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Classification;
 using Microsoft.VisualStudio.Text.Editor;
-using Microsoft.VisualStudio.Text.Formatting;
 using Microsoft.VisualStudio.Text.Tagging;
 using Microsoft.VisualStudio.Utilities;
 
@@ -26,14 +23,8 @@ namespace Acuminator.Vsix.Coloriser;
 [Export(typeof(IViewTaggerProvider))]
 public class PXColorizerTaggerProvider : IViewTaggerProvider
 {
-	private const string TextCategory = "text";
-	
 	private readonly IClassificationTypeRegistryService _classificationRegistry;
-	private readonly IClassificationFormatMapService _classificationFormatMapService;
 	private readonly ITextDocumentFactoryService _textDocumentFactory;
-
-	private static readonly object _syncRoot = new object();
-	private static volatile bool _isPriorityIncreased;
 
 	private readonly Dictionary<PXCodeType, IClassificationType> _codeColoringClassificationTypes;
 
@@ -50,19 +41,13 @@ public class PXColorizerTaggerProvider : IViewTaggerProvider
 			 : null;
 
 	[ImportingConstructor]
-	public PXColorizerTaggerProvider(IClassificationTypeRegistryService classificationRegistry,
-									 IClassificationFormatMapService classificationFormatMapService,
-									 ITextDocumentFactoryService textDocumentFactory)
+	public PXColorizerTaggerProvider(IClassificationTypeRegistryService classificationRegistry, ITextDocumentFactoryService textDocumentFactory)
 	{
-		_classificationRegistry 		= classificationRegistry;
-		_classificationFormatMapService = classificationFormatMapService;
-		_textDocumentFactory			= textDocumentFactory;
+		_classificationRegistry = classificationRegistry;
+		_textDocumentFactory	= textDocumentFactory;
 
 		_codeColoringClassificationTypes = GetClassificationTypesForAcumaticaCodeElements(_classificationRegistry);
 		_braceTypeByLevel = GetClassificationTypesForAngleBraces(_classificationRegistry);
-
-		IncreaseCommentFormatTypesPriority(_classificationRegistry, _classificationFormatMapService,
-											_codeColoringClassificationTypes[PXCodeType.BqlParameter]);
 	}
 
 	public virtual ITagger<T>? CreateTagger<T>(ITextView textView, ITextBuffer textBuffer)
@@ -127,47 +112,5 @@ public class PXColorizerTaggerProvider : IViewTaggerProvider
 		};
 
 		return braceTypeByLevel;
-	}
-
-	private static void IncreaseCommentFormatTypesPriority(IClassificationTypeRegistryService registry, IClassificationFormatMapService formatMapService,
-														   IClassificationType highestPriorityType)
-	{
-		if (_isPriorityIncreased)
-			return;
-
-		bool lockTaken = false;
-		Monitor.TryEnter(_syncRoot, ref lockTaken);
-
-		if (!lockTaken)
-			return;
-
-		try
-		{
-			if (_isPriorityIncreased)
-				return;
-
-			if (formatMapService.GetClassificationFormatMap(category: TextCategory) is IClassificationFormatMap formatMap)
-			{
-				IncreaseServiceFormatPriority(formatMap, registry, PredefinedClassificationTypeNames.ExcludedCode, highestPriorityType);
-				IncreaseServiceFormatPriority(formatMap, registry, PredefinedClassificationTypeNames.Comment, highestPriorityType);
-				_isPriorityIncreased = true;
-			}
-		}
-		finally
-		{
-			Monitor.Exit(_syncRoot);
-		}
-	}
-
-	private static void IncreaseServiceFormatPriority(IClassificationFormatMap formatMap, IClassificationTypeRegistryService registry, string formatName,
-													  IClassificationType highestPriorityType)
-	{
-		IClassificationType predefinedClassificationType = registry.GetClassificationType(formatName);
-		IClassificationType artificialClassType = registry.CreateTransientClassificationType(predefinedClassificationType);
-		TextFormattingRunProperties properties = formatMap.GetExplicitTextProperties(predefinedClassificationType);
-
-		formatMap.AddExplicitTextProperties(artificialClassType, properties, highestPriorityType);
-		formatMap.SwapPriorities(artificialClassType, predefinedClassificationType);
-		formatMap.SwapPriorities(highestPriorityType, predefinedClassificationType);
 	}
 }

--- a/src/Acuminator/Acuminator.Vsix/Coloriser/PXColorizerTaggerProvider.cs
+++ b/src/Acuminator/Acuminator.Vsix/Coloriser/PXColorizerTaggerProvider.cs
@@ -3,7 +3,6 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using System.Threading;
 
 using Acuminator.Utilities.Roslyn;
@@ -19,158 +18,156 @@ using Microsoft.VisualStudio.Utilities;
 
 using ThreadHelper = Microsoft.VisualStudio.Shell.ThreadHelper;
 
-namespace Acuminator.Vsix.Coloriser
+namespace Acuminator.Vsix.Coloriser;
+
+[ContentType(Constants.CSharp.LegacyLanguageName)]
+[TagType(typeof(IClassificationTag))]
+[TextViewRole(PredefinedTextViewRoles.Document)]
+[Export(typeof(IViewTaggerProvider))]
+public class PXColorizerTaggerProvider : IViewTaggerProvider
 {
-	[ContentType(Constants.CSharp.LegacyLanguageName)]
-	[TagType(typeof(IClassificationTag))]
-	[TextViewRole(PredefinedTextViewRoles.Document)]
-	[Export(typeof(IViewTaggerProvider))]
-	public class PXColorizerTaggerProvider : IViewTaggerProvider
+	private const string TextCategory = "text";
+	
+	private readonly IClassificationTypeRegistryService _classificationRegistry;
+	private readonly IClassificationFormatMapService _classificationFormatMapService;
+	private readonly ITextDocumentFactoryService _textDocumentFactory;
+
+	private static readonly object _syncRoot = new object();
+	private static volatile bool _isPriorityIncreased;
+
+	private readonly Dictionary<PXCodeType, IClassificationType> _codeColoringClassificationTypes;
+
+	public IClassificationType? this[PXCodeType codeType] =>
+		_codeColoringClassificationTypes.TryGetValue(codeType, out IClassificationType type)
+			 ? type
+			 : null;
+
+	private readonly Dictionary<int, IClassificationType> _braceTypeByLevel;
+
+	public IClassificationType? this[int braceLevel] =>
+		_braceTypeByLevel.TryGetValue(braceLevel, out IClassificationType type)
+			 ? type
+			 : null;
+
+	[ImportingConstructor]
+	public PXColorizerTaggerProvider(IClassificationTypeRegistryService classificationRegistry,
+									 IClassificationFormatMapService classificationFormatMapService,
+									 ITextDocumentFactoryService textDocumentFactory)
 	{
-		private readonly IClassificationTypeRegistryService _classificationRegistry;
-		private readonly IClassificationFormatMapService _classificationFormatMapService;
+		_classificationRegistry 		= classificationRegistry;
+		_classificationFormatMapService = classificationFormatMapService;
+		_textDocumentFactory			= textDocumentFactory;
 
-		internal ITextDocumentFactoryService TextDocumentFactory { get; }
+		_codeColoringClassificationTypes = GetClassificationTypesForAcumaticaCodeElements(_classificationRegistry);
+		_braceTypeByLevel = GetClassificationTypesForAngleBraces(_classificationRegistry);
 
-		private const string TextCategory = "text";
+		IncreaseCommentFormatTypesPriority(_classificationRegistry, _classificationFormatMapService,
+											_codeColoringClassificationTypes[PXCodeType.BqlParameter]);
+	}
 
-		private static readonly object _syncRoot = new object();
-		private static volatile bool _isPriorityIncreased;
+	public virtual ITagger<T>? CreateTagger<T>(ITextView textView, ITextBuffer textBuffer)
+	where T : ITag
+	{
+		if (textView == null || textBuffer == null || textView.TextBuffer != textBuffer || !ThreadHelper.CheckAccess())
+			return null;
 
-		private readonly Dictionary<PXCodeType, IClassificationType> _codeColoringClassificationTypes;
-
-		public IClassificationType? this[PXCodeType codeType] =>
-			_codeColoringClassificationTypes.TryGetValue(codeType, out IClassificationType type)
-				 ? type
-				 : null;
-
-		private readonly Dictionary<int, IClassificationType> _braceTypeByLevel;
-
-		public IClassificationType? this[int braceLevel] =>
-			_braceTypeByLevel.TryGetValue(braceLevel, out IClassificationType type)
-				 ? type
-				 : null;
-
-		[ImportingConstructor]
-		public PXColorizerTaggerProvider(IClassificationTypeRegistryService classificationRegistry,
-										 IClassificationFormatMapService classificationFormatMapService,
-										 ITextDocumentFactoryService textDocumentFactory)
+		var tagger = textBuffer.Properties.GetOrCreateSingletonProperty(typeof(PXRoslynColorizerTagger), () =>
 		{
-			_classificationRegistry 		= classificationRegistry;
-			_classificationFormatMapService = classificationFormatMapService;
-			TextDocumentFactory 			= textDocumentFactory;
+			return new PXRoslynColorizerTagger(textBuffer, _textDocumentFactory, this, subscribeToSettingsChanges: true, useCacheChecking: true);
+		});
 
-			_codeColoringClassificationTypes = GetClassificationTypesForAcumaticaCodeElements(_classificationRegistry);
-			_braceTypeByLevel = GetClassificationTypesForAngleBraces(_classificationRegistry);
+		return tagger as ITagger<T>;
+	}
 
-			IncreaseCommentFormatTypesPriority(_classificationRegistry, _classificationFormatMapService,
-												_codeColoringClassificationTypes[PXCodeType.BqlParameter]);
-		}
-
-		public virtual ITagger<T>? CreateTagger<T>(ITextView textView, ITextBuffer textBuffer)
-		where T : ITag
+	private static Dictionary<PXCodeType, IClassificationType> GetClassificationTypesForAcumaticaCodeElements(
+																				IClassificationTypeRegistryService classificationRegistry)
+	{
+		IClassificationType bqlClassificationType = classificationRegistry.GetClassificationType(ColoringConstants.BQLOperatorFormat);
+		var acumaticaCodeElementsClassificationTypes = new Dictionary<PXCodeType, IClassificationType>
 		{
-			if (textView == null || textBuffer == null || textView.TextBuffer != textBuffer || !ThreadHelper.CheckAccess())
-				return null;
+			[PXCodeType.Dac] 		  = classificationRegistry.GetClassificationType(ColoringConstants.DacFormat),
+			[PXCodeType.DacExtension] = classificationRegistry.GetClassificationType(ColoringConstants.DacExtensionFormat),
+			[PXCodeType.DacField] 	  = classificationRegistry.GetClassificationType(ColoringConstants.DacFieldFormat),
+			[PXCodeType.BqlParameter] = classificationRegistry.GetClassificationType(ColoringConstants.BQLParameterFormat),
+			[PXCodeType.BqlOperator]  = bqlClassificationType,
+			[PXCodeType.BqlCommand]   = bqlClassificationType,
 
-			var tagger = textBuffer.Properties.GetOrCreateSingletonProperty(typeof(PXRoslynColorizerTagger), () =>
-			{
-				return new PXRoslynColorizerTagger(textBuffer, this, subscribeToSettingsChanges: true, useCacheChecking: true);
-			});
+			[PXCodeType.BQLConstantPrefix] = classificationRegistry.GetClassificationType(ColoringConstants.BQLConstantPrefixFormat),
+			[PXCodeType.BQLConstantEnding] = classificationRegistry.GetClassificationType(ColoringConstants.BQLConstantEndingFormat),
 
-			return tagger as ITagger<T>;
-		}
+			[PXCodeType.PXGraph]  = classificationRegistry.GetClassificationType(ColoringConstants.PXGraphFormat),
+			[PXCodeType.PXAction] = classificationRegistry.GetClassificationType(ColoringConstants.PXActionFormat),
+		};
 
-		private static Dictionary<PXCodeType, IClassificationType> GetClassificationTypesForAcumaticaCodeElements(
-																					IClassificationTypeRegistryService classificationRegistry)
+		return acumaticaCodeElementsClassificationTypes;
+	}
+
+	private static Dictionary<int, IClassificationType> GetClassificationTypesForAngleBraces(IClassificationTypeRegistryService classificationRegistry)
+	{
+		var braceTypeByLevel = new Dictionary<int, IClassificationType>(capacity: ColoringConstants.MaxBraceLevel)
 		{
-			IClassificationType bqlClassificationType = classificationRegistry.GetClassificationType(ColoringConstants.BQLOperatorFormat);
-			var acumaticaCodeElementsClassificationTypes = new Dictionary<PXCodeType, IClassificationType>
-			{
-				[PXCodeType.Dac] 		  = classificationRegistry.GetClassificationType(ColoringConstants.DacFormat),
-				[PXCodeType.DacExtension] = classificationRegistry.GetClassificationType(ColoringConstants.DacExtensionFormat),
-				[PXCodeType.DacField] 	  = classificationRegistry.GetClassificationType(ColoringConstants.DacFieldFormat),
-				[PXCodeType.BqlParameter] = classificationRegistry.GetClassificationType(ColoringConstants.BQLParameterFormat),
-				[PXCodeType.BqlOperator]  = bqlClassificationType,
-				[PXCodeType.BqlCommand]   = bqlClassificationType,
+			[0] = classificationRegistry.GetClassificationType(ColoringConstants.BraceLevel_1_Format),
+			[1] = classificationRegistry.GetClassificationType(ColoringConstants.BraceLevel_2_Format),
+			[2] = classificationRegistry.GetClassificationType(ColoringConstants.BraceLevel_3_Format),
 
-				[PXCodeType.BQLConstantPrefix] = classificationRegistry.GetClassificationType(ColoringConstants.BQLConstantPrefixFormat),
-				[PXCodeType.BQLConstantEnding] = classificationRegistry.GetClassificationType(ColoringConstants.BQLConstantEndingFormat),
+			[3] = classificationRegistry.GetClassificationType(ColoringConstants.BraceLevel_4_Format),
+			[4] = classificationRegistry.GetClassificationType(ColoringConstants.BraceLevel_5_Format),
+			[5] = classificationRegistry.GetClassificationType(ColoringConstants.BraceLevel_6_Format),
 
-				[PXCodeType.PXGraph]  = classificationRegistry.GetClassificationType(ColoringConstants.PXGraphFormat),
-				[PXCodeType.PXAction] = classificationRegistry.GetClassificationType(ColoringConstants.PXActionFormat),
-			};
+			[6] = classificationRegistry.GetClassificationType(ColoringConstants.BraceLevel_7_Format),
+			[7] = classificationRegistry.GetClassificationType(ColoringConstants.BraceLevel_8_Format),
+			[8] = classificationRegistry.GetClassificationType(ColoringConstants.BraceLevel_9_Format),
 
-			return acumaticaCodeElementsClassificationTypes;
-		}
+			[9]  = classificationRegistry.GetClassificationType(ColoringConstants.BraceLevel_10_Format),
+			[10] = classificationRegistry.GetClassificationType(ColoringConstants.BraceLevel_11_Format),
+			[11] = classificationRegistry.GetClassificationType(ColoringConstants.BraceLevel_12_Format),
 
-		private static Dictionary<int, IClassificationType> GetClassificationTypesForAngleBraces(IClassificationTypeRegistryService classificationRegistry)
-		{
-			var braceTypeByLevel = new Dictionary<int, IClassificationType>(capacity: ColoringConstants.MaxBraceLevel)
-			{
-				[0] = classificationRegistry.GetClassificationType(ColoringConstants.BraceLevel_1_Format),
-				[1] = classificationRegistry.GetClassificationType(ColoringConstants.BraceLevel_2_Format),
-				[2] = classificationRegistry.GetClassificationType(ColoringConstants.BraceLevel_3_Format),
+			[12] = classificationRegistry.GetClassificationType(ColoringConstants.BraceLevel_13_Format),
+			[13] = classificationRegistry.GetClassificationType(ColoringConstants.BraceLevel_14_Format),
+		};
 
-				[3] = classificationRegistry.GetClassificationType(ColoringConstants.BraceLevel_4_Format),
-				[4] = classificationRegistry.GetClassificationType(ColoringConstants.BraceLevel_5_Format),
-				[5] = classificationRegistry.GetClassificationType(ColoringConstants.BraceLevel_6_Format),
+		return braceTypeByLevel;
+	}
 
-				[6] = classificationRegistry.GetClassificationType(ColoringConstants.BraceLevel_7_Format),
-				[7] = classificationRegistry.GetClassificationType(ColoringConstants.BraceLevel_8_Format),
-				[8] = classificationRegistry.GetClassificationType(ColoringConstants.BraceLevel_9_Format),
+	private static void IncreaseCommentFormatTypesPriority(IClassificationTypeRegistryService registry, IClassificationFormatMapService formatMapService,
+														   IClassificationType highestPriorityType)
+	{
+		if (_isPriorityIncreased)
+			return;
 
-				[9]  = classificationRegistry.GetClassificationType(ColoringConstants.BraceLevel_10_Format),
-				[10] = classificationRegistry.GetClassificationType(ColoringConstants.BraceLevel_11_Format),
-				[11] = classificationRegistry.GetClassificationType(ColoringConstants.BraceLevel_12_Format),
+		bool lockTaken = false;
+		Monitor.TryEnter(_syncRoot, ref lockTaken);
 
-				[12] = classificationRegistry.GetClassificationType(ColoringConstants.BraceLevel_13_Format),
-				[13] = classificationRegistry.GetClassificationType(ColoringConstants.BraceLevel_14_Format),
-			};
+		if (!lockTaken)
+			return;
 
-			return braceTypeByLevel;
-		}
-
-		private static void IncreaseCommentFormatTypesPriority(IClassificationTypeRegistryService registry, IClassificationFormatMapService formatMapService,
-															   IClassificationType highestPriorityType)
+		try
 		{
 			if (_isPriorityIncreased)
 				return;
 
-			bool lockTaken = false;
-			Monitor.TryEnter(_syncRoot, ref lockTaken);
-
-			if (!lockTaken)
-				return;
-
-			try
+			if (formatMapService.GetClassificationFormatMap(category: TextCategory) is IClassificationFormatMap formatMap)
 			{
-				if (_isPriorityIncreased)
-					return;
-
-				if (formatMapService.GetClassificationFormatMap(category: TextCategory) is IClassificationFormatMap formatMap)
-				{
-					IncreaseServiceFormatPriority(formatMap, registry, PredefinedClassificationTypeNames.ExcludedCode, highestPriorityType);
-					IncreaseServiceFormatPriority(formatMap, registry, PredefinedClassificationTypeNames.Comment, highestPriorityType);
-					_isPriorityIncreased = true;
-				}
-			}
-			finally
-			{
-				Monitor.Exit(_syncRoot);
+				IncreaseServiceFormatPriority(formatMap, registry, PredefinedClassificationTypeNames.ExcludedCode, highestPriorityType);
+				IncreaseServiceFormatPriority(formatMap, registry, PredefinedClassificationTypeNames.Comment, highestPriorityType);
+				_isPriorityIncreased = true;
 			}
 		}
-
-		private static void IncreaseServiceFormatPriority(IClassificationFormatMap formatMap, IClassificationTypeRegistryService registry, string formatName,
-														  IClassificationType highestPriorityType)
+		finally
 		{
-			IClassificationType predefinedClassificationType = registry.GetClassificationType(formatName);
-			IClassificationType artificialClassType = registry.CreateTransientClassificationType(predefinedClassificationType);
-			TextFormattingRunProperties properties = formatMap.GetExplicitTextProperties(predefinedClassificationType);
-
-			formatMap.AddExplicitTextProperties(artificialClassType, properties, highestPriorityType);
-			formatMap.SwapPriorities(artificialClassType, predefinedClassificationType);
-			formatMap.SwapPriorities(highestPriorityType, predefinedClassificationType);
+			Monitor.Exit(_syncRoot);
 		}
+	}
+
+	private static void IncreaseServiceFormatPriority(IClassificationFormatMap formatMap, IClassificationTypeRegistryService registry, string formatName,
+													  IClassificationType highestPriorityType)
+	{
+		IClassificationType predefinedClassificationType = registry.GetClassificationType(formatName);
+		IClassificationType artificialClassType = registry.CreateTransientClassificationType(predefinedClassificationType);
+		TextFormattingRunProperties properties = formatMap.GetExplicitTextProperties(predefinedClassificationType);
+
+		formatMap.AddExplicitTextProperties(artificialClassType, properties, highestPriorityType);
+		formatMap.SwapPriorities(artificialClassType, predefinedClassificationType);
+		formatMap.SwapPriorities(highestPriorityType, predefinedClassificationType);
 	}
 }

--- a/src/Acuminator/Acuminator.Vsix/Coloriser/PXColorizerTaggerProvider.cs
+++ b/src/Acuminator/Acuminator.Vsix/Coloriser/PXColorizerTaggerProvider.cs
@@ -28,8 +28,8 @@ namespace Acuminator.Vsix.Coloriser
 	[Export(typeof(IViewTaggerProvider))]
 	public class PXColorizerTaggerProvider : IViewTaggerProvider
 	{
-		[Import]
-		internal IClassificationTypeRegistryService _classificationRegistry = null!; // Set via MEF
+		private readonly IClassificationTypeRegistryService _classificationRegistry;
+		private readonly IClassificationFormatMapService _classificationFormatMapService;
 
 		[Import]
 		internal IClassificationFormatMapService _classificationFormatMapService = null!;  //Set via MEF
@@ -67,6 +67,15 @@ namespace Acuminator.Vsix.Coloriser
 				 ? type
 				 : null;
 			}
+		}
+
+		[ImportingConstructor]
+		public PXColorizerTaggerProvider(IClassificationTypeRegistryService classificationRegistry,
+										 IClassificationFormatMapService classificationFormatMapService,
+										 ITextDocumentFactoryService textDocumentFactory)
+		{
+			_classificationRegistry = classificationRegistry;
+			_classificationFormatMapService = classificationFormatMapService;
 		}
 
 		public virtual ITagger<T>? CreateTagger<T>(ITextView textView, ITextBuffer textBuffer)

--- a/src/Acuminator/Acuminator.Vsix/Coloriser/PXColorizerTaggerProvider.cs
+++ b/src/Acuminator/Acuminator.Vsix/Coloriser/PXColorizerTaggerProvider.cs
@@ -2,7 +2,6 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -34,48 +33,38 @@ namespace Acuminator.Vsix.Coloriser
 		internal ITextDocumentFactoryService TextDocumentFactory { get; }
 
 		private const string TextCategory = "text";
+
 		private static readonly object _syncRoot = new object();
-		private static bool _isPriorityIncreased;
+		private static volatile bool _isPriorityIncreased;
 
-		[MemberNotNullWhen(returnValue: true, nameof(_codeColoringClassificationTypes), nameof(_braceTypeByLevel))]
-		protected bool AreClassificationsInitialized
-		{
-			get;
-			private set;
-		}
+		private readonly Dictionary<PXCodeType, IClassificationType> _codeColoringClassificationTypes;
 
-		private Dictionary<PXCodeType, IClassificationType> _codeColoringClassificationTypes = null!;
-
-		public IClassificationType? this[PXCodeType codeType]
-		{
-			[MethodImpl(MethodImplOptions.AggressiveInlining)]
-			get {
-				return _codeColoringClassificationTypes.TryGetValue(codeType, out IClassificationType type)
+		public IClassificationType? this[PXCodeType codeType] =>
+			_codeColoringClassificationTypes.TryGetValue(codeType, out IClassificationType type)
 				 ? type
 				 : null;
-			}
-		}
 
-		private Dictionary<int, IClassificationType> _braceTypeByLevel = null!;
+		private readonly Dictionary<int, IClassificationType> _braceTypeByLevel;
 
-		public IClassificationType? this[int braceLevel]
-		{
-			[MethodImpl(MethodImplOptions.AggressiveInlining)]
-			get {
-				return _braceTypeByLevel.TryGetValue(braceLevel, out IClassificationType type)
+		public IClassificationType? this[int braceLevel] =>
+			_braceTypeByLevel.TryGetValue(braceLevel, out IClassificationType type)
 				 ? type
 				 : null;
-			}
-		}
 
 		[ImportingConstructor]
 		public PXColorizerTaggerProvider(IClassificationTypeRegistryService classificationRegistry,
 										 IClassificationFormatMapService classificationFormatMapService,
 										 ITextDocumentFactoryService textDocumentFactory)
 		{
-			_classificationRegistry = classificationRegistry;
+			_classificationRegistry 		= classificationRegistry;
 			_classificationFormatMapService = classificationFormatMapService;
-			TextDocumentFactory = textDocumentFactory;
+			TextDocumentFactory 			= textDocumentFactory;
+
+			_codeColoringClassificationTypes = GetClassificationTypesForAcumaticaCodeElements(_classificationRegistry);
+			_braceTypeByLevel = GetClassificationTypesForAngleBraces(_classificationRegistry);
+
+			IncreaseCommentFormatTypesPriority(_classificationRegistry, _classificationFormatMapService,
+												_codeColoringClassificationTypes[PXCodeType.BqlParameter]);
 		}
 
 		public virtual ITagger<T>? CreateTagger<T>(ITextView textView, ITextBuffer textBuffer)
@@ -83,8 +72,6 @@ namespace Acuminator.Vsix.Coloriser
 		{
 			if (textView == null || textBuffer == null || textView.TextBuffer != textBuffer || !ThreadHelper.CheckAccess())
 				return null;
-
-			Initialize(textBuffer);
 
 			var tagger = textBuffer.Properties.GetOrCreateSingletonProperty(typeof(PXRoslynColorizerTagger), () =>
 			{
@@ -94,84 +81,83 @@ namespace Acuminator.Vsix.Coloriser
 			return tagger as ITagger<T>;
 		}
 
-		[MemberNotNull(nameof(_codeColoringClassificationTypes), nameof(_braceTypeByLevel))]
-		protected void Initialize(ITextBuffer textBuffer)
+		private static Dictionary<PXCodeType, IClassificationType> GetClassificationTypesForAcumaticaCodeElements(
+																					IClassificationTypeRegistryService classificationRegistry)
 		{
-			if (AreClassificationsInitialized)
-				return;
-
-			AreClassificationsInitialized = true;
-			InitializeClassificationTypes();
-			IncreaseCommentFormatTypesPriority(_classificationRegistry, _classificationFormatMapService,
-												_codeColoringClassificationTypes[PXCodeType.BqlParameter]);
-		}
-
-		[MemberNotNull(nameof(_codeColoringClassificationTypes), nameof(_braceTypeByLevel))]
-		protected void InitializeClassificationTypes()
-		{
-			IClassificationType bqlClassificationType = _classificationRegistry.GetClassificationType(ColoringConstants.BQLOperatorFormat);
-
-			_codeColoringClassificationTypes = new Dictionary<PXCodeType, IClassificationType>
+			IClassificationType bqlClassificationType = classificationRegistry.GetClassificationType(ColoringConstants.BQLOperatorFormat);
+			var acumaticaCodeElementsClassificationTypes = new Dictionary<PXCodeType, IClassificationType>
 			{
-				[PXCodeType.Dac] 		  = _classificationRegistry.GetClassificationType(ColoringConstants.DacFormat),
-				[PXCodeType.DacExtension] = _classificationRegistry.GetClassificationType(ColoringConstants.DacExtensionFormat),
-				[PXCodeType.DacField] 	  = _classificationRegistry.GetClassificationType(ColoringConstants.DacFieldFormat),
-				[PXCodeType.BqlParameter] = _classificationRegistry.GetClassificationType(ColoringConstants.BQLParameterFormat),
+				[PXCodeType.Dac] 		  = classificationRegistry.GetClassificationType(ColoringConstants.DacFormat),
+				[PXCodeType.DacExtension] = classificationRegistry.GetClassificationType(ColoringConstants.DacExtensionFormat),
+				[PXCodeType.DacField] 	  = classificationRegistry.GetClassificationType(ColoringConstants.DacFieldFormat),
+				[PXCodeType.BqlParameter] = classificationRegistry.GetClassificationType(ColoringConstants.BQLParameterFormat),
 				[PXCodeType.BqlOperator]  = bqlClassificationType,
 				[PXCodeType.BqlCommand]   = bqlClassificationType,
 
-				[PXCodeType.BQLConstantPrefix] = _classificationRegistry.GetClassificationType(ColoringConstants.BQLConstantPrefixFormat),
-				[PXCodeType.BQLConstantEnding] = _classificationRegistry.GetClassificationType(ColoringConstants.BQLConstantEndingFormat),
+				[PXCodeType.BQLConstantPrefix] = classificationRegistry.GetClassificationType(ColoringConstants.BQLConstantPrefixFormat),
+				[PXCodeType.BQLConstantEnding] = classificationRegistry.GetClassificationType(ColoringConstants.BQLConstantEndingFormat),
 
-				[PXCodeType.PXGraph]  = _classificationRegistry.GetClassificationType(ColoringConstants.PXGraphFormat),
-				[PXCodeType.PXAction] = _classificationRegistry.GetClassificationType(ColoringConstants.PXActionFormat),
+				[PXCodeType.PXGraph]  = classificationRegistry.GetClassificationType(ColoringConstants.PXGraphFormat),
+				[PXCodeType.PXAction] = classificationRegistry.GetClassificationType(ColoringConstants.PXActionFormat),
 			};
 
-			_braceTypeByLevel = new Dictionary<int, IClassificationType>(capacity: ColoringConstants.MaxBraceLevel)
+			return acumaticaCodeElementsClassificationTypes;
+		}
+
+		private static Dictionary<int, IClassificationType> GetClassificationTypesForAngleBraces(IClassificationTypeRegistryService classificationRegistry)
+		{
+			var braceTypeByLevel = new Dictionary<int, IClassificationType>(capacity: ColoringConstants.MaxBraceLevel)
 			{
-				[0] = _classificationRegistry.GetClassificationType(ColoringConstants.BraceLevel_1_Format),
-				[1] = _classificationRegistry.GetClassificationType(ColoringConstants.BraceLevel_2_Format),
-				[2] = _classificationRegistry.GetClassificationType(ColoringConstants.BraceLevel_3_Format),
+				[0] = classificationRegistry.GetClassificationType(ColoringConstants.BraceLevel_1_Format),
+				[1] = classificationRegistry.GetClassificationType(ColoringConstants.BraceLevel_2_Format),
+				[2] = classificationRegistry.GetClassificationType(ColoringConstants.BraceLevel_3_Format),
 
-				[3] = _classificationRegistry.GetClassificationType(ColoringConstants.BraceLevel_4_Format),
-				[4] = _classificationRegistry.GetClassificationType(ColoringConstants.BraceLevel_5_Format),
-				[5] = _classificationRegistry.GetClassificationType(ColoringConstants.BraceLevel_6_Format),
+				[3] = classificationRegistry.GetClassificationType(ColoringConstants.BraceLevel_4_Format),
+				[4] = classificationRegistry.GetClassificationType(ColoringConstants.BraceLevel_5_Format),
+				[5] = classificationRegistry.GetClassificationType(ColoringConstants.BraceLevel_6_Format),
 
-				[6] = _classificationRegistry.GetClassificationType(ColoringConstants.BraceLevel_7_Format),
-				[7] = _classificationRegistry.GetClassificationType(ColoringConstants.BraceLevel_8_Format),
-				[8] = _classificationRegistry.GetClassificationType(ColoringConstants.BraceLevel_9_Format),
+				[6] = classificationRegistry.GetClassificationType(ColoringConstants.BraceLevel_7_Format),
+				[7] = classificationRegistry.GetClassificationType(ColoringConstants.BraceLevel_8_Format),
+				[8] = classificationRegistry.GetClassificationType(ColoringConstants.BraceLevel_9_Format),
 
-				[9]  = _classificationRegistry.GetClassificationType(ColoringConstants.BraceLevel_10_Format),
-				[10] = _classificationRegistry.GetClassificationType(ColoringConstants.BraceLevel_11_Format),
-				[11] = _classificationRegistry.GetClassificationType(ColoringConstants.BraceLevel_12_Format),
+				[9]  = classificationRegistry.GetClassificationType(ColoringConstants.BraceLevel_10_Format),
+				[10] = classificationRegistry.GetClassificationType(ColoringConstants.BraceLevel_11_Format),
+				[11] = classificationRegistry.GetClassificationType(ColoringConstants.BraceLevel_12_Format),
 
-				[12] = _classificationRegistry.GetClassificationType(ColoringConstants.BraceLevel_13_Format),
-				[13] = _classificationRegistry.GetClassificationType(ColoringConstants.BraceLevel_14_Format),
+				[12] = classificationRegistry.GetClassificationType(ColoringConstants.BraceLevel_13_Format),
+				[13] = classificationRegistry.GetClassificationType(ColoringConstants.BraceLevel_14_Format),
 			};
+
+			return braceTypeByLevel;
 		}
 
 		private static void IncreaseCommentFormatTypesPriority(IClassificationTypeRegistryService registry, IClassificationFormatMapService formatMapService,
 															   IClassificationType highestPriorityType)
 		{
+			if (_isPriorityIncreased)
+				return;
+
 			bool lockTaken = false;
 			Monitor.TryEnter(_syncRoot, ref lockTaken);
 
-			if (lockTaken)
+			if (!lockTaken)
+				return;
+
+			try
 			{
-				try
+				if (_isPriorityIncreased)
+					return;
+
+				if (formatMapService.GetClassificationFormatMap(category: TextCategory) is IClassificationFormatMap formatMap)
 				{
-					if (!_isPriorityIncreased)
-					{
-						_isPriorityIncreased = true;
-						IClassificationFormatMap formatMap = formatMapService.GetClassificationFormatMap(category: TextCategory);
-						IncreaseServiceFormatPriority(formatMap, registry, PredefinedClassificationTypeNames.ExcludedCode, highestPriorityType);
-						IncreaseServiceFormatPriority(formatMap, registry, PredefinedClassificationTypeNames.Comment, highestPriorityType);
-					}
+					IncreaseServiceFormatPriority(formatMap, registry, PredefinedClassificationTypeNames.ExcludedCode, highestPriorityType);
+					IncreaseServiceFormatPriority(formatMap, registry, PredefinedClassificationTypeNames.Comment, highestPriorityType);
+					_isPriorityIncreased = true;
 				}
-				finally
-				{
-					Monitor.Exit(_syncRoot);
-				}
+			}
+			finally
+			{
+				Monitor.Exit(_syncRoot);
 			}
 		}
 

--- a/src/Acuminator/Acuminator.Vsix/Coloriser/PXRoslynColorizerTagger.cs
+++ b/src/Acuminator/Acuminator.Vsix/Coloriser/PXRoslynColorizerTagger.cs
@@ -14,7 +14,6 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Tagging;
-using Microsoft.VisualStudio.TextManager.Interop;
 
 using ThreadHelper = Microsoft.VisualStudio.Shell.ThreadHelper;
 

--- a/src/Acuminator/Acuminator.Vsix/Coloriser/PXRoslynColorizerTagger.cs
+++ b/src/Acuminator/Acuminator.Vsix/Coloriser/PXRoslynColorizerTagger.cs
@@ -56,10 +56,14 @@ internal partial class PXRoslynColorizerTagger : PXTaggerBase, ITagger<IClassifi
 		ClassificationTagsCache = new TagsCacheAsync<IClassificationTag>();
 		OutliningsTagsCache = new TagsCacheAsync<IOutliningRegionTag>();
 
-		_roslynWorkspaceProvider = new RoslynWorkspaceProvider(buffer);
+		// Roslyn workspace provider creation and subscription to workspace events should be done under sync lock to avoid
+		// unlikely race condition in the constructor.
+		// The lock is expected to be re-entrant, the Monitor synchronization should not be changed to another synchronization mechanism without a rework.
+		object workspaceLock = new object();
 
-		lock (_roslynWorkspaceProvider.WorkspaceSubscriptionLocker)
+		lock (workspaceLock)
 		{
+			_roslynWorkspaceProvider = RoslynWorkspaceProvider.Create(_cachedTextContainer, workspaceLock);
 			_roslynWorkspaceProvider.WorkspaceChanged += WorkspaceAttachedToDocumentChanged;
 
 			// Drive initial setup through the same code path as change events.

--- a/src/Acuminator/Acuminator.Vsix/Coloriser/PXRoslynColorizerTagger.cs
+++ b/src/Acuminator/Acuminator.Vsix/Coloriser/PXRoslynColorizerTagger.cs
@@ -14,6 +14,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Tagging;
+using Microsoft.VisualStudio.TextManager.Interop;
 
 using ThreadHelper = Microsoft.VisualStudio.Shell.ThreadHelper;
 
@@ -22,7 +23,7 @@ namespace Acuminator.Vsix.Coloriser;
 /// <summary>
 /// A Roslyn-based colorizer tagger.
 /// </summary>
-internal partial class PXRoslynColorizerTagger : PXTaggerBase, ITagger<IClassificationTag>, IDisposable
+internal partial class PXRoslynColorizerTagger : PXTaggerBase, ITagger<IClassificationTag>
 {
 	protected internal TagsCacheAsync<IClassificationTag> ClassificationTagsCache { get; }
 
@@ -47,9 +48,9 @@ internal partial class PXRoslynColorizerTagger : PXTaggerBase, ITagger<IClassifi
 	private readonly RoslynWorkspaceProvider _roslynWorkspaceProvider;
 	private readonly SourceTextContainer _cachedTextContainer;
 
-	public PXRoslynColorizerTagger(ITextBuffer buffer, PXColorizerTaggerProvider provider, bool subscribeToSettingsChanges,
-									bool useCacheChecking) :
-							  base(buffer, subscribeToSettingsChanges, useCacheChecking)
+	public PXRoslynColorizerTagger(ITextBuffer buffer, ITextDocumentFactoryService textDocumentFactory, PXColorizerTaggerProvider provider,
+								   bool subscribeToSettingsChanges, bool useCacheChecking) :
+							  base(buffer, textDocumentFactory, subscribeToSettingsChanges, useCacheChecking)
 	{
 		Provider = provider.CheckIfNull();
 		_cachedTextContainer = Buffer.AsTextContainer();
@@ -230,8 +231,10 @@ internal partial class PXRoslynColorizerTagger : PXTaggerBase, ITagger<IClassifi
 		OutliningsTagsCache.CompleteProcessing();
 	}
 
-	public override void Dispose()
+	protected override void CleanupOnTextDocumentDisposed(object sender, EventArgs e)
 	{
+		base.CleanupOnTextDocumentDisposed(sender, e);
+
 		lock (_roslynWorkspaceProvider.WorkspaceSubscriptionLocker)
 		{
 			_roslynWorkspaceProvider.WorkspaceChanged -= WorkspaceAttachedToDocumentChanged;
@@ -241,15 +244,12 @@ internal partial class PXRoslynColorizerTagger : PXTaggerBase, ITagger<IClassifi
 				workspaceToUnsubscribe.WorkspaceChanged -= OnWorkspaceChanged;
 		}
 		
-
 		_roslynWorkspaceProvider.Dispose();
 		BackgroundTagging?.Dispose();
 		ClassificationTagsCache.Reset();
 		OutliningsTagsCache.Reset();
 
 		_hasReferenceToAcumaticaPlatform = false;
-
-		base.Dispose();
 	}
 
 	private void WorkspaceAttachedToDocumentChanged(object sender, DocumentWorkspaceChangedEventArgs e)

--- a/src/Acuminator/Acuminator.Vsix/Coloriser/PXRoslynColorizerTagger.cs
+++ b/src/Acuminator/Acuminator.Vsix/Coloriser/PXRoslynColorizerTagger.cs
@@ -241,9 +241,10 @@ internal partial class PXRoslynColorizerTagger : PXTaggerBase, ITagger<IClassifi
 
 			if (workspaceToUnsubscribe != null)
 				workspaceToUnsubscribe.WorkspaceChanged -= OnWorkspaceChanged;
+
+			_roslynWorkspaceProvider.Dispose();
 		}
 		
-		_roslynWorkspaceProvider.Dispose();
 		BackgroundTagging?.Dispose();
 		ClassificationTagsCache.Reset();
 		OutliningsTagsCache.Reset();

--- a/src/Acuminator/Acuminator.Vsix/Coloriser/Roslyn/RoslynWorkspaceProvider.cs
+++ b/src/Acuminator/Acuminator.Vsix/Coloriser/Roslyn/RoslynWorkspaceProvider.cs
@@ -7,7 +7,6 @@ using Acuminator.Vsix.Logger;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
-using Microsoft.VisualStudio.Text;
 
 namespace Acuminator.Vsix.Coloriser;
 
@@ -28,7 +27,7 @@ internal class RoslynWorkspaceProvider : IDisposable
 	/// This locker has to be externally available because external subscribers like Roslyn colorizer subscribe on workspace changes and have unavoidable race condition<br/>
 	/// that has to use this locker to synchronize with change of the Roslyn workspace associated with a VS text buffer.
 	/// </remarks>
-	public object WorkspaceSubscriptionLocker { get; } = new object();
+	public object WorkspaceSubscriptionLocker { get; }
 
 	private Workspace? _workspace;
 
@@ -45,16 +44,24 @@ internal class RoslynWorkspaceProvider : IDisposable
 
 	public event EventHandler<DocumentWorkspaceChangedEventArgs>? WorkspaceChanged;
 
-	public RoslynWorkspaceProvider(ITextBuffer buffer)
+	private RoslynWorkspaceProvider(WorkspaceRegistration workspaceRegistration, object workspaceSubscriptionLocker)
 	{
-		SourceTextContainer sourceTextContainer = buffer.CheckIfNull().AsTextContainer();
+		WorkspaceSubscriptionLocker = workspaceSubscriptionLocker;
+		_workspaceRegistration = workspaceRegistration;
+		_workspaceRegistration.WorkspaceChanged += OnWorkspaceChanged;
+		_workspace = GetWorkspaceThatSupportsColoring(_workspaceRegistration);
+	}
 
-		lock (WorkspaceSubscriptionLocker)
+	internal static RoslynWorkspaceProvider Create(SourceTextContainer sourceTextContainer, object syncLock)
+	{
+		sourceTextContainer.ThrowOnNull();
+		syncLock.ThrowOnNull();
+
+		lock (syncLock)
 		{
-			_workspaceRegistration = Workspace.GetWorkspaceRegistration(sourceTextContainer);
-			_workspaceRegistration.WorkspaceChanged += OnWorkspaceChanged;
-
-			_workspace = GetWorkspaceThatSupportsColoring(_workspaceRegistration);
+			var workspaceRegistration = Workspace.GetWorkspaceRegistration(sourceTextContainer);
+			var workspaceProvider = new RoslynWorkspaceProvider(workspaceRegistration, syncLock);
+			return workspaceProvider;
 		}
 	}
 

--- a/src/Acuminator/Acuminator.Vsix/Coloriser/TextDocumentDisposedNotification.cs
+++ b/src/Acuminator/Acuminator.Vsix/Coloriser/TextDocumentDisposedNotification.cs
@@ -1,0 +1,69 @@
+﻿#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using Acuminator.Utilities.Common;
+
+using Microsoft.VisualStudio.Text;
+
+namespace Acuminator.Vsix.Coloriser;
+
+public class TextDocumentDisposedNotification
+{
+	private readonly ITextDocumentFactoryService _textDocumentFactory;
+	private readonly ITextBuffer _textBuffer;
+	private ITextDocument? _textDocument;
+
+	public event EventHandler? OnCurrentTextDocumentDisposed;
+
+	public TextDocumentDisposedNotification(ITextDocumentFactoryService textDocumentFactory, ITextBuffer textBuffer)
+	{
+		_textDocumentFactory = textDocumentFactory.CheckIfNull();
+		_textBuffer = textBuffer.CheckIfNull();
+
+		SubscribeToDocumentLifetimeEvents();
+	}
+
+	private void SubscribeToDocumentLifetimeEvents()
+	{
+		// If a document already exists for this buffer just attach the disposed handler.
+		if (_textDocumentFactory.TryGetTextDocument(_textBuffer, out ITextDocument existingTextDocument))
+		{
+			SubscribeOnTextDocumentDisposedEvent(existingTextDocument);
+		}
+		else
+		{
+			// If the document is created later, attach to the created event and listen for the right document to be created, then attach the disposed handler.
+			_textDocumentFactory.TextDocumentCreated += OnTextDocumentCreated;
+		}
+	}
+
+	private void OnTextDocumentCreated(object sender, TextDocumentEventArgs e)
+	{
+		// Filter out doc creation events for other documents
+		if (e.TextDocument == null || !ReferenceEquals(_textBuffer, e.TextDocument.TextBuffer))
+			return;
+
+		//Dispose of the subscription immediately to always run the handler only once
+		_textDocumentFactory.TextDocumentCreated -= OnTextDocumentCreated;
+		SubscribeOnTextDocumentDisposedEvent(e.TextDocument);
+	}
+
+	private void SubscribeOnTextDocumentDisposedEvent(ITextDocument textDocument)
+	{
+		_textDocument = textDocument;
+		_textDocumentFactory.TextDocumentDisposed += OnTextDocumentDisposed;
+	}
+
+	private void OnTextDocumentDisposed(object sender, TextDocumentEventArgs e)
+	{
+		// Filter out dispose events for other documents
+		if (!ReferenceEquals(_textDocument, e.TextDocument))
+			return;
+
+		//Dispose of the subscription immediately to always run the handler only once
+		_textDocumentFactory.TextDocumentDisposed -= OnTextDocumentDisposed;
+		OnCurrentTextDocumentDisposed?.Invoke(this, EventArgs.Empty);
+	}
+}

--- a/src/Acuminator/Acuminator.Vsix/Coloriser/TextDocumentDisposedNotification.cs
+++ b/src/Acuminator/Acuminator.Vsix/Coloriser/TextDocumentDisposedNotification.cs
@@ -15,7 +15,7 @@ public class TextDocumentDisposedNotification
 	private readonly ITextBuffer _textBuffer;
 	private ITextDocument? _textDocument;
 
-	public event EventHandler? OnCurrentTextDocumentDisposed;
+	public event EventHandler? CurrentTextDocumentDisposed;
 
 	public TextDocumentDisposedNotification(ITextDocumentFactoryService textDocumentFactory, ITextBuffer textBuffer)
 	{
@@ -64,6 +64,6 @@ public class TextDocumentDisposedNotification
 
 		//Dispose of the subscription immediately to always run the handler only once
 		_textDocumentFactory.TextDocumentDisposed -= OnTextDocumentDisposed;
-		OnCurrentTextDocumentDisposed?.Invoke(this, EventArgs.Empty);
+		CurrentTextDocumentDisposed?.Invoke(this, EventArgs.Empty);
 	}
 }

--- a/src/Acuminator/Acuminator.Vsix/Coloriser/TextDocumentDisposedNotification.cs
+++ b/src/Acuminator/Acuminator.Vsix/Coloriser/TextDocumentDisposedNotification.cs
@@ -9,6 +9,12 @@ using Microsoft.VisualStudio.Text;
 
 namespace Acuminator.Vsix.Coloriser;
 
+/// <summary>
+/// A text document disposed notification provider.
+/// </summary>
+/// <remarks>
+/// This component is not thread safe and is supposed to run only on the UI thread.
+/// </remarks>
 internal class TextDocumentDisposedNotification
 {
 	private readonly ITextDocumentFactoryService _textDocumentFactory;

--- a/src/Acuminator/Acuminator.Vsix/Coloriser/TextDocumentDisposedNotification.cs
+++ b/src/Acuminator/Acuminator.Vsix/Coloriser/TextDocumentDisposedNotification.cs
@@ -9,7 +9,7 @@ using Microsoft.VisualStudio.Text;
 
 namespace Acuminator.Vsix.Coloriser;
 
-public class TextDocumentDisposedNotification
+internal class TextDocumentDisposedNotification
 {
 	private readonly ITextDocumentFactoryService _textDocumentFactory;
 	private readonly ITextBuffer _textBuffer;


### PR DESCRIPTION
### Changes Overview
- Added new `TextDocumentDisposedNotification` component to subscribe to the disposal of the text document for which tagger was created
- Removed `IDisposable` interface from coloring and outlining taggers, added the use of the new mechanism to dispose taggers only on the text document's disposal to avoid calls to `Dispose` for the cached tagger instance from the temp VS text views.
- Enhanced sync block in the colorizer tagger's constructor for the Roslyn workspace provider creation
- Refactored the colorizing tagger provider:
   - Made MEF-injected services private readonly fields injected via injecting constructor MEF mechanism,
   - Moved initialization from the `CreateTagger` method to the constructor, simplified code.
   - Removed code that increases the priority of code comments since it was needed only for reg ex based coloring which was already removed. Greatly simplified code coloring.