### PR TITLE
Bugfix/atr 973 dev fix exception on broken solution

### DIFF
--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/AsyncVoidMethodsAndLambdas/AsyncVoidMethodsAndLambdasAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/AsyncVoidMethodsAndLambdas/AsyncVoidMethodsAndLambdasAnalyzer.cs
@@ -108,7 +108,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.AsyncVoidMethodsAndLambdas
 			if (!lambdaOrAnonymousDelegateDeclaration.AsyncKeyword.IsKind(SyntaxKind.AsyncKeyword))
 				return;
 
-			var lambdaMethodSymbol = syntaxContext.SemanticModel.GetSymbolOrFirstCandidate(lambdaOrAnonymousDelegateDeclaration, 
+			var lambdaMethodSymbol = syntaxContext.SemanticModel.GetSymbolOrBestCandidate(lambdaOrAnonymousDelegateDeclaration, 
 																						   syntaxContext.CancellationToken) as IMethodSymbol;
 			if (lambdaMethodSymbol == null || !lambdaMethodSymbol.ReturnsVoid)
 				return;

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/BannedApi/BannedApiAnalyzer.ApiNodesWalker.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/BannedApi/BannedApiAnalyzer.ApiNodesWalker.cs
@@ -94,7 +94,7 @@ public partial class BannedApiAnalyzer
 			Cancellation.ThrowIfCancellationRequested();
 
 			if (usingDirectiveNode.Name == null ||
-				SemanticModel.GetSymbolOrFirstCandidate(usingDirectiveNode.Name, Cancellation) is not ISymbol typeOrNamespaceSymbol)
+				SemanticModel.GetSymbolOrBestCandidate(usingDirectiveNode.Name, Cancellation) is not ISymbol typeOrNamespaceSymbol)
 			{
 				return;
 			}
@@ -139,7 +139,7 @@ public partial class BannedApiAnalyzer
 		{
 			Cancellation.ThrowIfCancellationRequested();
 
-			if (SemanticModel.GetSymbolOrFirstCandidate(genericNameNode, Cancellation) is not ISymbol symbol)
+			if (SemanticModel.GetSymbolOrBestCandidate(genericNameNode, Cancellation) is not ISymbol symbol)
 			{
 				Cancellation.ThrowIfCancellationRequested();
 				base.VisitGenericName(genericNameNode);
@@ -202,8 +202,8 @@ public partial class BannedApiAnalyzer
 		{
 			Cancellation.ThrowIfCancellationRequested();
 
-			ISymbol? accessedMember = SemanticModel.GetSymbolOrFirstCandidate(wholeAccessExpression, Cancellation);
-			accessedMember ??= SemanticModel.GetSymbolOrFirstCandidate(accessMemberExpression, Cancellation);
+			ISymbol? accessedMember = SemanticModel.GetSymbolOrBestCandidate(wholeAccessExpression, Cancellation);
+			accessedMember ??= SemanticModel.GetSymbolOrBestCandidate(accessMemberExpression, Cancellation);
 
 			if (accessedMember == null)
 				return true;
@@ -214,7 +214,7 @@ public partial class BannedApiAnalyzer
 				return false;
 
 			expressionBeingAccessed = UnwrapAccessExpressionFromArrayAccess(expressionBeingAccessed);
-			var symbolBeingAccessed = SemanticModel.GetSymbolOrFirstCandidate(expressionBeingAccessed, Cancellation);
+			var symbolBeingAccessed = SemanticModel.GetSymbolOrBestCandidate(expressionBeingAccessed, Cancellation);
 			
 			if (symbolBeingAccessed == null || symbolBeingAccessed.Equals(accessedMember.ContainingType, SymbolEqualityComparer.Default))
 				return !IsAllowedApi(accessedMember);
@@ -238,7 +238,7 @@ public partial class BannedApiAnalyzer
 		{
 			Cancellation.ThrowIfCancellationRequested();
 
-			if (SemanticModel.GetSymbolOrFirstCandidate(identifierNode, Cancellation) is not ISymbol symbol)
+			if (SemanticModel.GetSymbolOrBestCandidate(identifierNode, Cancellation) is not ISymbol symbol)
 				return;
 
 			Cancellation.ThrowIfCancellationRequested();
@@ -249,7 +249,7 @@ public partial class BannedApiAnalyzer
 		{
 			Cancellation.ThrowIfCancellationRequested();
 
-			if (SemanticModel.GetSymbolOrFirstCandidate(qualifiedName, Cancellation) is not ISymbol symbol)
+			if (SemanticModel.GetSymbolOrBestCandidate(qualifiedName, Cancellation) is not ISymbol symbol)
 			{
 				base.VisitQualifiedName(qualifiedName);
 				return;

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/DatabaseQueries/DatabaseQueriesInRowSelectingAnalyzer.PXConnectionScopeVisitor.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/DatabaseQueries/DatabaseQueriesInRowSelectingAnalyzer.PXConnectionScopeVisitor.cs
@@ -35,14 +35,14 @@ namespace Acuminator.Analyzers.StaticAnalysis.DatabaseQueries
 			public override bool VisitObjectCreationExpression(ObjectCreationExpressionSyntax node)
 			{
 				var semanticModel = _semanticModelGetter(node.SyntaxTree);
-				var typeSymbol = semanticModel?.GetSymbolOrFirstCandidate(node.Type, _cancellation) as ITypeSymbol;
+				var typeSymbol = semanticModel?.GetSymbolOrBestCandidate(node.Type, _cancellation) as ITypeSymbol;
 				return IsPXConnectionScope(typeSymbol);
 			}
 
 			public override bool VisitImplicitObjectCreationExpression(ImplicitObjectCreationExpressionSyntax node)
 			{
 				var semanticModel = _semanticModelGetter(node.SyntaxTree);
-				var constructor = semanticModel?.GetSymbolOrFirstCandidate(node, _cancellation) as IMethodSymbol;
+				var constructor = semanticModel?.GetSymbolOrBestCandidate(node, _cancellation) as IMethodSymbol;
 
 				if (constructor?.ContainingType == null || constructor.MethodKind != MethodKind.Constructor)
 					return false;

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/IncorrectTaskUsageInAsyncCode/IncorrectTaskUsageInAsyncCodeAnalyzer.TaskUsageCheckingWalker.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/IncorrectTaskUsageInAsyncCode/IncorrectTaskUsageInAsyncCodeAnalyzer.TaskUsageCheckingWalker.cs
@@ -65,7 +65,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.IncorrectTaskUsageInAsyncCode
 				if (typeNode == null)
 					return;
 
-				var variableType = SemanticModel.GetSymbolOrFirstCandidate(typeNode, Cancellation) as ITypeSymbol;
+				var variableType = SemanticModel.GetSymbolOrBestCandidate(typeNode, Cancellation) as ITypeSymbol;
 
 				if (variableType == null || !IsTaskType(variableType))
 					return;
@@ -159,7 +159,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.IncorrectTaskUsageInAsyncCode
 			{
 				if (containingMethodOrLocalFunction is AnonymousFunctionExpressionSyntax lambdaDeclaration)
 				{
-					var lambdaSymbol = SemanticModel.GetSymbolOrFirstCandidate(lambdaDeclaration, Cancellation) as IMethodSymbol;
+					var lambdaSymbol = SemanticModel.GetSymbolOrBestCandidate(lambdaDeclaration, Cancellation) as IMethodSymbol;
 					return lambdaSymbol?.ReturnType;
 				}
 
@@ -174,7 +174,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.IncorrectTaskUsageInAsyncCode
 				if (returnTypeNode == null)
 					return null;
 
-				var returnTypeSymbol = SemanticModel.GetSymbolOrFirstCandidate(returnTypeNode, Cancellation) as ITypeSymbol;
+				var returnTypeSymbol = SemanticModel.GetSymbolOrBestCandidate(returnTypeNode, Cancellation) as ITypeSymbol;
 				return returnTypeSymbol;
 			}
 

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/Localization/LocalizationPXExceptionAndPXexceptionInfoAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/Localization/LocalizationPXExceptionAndPXexceptionInfoAnalyzer.cs
@@ -78,7 +78,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.Localization
 			if (!isLocalizableException && !isPXExceptionInfo)
 				return;
 
-			var symbol = syntaxContext.SemanticModel.GetSymbolOrFirstCandidate(constructorCall, syntaxContext.CancellationToken);
+			var symbol = syntaxContext.SemanticModel.GetSymbolOrBestCandidate(constructorCall, syntaxContext.CancellationToken);
 
 			if (symbol is not IMethodSymbol constructor)
 				return;
@@ -116,7 +116,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.Localization
 
 			foreach (ConstructorInitializerSyntax constructorCall in baseOrThisConstructorCalls)
 			{
-				var symbol = syntaxContext.SemanticModel.GetSymbolOrFirstCandidate(constructorCall, syntaxContext.CancellationToken);
+				var symbol = syntaxContext.SemanticModel.GetSymbolOrBestCandidate(constructorCall, syntaxContext.CancellationToken);
 
 				if (symbol is not IMethodSymbol constructorSymbol)
 					continue;

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/Localization/LocalizationPXExceptionAndPXexceptionInfoAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/Localization/LocalizationPXExceptionAndPXexceptionInfoAnalyzer.cs
@@ -145,9 +145,9 @@ namespace Acuminator.Analyzers.StaticAnalysis.Localization
 
 			for (int argIndex = 0; argIndex < args.Arguments.Count; argIndex++)
 			{
-				IParameterSymbol mappedParameter = argumentsToParametersMapping.Value.GetMappedParameter(constructor, argIndex);
+				IParameterSymbol? mappedParameter = argumentsToParametersMapping.Value.GetMappedParameter(constructor, argIndex);
 
-				if (parametersWithLocalizableText.Contains(mappedParameter.Name, StringComparer.Ordinal))
+				if (mappedParameter != null && parametersWithLocalizableText.Contains(mappedParameter.Name, StringComparer.Ordinal))
 				{
 					var argument = args.Arguments[argIndex];
 					return argument.Expression;

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/LongOperationDelegateClosures/LongOperationDelegateClosuresAnalyzer.LongOperationsChecker.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/LongOperationDelegateClosures/LongOperationDelegateClosuresAnalyzer.LongOperationsChecker.cs
@@ -698,7 +698,11 @@ namespace Acuminator.Analyzers.StaticAnalysis.LongOperationDelegateClosures
 						continue;
 
 					var mappedParameter = argumentsToParametersMapping.Value.GetMappedParameter(calledMethod, argument.Index);
-					nonCapturableParametersOfCalledMethodFromCallArgs.Add(new PassedParameter(mappedParameter.Name, capturedTypes));
+
+					if (mappedParameter != null)
+					{
+						nonCapturableParametersOfCalledMethodFromCallArgs.Add(new PassedParameter(mappedParameter.Name, capturedTypes));
+					}
 				}
 
 				return nonCapturableParametersOfCalledMethodFromCallArgs;

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/LongOperationDelegateClosures/LongOperationDelegateTypeClassifier.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/LongOperationDelegateClosures/LongOperationDelegateTypeClassifier.cs
@@ -51,7 +51,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.LongOperationDelegateClosures
 			{
 				case DelegateNames.Processing.SetProcessDelegate:
 				case DelegateNames.Processing.SetAsyncProcessDelegate:
-					var setDelegateSymbol = semanticModel.GetSymbolOrFirstCandidate(methodAccessNode, cancellationToken) as IMethodSymbol;
+					var setDelegateSymbol = semanticModel.GetSymbolOrBestCandidate(methodAccessNode, cancellationToken) as IMethodSymbol;
 
 					if (setDelegateSymbol != null && setDelegateSymbol.ContainingType.ConstructedFrom.InheritsFromOrEquals(pxContext.PXProcessingBase.Type))
 						return (LongOperationDelegateType.ProcessingDelegate, setDelegateSymbol);
@@ -61,7 +61,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.LongOperationDelegateClosures
 				case DelegateNames.Async.StartOperation:
 				case DelegateNames.Async.StartAsyncOperation:
 				case DelegateNames.Async.Await:
-					var longRunDelegate = semanticModel.GetSymbolOrFirstCandidate(methodAccessNode, cancellationToken) as IMethodSymbol;
+					var longRunDelegate = semanticModel.GetSymbolOrBestCandidate(methodAccessNode, cancellationToken) as IMethodSymbol;
 
 					if (longRunDelegate == null)
 						return null;

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/NoPrimaryViewForPrimaryDac/NoPrimaryViewForPrimaryDacAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/NoPrimaryViewForPrimaryDac/NoPrimaryViewForPrimaryDacAnalyzer.cs
@@ -63,7 +63,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.NoPrimaryViewForPrimaryDac
 
 			foreach (GenericNameSyntax baseClassTypeNode in baseClassesTypeNodes)
 			{
-				var baseClassTypeSymbol = semanticModel.GetSymbolOrFirstCandidate(baseClassTypeNode, context.CancellationToken) as INamedTypeSymbol;
+				var baseClassTypeSymbol = semanticModel.GetSymbolOrBestCandidate(baseClassTypeNode, context.CancellationToken) as INamedTypeSymbol;
 				Location? location = GetLocationFromBaseClassTypeNode(baseClassTypeNode, baseClassTypeSymbol, declaredPrimaryDacType);
 
 				if (location != null)

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXGraphCreateInstance/PXGraphCreateInstanceAnalyzer.Walker.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXGraphCreateInstance/PXGraphCreateInstanceAnalyzer.Walker.cs
@@ -30,7 +30,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXGraphCreateInstance
 			{
 				_context.CancellationToken.ThrowIfCancellationRequested();
 
-				if (node.Type == null || _semanticModel.GetSymbolOrFirstCandidate(node.Type, _context.CancellationToken) is not ITypeSymbol typeSymbol)
+				if (node.Type == null || _semanticModel.GetSymbolOrBestCandidate(node.Type, _context.CancellationToken) is not ITypeSymbol typeSymbol)
 				{
 					base.VisitObjectCreationExpression(node);
 					return;
@@ -53,7 +53,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXGraphCreateInstance
 			{
 				_context.CancellationToken.ThrowIfCancellationRequested();
 
-				var constructor = _semanticModel.GetSymbolOrFirstCandidate(node, _context.CancellationToken) as IMethodSymbol;
+				var constructor = _semanticModel.GetSymbolOrBestCandidate(node, _context.CancellationToken) as IMethodSymbol;
 
 				if (constructor?.ContainingType == null || constructor.MethodKind != MethodKind.Constructor) 
 				{

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXGraphCreateInstance/PXGraphCreateInstanceFix.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXGraphCreateInstance/PXGraphCreateInstanceFix.cs
@@ -87,7 +87,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXGraphCreateInstance
 				if (_generator == null) 
 					return base.VisitObjectCreationExpression(node);
 
-				var graphTypeSymbol		   = _semanticModel.GetSymbolOrFirstCandidate(node.Type, _cancellation) as ITypeSymbol;
+				var graphTypeSymbol		   = _semanticModel.GetSymbolOrBestCandidate(node.Type, _cancellation) as ITypeSymbol;
 				var createInstanceCallNode = GeneratePXGraphCreateInstanceCall(graphTypeSymbol);
 
 				return createInstanceCallNode ?? base.VisitObjectCreationExpression(node);
@@ -100,7 +100,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXGraphCreateInstance
 				if (_generator == null)
 					return base.VisitImplicitObjectCreationExpression(node);
 
-				var constructor = _semanticModel.GetSymbolOrFirstCandidate(node, _cancellation) as IMethodSymbol;
+				var constructor = _semanticModel.GetSymbolOrBestCandidate(node, _cancellation) as IMethodSymbol;
 
 				if (constructor?.ContainingType == null || constructor.MethodKind != MethodKind.Constructor)
 					return base.VisitImplicitObjectCreationExpression(node);

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXGraphCreationForBqlQueries/PXGraphCreationForBqlQueriesAnalyzer.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXGraphCreationForBqlQueries/PXGraphCreationForBqlQueriesAnalyzer.cs
@@ -135,7 +135,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXGraphCreationForBqlQueries
 
 		private HashSet<ISymbol> GetDifferentSymbolsFromCallArgs(SemanticModel semanticModel, List<ExpressionSyntax> bqlSelectGraphArgNodes, 
 																 CancellationToken cancellation) =>
-			bqlSelectGraphArgNodes.Select(graphArgSyntax => semanticModel.GetSymbolOrFirstCandidate(graphArgSyntax, cancellation))
+			bqlSelectGraphArgNodes.Select(graphArgSyntax => semanticModel.GetSymbolOrBestCandidate(graphArgSyntax, cancellation))
 								  .Where(graphArgSymbol => graphArgSymbol != null && graphArgSymbol is not (IPropertySymbol or IFieldSymbol))
 								  .ToHashSet(SymbolEqualityComparer.Default)!;
 
@@ -150,7 +150,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXGraphCreationForBqlQueries
 
 			foreach (var subNode in nodesToVisit)
 			{
-				var symbol = semanticModel.GetSymbolOrFirstCandidate(subNode, cancellation);
+				var symbol = semanticModel.GetSymbolOrBestCandidate(subNode, cancellation);
 
 				if (symbol != null && existingGraphs.Contains(symbol, SymbolEqualityComparer.Default))
 				{
@@ -183,7 +183,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXGraphCreationForBqlQueries
 				return;
 			}
 
-			var localVar = context.SemanticModel.GetSymbolOrFirstCandidate(graphArgSyntax, context.CancellationToken) as ILocalSymbol;
+			var localVar = context.SemanticModel.GetSymbolOrBestCandidate(graphArgSyntax, context.CancellationToken) as ILocalSymbol;
 
 			// Do not report and do not suggest to change the graph if it is used somewhere else to avoid disruptive side effects in the business logic
 			// This includes fields and properties that store graph or a graph extension. The analysis of type members that store graphs

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXGraphCreationForBqlQueries/Walker.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXGraphCreationForBqlQueries/Walker.cs
@@ -47,7 +47,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXGraphCreationForBqlQueries
 					return;
 				}
 
-				var methodSymbol = _semanticModel.GetSymbolOrFirstCandidate(node, _cancellation) as IMethodSymbol;
+				var methodSymbol = _semanticModel.GetSymbolOrBestCandidate(node, _cancellation) as IMethodSymbol;
 
 				if (IsBqlSelectOrSearch(methodSymbol))
 				{
@@ -85,7 +85,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXGraphCreationForBqlQueries
 
 			private bool ArgumentIsPropertyOrField(IdentifierNameSyntax identifier)
 			{
-				var graphArgSymbol = _semanticModel.GetSymbolOrFirstCandidate(identifier, _cancellation);
+				var graphArgSymbol = _semanticModel.GetSymbolOrBestCandidate(identifier, _cancellation);
 				return graphArgSymbol is IPropertySymbol or IFieldSymbol;
 			}
 		}

--- a/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXOverride/Helpers/BaseMethodReferenceInXmlDocComment.cs
+++ b/src/Acuminator/Acuminator.Analyzers/StaticAnalysis/PXOverride/Helpers/BaseMethodReferenceInXmlDocComment.cs
@@ -91,7 +91,7 @@ namespace Acuminator.Analyzers.StaticAnalysis.PXOverride
 				if (attributes.Value[i] is not XmlCrefAttributeSyntax crefAttribute)
 					continue;
 
-				var referencedSymbol = semanticModel.GetSymbolOrFirstCandidate(crefAttribute.Cref, cancellation);
+				var referencedSymbol = semanticModel.GetSymbolOrBestCandidate(crefAttribute.Cref, cancellation);
 
 				if (DoesReferencedSymbolPointToBaseMethod(referencedSymbol, baseMethod))
 					return true;

--- a/src/Acuminator/Acuminator.Tests/Tests/Utilities/LocalFunction/LocalFunctionTests.cs
+++ b/src/Acuminator/Acuminator.Tests/Tests/Utilities/LocalFunction/LocalFunctionTests.cs
@@ -73,7 +73,7 @@ namespace Acuminator.Tests.Tests.Utilities.SemanticModels
 
 				foreach (var lambda in lambdas)
 				{
-					var symbol = semanticModel.GetSymbolOrFirstCandidate(lambda, default) as IMethodSymbol;
+					var symbol = semanticModel.GetSymbolOrBestCandidate(lambda, default) as IMethodSymbol;
 					symbol.Should().NotBeNull();
 
 					symbol!.MethodKind.Should().Be(MethodKind.LambdaMethod);

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/ArgumentsToParametersMapping/ArgumentsToParametersMapping.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/ArgumentsToParametersMapping/ArgumentsToParametersMapping.cs
@@ -57,10 +57,15 @@ namespace Acuminator.Utilities.Roslyn.Semantic.ArgumentsToParametersMapping
 			_length = parametersMapping.Length;
 		}
 
-		public IParameterSymbol GetMappedParameter(IMethodSymbol methodSymbol, int argIndex)
+		public IParameterSymbol? GetMappedParameter(IMethodSymbol methodSymbol, int argIndex)
 		{
 			methodSymbol.ThrowOnNull();
 			int parameterIndex = GetMappedParameterPosition(argIndex);
+
+			// In case of a broken solution we can get index out of bound because of a method node being mapped to a wrong symbol
+			if (parameterIndex >= methodSymbol.Parameters.Length)
+				return null;
+
 			return methodSymbol.Parameters[parameterIndex];
 		}
 

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/ArgumentsToParametersMapping/ArgumentsToParametersMapping.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/ArgumentsToParametersMapping/ArgumentsToParametersMapping.cs
@@ -62,7 +62,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic.ArgumentsToParametersMapping
 			methodSymbol.ThrowOnNull();
 			int parameterIndex = GetMappedParameterPosition(argIndex);
 
-			// In case of a broken solution we can get index out of bound because of a method node being mapped to a wrong symbol
+			// In case of a broken solution we can get index out of range error because of a method node being mapped to a wrong symbol
 			if (parameterIndex >= methodSymbol.Parameters.Length)
 				return null;
 

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/ISymbolGenericUtils.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/ISymbolGenericUtils.cs
@@ -1,5 +1,4 @@
 ﻿#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -11,6 +10,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 using Acuminator.Utilities.Common;
 using Acuminator.Utilities.Roslyn.Syntax;
+using System.Collections.Immutable;
 
 namespace Acuminator.Utilities.Roslyn.Semantic
 {
@@ -26,6 +26,14 @@ namespace Acuminator.Utilities.Roslyn.Semantic
 				IPropertySymbol property => property.IsReadOnly,
 				ITypeSymbol type 		 => type.IsReadOnly(),
 				_ 						 => false
+			};
+
+		public static ImmutableArray<IParameterSymbol>? Parameters(this ISymbol symbol) =>
+			symbol.CheckIfNull() switch
+			{
+				IMethodSymbol method 	 => method.Parameters,
+				IPropertySymbol property => property.Parameters,
+				_ 						 => null
 			};
 
 		public static bool IsReadOnly(this ITypeSymbol typeSymbol)

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/ISymbolGenericUtils.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/ISymbolGenericUtils.cs
@@ -1,6 +1,7 @@
 ﻿#nullable enable
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Runtime.CompilerServices;
 
@@ -10,7 +11,6 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 using Acuminator.Utilities.Common;
 using Acuminator.Utilities.Roslyn.Syntax;
-using System.Collections.Immutable;
 
 namespace Acuminator.Utilities.Roslyn.Semantic
 {

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModelUtils.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModelUtils.cs
@@ -44,7 +44,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic
 		}
 
 		/// <summary>
-		/// Get symbol or first candidate symbol from the <see cref="SemanticModel"/>.
+		/// Get symbol or best candidate symbol from the <see cref="SemanticModel"/>.
 		/// </summary>
 		/// <param name="semanticModel">The semanticModel to act on.</param>
 		/// <param name="node">The node to retrieve symbol for.</param>
@@ -52,7 +52,7 @@ namespace Acuminator.Utilities.Roslyn.Semantic
 		/// <returns>
 		/// The symbol or the first candidate symbol.
 		/// </returns>
-		public static ISymbol? GetSymbolOrFirstCandidate(this SemanticModel semanticModel, SyntaxNode node, CancellationToken cancellation)
+		public static ISymbol? GetSymbolOrBestCandidate(this SemanticModel semanticModel, SyntaxNode node, CancellationToken cancellation)
 		{
 			node.ThrowOnNull();
 

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModelUtils.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModelUtils.cs
@@ -52,8 +52,12 @@ namespace Acuminator.Utilities.Roslyn.Semantic
 		/// <param name="node">The node to retrieve symbol for.</param>
 		/// <param name="cancellation">Cancellation token.</param>
 		/// <returns>
-		/// The symbol or the first candidate symbol.
+		/// The symbol or the best candidate symbol.
 		/// </returns>
+		/// <remarks>
+		/// The best candidate symbols is determined heuristically based on arguments count in case of method group or overloaded method invocation.<br/>
+		/// The candidate with the closest match in terms of arguments count is selected as the best candidate.
+		/// </remarks>
 		public static ISymbol? GetSymbolOrBestCandidate(this SemanticModel semanticModel, SyntaxNode node, 
 														CancellationToken cancellation)
 		{

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModelUtils.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModelUtils.cs
@@ -55,8 +55,8 @@ namespace Acuminator.Utilities.Roslyn.Semantic
 		/// The symbol or the best candidate symbol.
 		/// </returns>
 		/// <remarks>
-		/// The best candidate symbols is determined heuristically based on arguments count in case of method group or overloaded method invocation.<br/>
-		/// The candidate with the closest match in terms of arguments count is selected as the best candidate.
+		/// The best candidate symbol is determined heuristically based on argument count in case of method group or overloaded method invocation.<br/>
+		/// The candidate with the closest match in terms of argument count is selected as the best candidate.
 		/// </remarks>
 		public static ISymbol? GetSymbolOrBestCandidate(this SemanticModel semanticModel, SyntaxNode node, 
 														CancellationToken cancellation)

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModelUtils.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModelUtils.cs
@@ -95,18 +95,40 @@ namespace Acuminator.Utilities.Roslyn.Semantic
 			{
 				var parameters = candidate.Parameters();
 
-				if (parameters == null)     // symbol doesn't have parameters
+				if (parameters == null)			// symbol doesn't have parameters
 					continue;
 
 				int parametersCount = parameters.Value.Length;
+				bool hasParamsParameter = parametersCount > 0 && parameters.Value[parametersCount - 1].IsParams;
 
-				if (argsCount > parametersCount)
+				if (!hasParamsParameter)
+				{
+					// perfect match heuristic: the same number of arguments and parameters and no params parameter
+					if (argsCount == parametersCount)
+						return candidate;
+					else if (argsCount > parametersCount)
+					{
+						// Filtering out candidates with too few parameters when the invocation has more arguments than parameters,
+						// but only if there is no params parameter that can match extra arguments
+						continue;
+					} 
+				}
+
+				int optionalCount = parameters.Value.Count(p => p.IsOptional);
+				int minRequiredParametersCount = hasParamsParameter
+					? parametersCount - optionalCount - 1       // params parameter can match 0 or more arguments, so it's not required
+					: parametersCount - optionalCount;
+
+				// If the invocation has fewer arguments than required parameters, then this candidate is not a good match
+				if (argsCount < minRequiredParametersCount)
 					continue;
-				else if (argsCount == parametersCount)
-					return candidate;									// perfect match
-				else if (minSuitableParametersCount > parametersCount)
+
+				if (minSuitableParametersCount > parametersCount)
 				{
 					// Keep the overload with fewest parameters
+					// In theory, we could specify parametersCount - 1 here for candidate with params parameter, 
+					// but in C# overload resolution method with params parameter is considered less specific 
+					// than the same method without params parameter, so we can keep the current heuristic simple
 					minSuitableParametersCount = parametersCount;
 					heuristicBestCandidate = candidate;
 				}

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModelUtils.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Semantic/SemanticModelUtils.cs
@@ -1,14 +1,16 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
-
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis;
+using System.Threading.Tasks;
 
 using Acuminator.Utilities.Common;
-using System.Threading.Tasks;
-using System.Diagnostics.CodeAnalysis;
+using Acuminator.Utilities.Roslyn.Syntax;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Acuminator.Utilities.Roslyn.Semantic
 {
@@ -52,12 +54,61 @@ namespace Acuminator.Utilities.Roslyn.Semantic
 		/// <returns>
 		/// The symbol or the first candidate symbol.
 		/// </returns>
-		public static ISymbol? GetSymbolOrBestCandidate(this SemanticModel semanticModel, SyntaxNode node, CancellationToken cancellation)
+		public static ISymbol? GetSymbolOrBestCandidate(this SemanticModel semanticModel, SyntaxNode node, 
+														CancellationToken cancellation)
 		{
 			node.ThrowOnNull();
-
 			var symbolInfo = semanticModel.CheckIfNull().GetSymbolInfo(node, cancellation);
-			return symbolInfo.Symbol ?? symbolInfo.CandidateSymbols.FirstOrDefault();
+
+			// Fast paths
+			if (symbolInfo.Symbol != null)
+				return symbolInfo.Symbol;
+			else if (symbolInfo.CandidateSymbols.Length == 1)
+				return symbolInfo.CandidateSymbols[0];
+			else if (symbolInfo.CandidateSymbols.IsDefaultOrEmpty ||
+					 symbolInfo.CandidateReason is not (CandidateReason.Inaccessible or
+														CandidateReason.OverloadResolutionFailure or
+														CandidateReason.Ambiguous))
+			{
+				return null;
+			}
+
+			// Try to match symbol with node based on arguments count heuristic
+			var argumentList = node.GetArgumentsList();
+
+			if (argumentList == null)
+				return symbolInfo.CandidateSymbols.FirstOrDefault();
+
+			return GetBestCandidateHeuristicallyByArgsCount(symbolInfo, argumentList.Arguments.Count);
+		}
+
+		private static ISymbol? GetBestCandidateHeuristicallyByArgsCount(in SymbolInfo symbolInfo, int argsCount)
+		{
+			int minSuitableParametersCount = int.MaxValue;
+			ISymbol? heuristicBestCandidate = null;
+
+			foreach (ISymbol candidate in symbolInfo.CandidateSymbols)
+			{
+				var parameters = candidate.Parameters();
+
+				if (parameters == null)     // symbol doesn't have parameters
+					continue;
+
+				int parametersCount = parameters.Value.Length;
+
+				if (argsCount > parametersCount)
+					continue;
+				else if (argsCount == parametersCount)
+					return candidate;									// perfect match
+				else if (minSuitableParametersCount > parametersCount)
+				{
+					// Keep the overload with fewest parameters
+					minSuitableParametersCount = parametersCount;
+					heuristicBestCandidate = candidate;
+				}
+			}
+
+			return heuristicBestCandidate ?? symbolInfo.CandidateSymbols.FirstOrDefault();
 		}
 
 		[SuppressMessage("Usage", "VSTHRD103:Call async methods when in an async method", Justification = "Aggregated await is used")]

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Syntax/MultipleParametersUsagesRewriter.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Syntax/MultipleParametersUsagesRewriter.cs
@@ -34,7 +34,7 @@ namespace Acuminator.Utilities.Roslyn.Syntax
 		{
 			_cancellation.ThrowIfCancellationRequested();
 
-			var symbolInfo = _semanticModel.GetSymbolOrFirstCandidate(node, _cancellation) as IParameterSymbol;
+			var symbolInfo = _semanticModel.GetSymbolOrBestCandidate(node, _cancellation) as IParameterSymbol;
 
 			if (symbolInfo == null || !_parametersWithReplacements.TryGetValue(symbolInfo, out SyntaxNode replaceWith))
 				return base.VisitIdentifierName(node);

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Syntax/PXGraph/GraphSyntaxUtils.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Syntax/PXGraph/GraphSyntaxUtils.cs
@@ -36,7 +36,7 @@ namespace Acuminator.Utilities.Roslyn.Syntax.PXGraph
 				// new PXGraph()
 				case ObjectCreationExpressionSyntax objCreationSyntax:
 				{
-					var typeSymbol = semanticModel.GetSymbolOrFirstCandidate(objCreationSyntax.Type, cancellation) as ITypeSymbol;
+					var typeSymbol = semanticModel.GetSymbolOrBestCandidate(objCreationSyntax.Type, cancellation) as ITypeSymbol;
 
 					if (typeSymbol == null || !typeSymbol.IsPXGraph(pxContext))
 						return GraphInstantiationType.None;
@@ -62,7 +62,7 @@ namespace Acuminator.Utilities.Roslyn.Syntax.PXGraph
 				// PXGraph.CreateInstance
 				case InvocationExpressionSyntax invocationSyntax:
 				{
-						var methodSymbol = semanticModel.GetSymbolOrFirstCandidate(invocationSyntax, cancellation) as IMethodSymbol;
+						var methodSymbol = semanticModel.GetSymbolOrBestCandidate(invocationSyntax, cancellation) as IMethodSymbol;
 
 						if (methodSymbol == null || methodSymbol.MethodKind != MethodKind.Ordinary)
 							return GraphInstantiationType.None;

--- a/src/Acuminator/Acuminator.Utilities/Roslyn/Walkers/ParametersReassignedFinder.cs
+++ b/src/Acuminator/Acuminator.Utilities/Roslyn/Walkers/ParametersReassignedFinder.cs
@@ -255,7 +255,7 @@ namespace Acuminator.Utilities.Roslyn.Walkers
 				if (invocationExpression.Expression is not IdentifierNameSyntax)
 					return;
 
-				var localFunctionOrLambda = _semanticModel?.GetSymbolOrFirstCandidate(invocationExpression, _cancellation) as IMethodSymbol;
+				var localFunctionOrLambda = _semanticModel?.GetSymbolOrBestCandidate(invocationExpression, _cancellation) as IMethodSymbol;
 
 				// Analyse local functions since they can reassign parameters from containing methods
 				if (localFunctionOrLambda == null || !localFunctionOrLambda.IsNestedMethod())

--- a/src/Acuminator/Acuminator.Vsix/Coloriser/Roslyn/PXRoslynColorizerTagger.PXColorizerSyntaxWalker.cs
+++ b/src/Acuminator/Acuminator.Vsix/Coloriser/Roslyn/PXRoslynColorizerTagger.PXColorizerSyntaxWalker.cs
@@ -65,7 +65,7 @@ namespace Acuminator.Vsix.Coloriser
 				if (_cancellationToken.IsCancellationRequested || IsVar(nodeText))
 					return;
 
-				ITypeSymbol? typeSymbol = _document.SemanticModel.GetSymbolOrFirstCandidate(node, _cancellationToken) as ITypeSymbol;
+				ITypeSymbol? typeSymbol = _document.SemanticModel.GetSymbolOrBestCandidate(node, _cancellationToken) as ITypeSymbol;
 
 				if (typeSymbol == null)
 				{


### PR DESCRIPTION
### Changes Overview
During the investigation of ATR-973 it was discovered that Acuminator may throw unhandled IndexOutOfBounds exception on a broken solution. By broken solution I mean a solution that does not compile and is only partially correct. 

In case of such solution, the IOOB exception can be thrown by the Argument to Parameter matching utility, This happens when semantic model's `GetSymbolInfo` doesn't return a correctly resolved `SymbolInfo` (solution is broken). So, there is no Symbol, just candidate symbols. In this case Acuminator just returns the first of the candidate symbols which is random and almost always incorrect. 

This leads to the argument to parameter matching try to match arguments to parameters of an incorrect method symbol. Sometimes, it is a symbol that has less parameters then there are arguments. This leads to an attempt to access the mapped parameters array out of its bounds. 

The fix does two things:
- Add sanity check before accessing the array + adding a possibility that the returned mapped parameter can be null
- Add simple heuristic that tries to resolve symbol candidates provided by semantic model by comparing the number of arguments with the number of parameters of a candidate symbol and filtering out candidates with fewer parameters then possible. 

The heuristic will pick the suitable candidate with the lowest possible number of parameters. 
This is not always correct (for example, if there are overrides with parameters with different types, or optional parameters). 
However, we don't want to re-implement complex C# overload analysis in Acuminator, this is only a heuristic that should not run in normal situations at all. It will work only on broken solutions.