### PR TITLE
Bugfix/atr 970 dev fix ms build workspace dependency

### DIFF
--- a/src/Acuminator/Acuminator.Runner.NetFramework/Acuminator.Runner.NetFramework.csproj
+++ b/src/Acuminator/Acuminator.Runner.NetFramework/Acuminator.Runner.NetFramework.csproj
@@ -52,9 +52,9 @@
 		<PackageReference Include="Microsoft.Build.Framework" ExcludeAssets="runtime" Version="18.0.2"/>
 		<PackageReference Include="Microsoft.Build.Utilities.Core" ExcludeAssets="runtime" Version="18.0.2"/>
 		
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.0.0" />
-		<PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="5.0.0" />
-		<PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="5.0.0" />
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.9.0" />
+		<PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="5.9.0" />
+		<PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="5.9.0" />
 		<PackageReference Include="PolySharp" Version="1.15.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Acuminator/Acuminator.Runner.NetFramework/Analysis/SolutionAnalysisRunner.cs
+++ b/src/Acuminator/Acuminator.Runner.NetFramework/Analysis/SolutionAnalysisRunner.cs
@@ -178,9 +178,15 @@ namespace Acuminator.Runner.Analysis
 				return false;
 			}
 
-			string? msBuildDir = fileExists
-				? Path.GetDirectoryName(msBuildPath)
-				: msBuildPath;
+			string? msBuildDir;
+			
+			if (fileExists)
+			{
+				string expandedFileName = Path.GetFullPath(msBuildPath);
+				msBuildDir = Path.GetDirectoryName(msBuildPath);
+			}
+			else
+				msBuildDir = msBuildPath;
 
 			_logger.Information(Messages.RegisteringMSBuildAtTheProvidedPathStatusMessage, msBuildDir);
 

--- a/src/Acuminator/Acuminator.Runner.NetFramework/Analysis/SolutionAnalysisRunner.cs
+++ b/src/Acuminator/Acuminator.Runner.NetFramework/Analysis/SolutionAnalysisRunner.cs
@@ -128,13 +128,14 @@ namespace Acuminator.Runner.Analysis
 
 		private bool TryRegisterMSBuild(AnalysisContext analysisContext)
 		{
+			if (MSBuildLocator.IsRegistered)
+				return true;
+
 			if (!MSBuildLocator.CanRegister)
 			{
 				_logger.Warning(Messages.MSBuild_RegistrationDeniedWarning);
-				return MSBuildLocator.IsRegistered;
+				return false;
 			}
-			else if (MSBuildLocator.IsRegistered)
-				return true;
 
 			if (analysisContext.MSBuildPath != null)
 			{

--- a/src/Acuminator/Acuminator.Runner.NetFramework/Analysis/SolutionAnalysisRunner.cs
+++ b/src/Acuminator/Acuminator.Runner.NetFramework/Analysis/SolutionAnalysisRunner.cs
@@ -128,6 +128,14 @@ namespace Acuminator.Runner.Analysis
 
 		private bool TryRegisterMSBuild(AnalysisContext analysisContext)
 		{
+			if (!MSBuildLocator.CanRegister)
+			{
+				_logger.Warning(Messages.MSBuild_RegistrationDeniedWarning);
+				return MSBuildLocator.IsRegistered;
+			}
+			else if (MSBuildLocator.IsRegistered)
+				return true;
+
 			if (analysisContext.MSBuildPath != null)
 			{
 				return TryRegisterMSBuildByPath(analysisContext.MSBuildPath);

--- a/src/Acuminator/Acuminator.Runner.NetFramework/Analysis/SolutionAnalysisRunner.cs
+++ b/src/Acuminator/Acuminator.Runner.NetFramework/Analysis/SolutionAnalysisRunner.cs
@@ -184,7 +184,7 @@ namespace Acuminator.Runner.Analysis
 			if (fileExists)
 			{
 				string expandedFileName = Path.GetFullPath(msBuildPath);
-				msBuildDir = Path.GetDirectoryName(msBuildPath);
+				msBuildDir = Path.GetDirectoryName(expandedFileName);
 			}
 			else
 				msBuildDir = msBuildPath;

--- a/src/Acuminator/Acuminator.Runner.NetFramework/Analysis/SolutionAnalysisRunner.cs
+++ b/src/Acuminator/Acuminator.Runner.NetFramework/Analysis/SolutionAnalysisRunner.cs
@@ -169,19 +169,32 @@ namespace Acuminator.Runner.Analysis
 
 		private bool TryRegisterMSBuildByPath(string msBuildPath)
 		{
+			bool fileExists = File.Exists(msBuildPath);
+			bool directoryExists = Directory.Exists(msBuildPath);
+
+			if (!fileExists && !directoryExists)
+			{
+				_logger.Error(Messages.MSBuildDoesNotExistAtTheProvidedPathError, msBuildPath);
+				return false;
+			}
+
+			string? msBuildDir = fileExists
+				? Path.GetDirectoryName(msBuildPath)
+				: msBuildPath;
+
+			_logger.Information(Messages.RegisteringMSBuildAtTheProvidedPathStatusMessage, msBuildDir);
+
 			try
 			{
-				_logger.Information(Messages.RegisteringMSBuildAtTheProvidedPathStatusMessage, msBuildPath);
-
-				string? msBuildDir = Path.GetDirectoryName(msBuildPath);
+				
 				MSBuildLocator.RegisterMSBuildPath(msBuildDir);
 
-				_logger.Information(Messages.SuccessfullyRegisteredMSBuildAtProvidedPathStatusMessage, msBuildPath);
+				_logger.Information(Messages.SuccessfullyRegisteredMSBuildAtProvidedPathStatusMessage, msBuildDir);
 				return true;
 			}
 			catch (Exception e)
 			{
-				_logger.Error(e, Messages.MSBuildRegistrationAtProvidedPathFailedError, msBuildPath);
+				_logger.Error(e, Messages.MSBuildRegistrationAtProvidedPathFailedError, msBuildDir);
 				return false;
 			}
 		}

--- a/src/Acuminator/Acuminator.Runner.NetFramework/Properties/launchSettings.json
+++ b/src/Acuminator/Acuminator.Runner.NetFramework/Properties/launchSettings.json
@@ -16,6 +16,10 @@
       "commandName": "Project",
       "commandLineArgs": "\"..\\..\\..\\..\\..\\Samples\\PX.Objects.HackathonDemo\\PX.Objects.HackathonDemo\\PX.Objects.HackathonDemo.csproj\" -f report.json  --format json -g d --enable-PX1007 --disable-PX1099"
     },
+    "msbuild + json + file + grouping by diagnostic + PX1007 + no PX1099": {
+      "commandName": "Project",
+      "commandLineArgs": "\"..\\..\\..\\..\\..\\Samples\\PX.Objects.HackathonDemo\\PX.Objects.HackathonDemo\\PX.Objects.HackathonDemo.csproj\" -f report.json  --format json -g d --enable-PX1007 --disable-PX1099 --msBuild-path \"C:\\Program Files\\Microsoft Visual Studio\\18\\Professional\\MSBuild\\Current\\Bin\""
+    },
     "text + console + grouping by diagnostic and file + ISV mode + PX1007 + PX1099": {
       "commandName": "Project",
       "commandLineArgs": "\"..\\..\\..\\..\\..\\Samples\\PX.Objects.HackathonDemo\\PX.Objects.HackathonDemo\\PX.Objects.HackathonDemo.csproj\" -g FD --isv-mode --enable-PX1007"

--- a/src/Acuminator/Acuminator.Runner.NetFramework/Resources/Messages.Designer.cs
+++ b/src/Acuminator/Acuminator.Runner.NetFramework/Resources/Messages.Designer.cs
@@ -19,7 +19,7 @@ namespace Acuminator.Runner.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "18.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Messages {
@@ -61,7 +61,7 @@ namespace Acuminator.Runner.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The project &quot;{0}&quot; passed Acuminator validation successfully.
+        ///   Looks up a localized string similar to The &quot;{0}&quot; project passed Acuminator validation successfully..
         /// </summary>
         internal static string AcuminatorValidationPassedMessage {
             get {
@@ -88,7 +88,7 @@ namespace Acuminator.Runner.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Cancelled Acuminator validation of the &quot;{CodeSource}&quot;. Project &quot;{ProjectName}&quot; validation result: {Result}..
+        ///   Looks up a localized string similar to Acuminator validation of the &quot;{CodeSource}&quot; has been cancelled. The result of the &quot;{ProjectName}&quot; project validation: {Result}..
         /// </summary>
         internal static string CancelledCodeSourceValidationInfo {
             get {
@@ -97,7 +97,7 @@ namespace Acuminator.Runner.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The validation is finished. &quot;{CodeSource}&quot; failed the validation..
+        ///   Looks up a localized string similar to The validation has been finished. &quot;{CodeSource}&quot; has failed the validation..
         /// </summary>
         internal static string CodeSourceFailedValidationMessage {
             get {
@@ -106,7 +106,7 @@ namespace Acuminator.Runner.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Code source to use for Acuminator validation is not found at {0}.
+        ///   Looks up a localized string similar to Code source to use for Acuminator validation has not been found at {0}..
         /// </summary>
         internal static string CodeSourceNotFoundError {
             get {
@@ -115,7 +115,7 @@ namespace Acuminator.Runner.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Code source is not specified.
+        ///   Looks up a localized string similar to The code source is not specified..
         /// </summary>
         internal static string CodeSourceNotSpecifiedError {
             get {
@@ -124,7 +124,7 @@ namespace Acuminator.Runner.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The Acuminator validation of &quot;{CodeSource}&quot; was cancelled..
+        ///   Looks up a localized string similar to The Acuminator validation of &quot;{CodeSource}&quot; has been cancelled..
         /// </summary>
         internal static string CodeSourceValidationWasCancelled {
             get {
@@ -142,7 +142,7 @@ namespace Acuminator.Runner.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Error during the collection of Acuminator analyzers.
+        ///   Looks up a localized string similar to An error occured during the collection of Acuminator analyzers..
         /// </summary>
         internal static string ErrorDuringAcuminatorAnalyzersCollection {
             get {
@@ -160,7 +160,7 @@ namespace Acuminator.Runner.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Failed to initialize Acuminator global suppression mechanism for the code source &quot;{CodeSource}&quot;..
+        ///   Looks up a localized string similar to Failed to initialize the Acuminator global suppression mechanism for the code source &quot;{CodeSource}&quot;..
         /// </summary>
         internal static string FailedToInitializeAcuminatorGlobalSuppressionMechanismError {
             get {
@@ -169,7 +169,7 @@ namespace Acuminator.Runner.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Failed to load Acuminator analyzers. The analysis of the code source &quot;{CodeSource}&quot; cannot be performed.
+        ///   Looks up a localized string similar to Failed to load Acuminator analyzers. The analysis of the code source &quot;{CodeSource}&quot; cannot be performed..
         /// </summary>
         internal static string FailedToLoadAcuminatorAnalyzersError {
             get {
@@ -178,7 +178,7 @@ namespace Acuminator.Runner.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Failed to load solution from the code source &quot;{CodeSource}&quot;..
+        ///   Looks up a localized string similar to Failed to load the solution from the code source &quot;{CodeSource}&quot;..
         /// </summary>
         internal static string FailedToLoadSolutionFromCodeSourceError {
             get {
@@ -187,7 +187,7 @@ namespace Acuminator.Runner.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Failed to obtain Acuminator version. The analysis will be performed without Acuminator version information..
+        ///   Looks up a localized string similar to Failed to obtain the Acuminator version. The analysis will be performed without Acuminator version information..
         /// </summary>
         internal static string FailedToObtainAcuminatorVersionWarning {
             get {
@@ -196,7 +196,7 @@ namespace Acuminator.Runner.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Failed to obtain compilation with analyzers.
+        ///   Looks up a localized string similar to Failed to obtain the compilation with analyzers..
         /// </summary>
         internal static string FailedToObtainCompilationWithAnalyzersError {
             get {
@@ -205,7 +205,7 @@ namespace Acuminator.Runner.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Failed to obtain Roslyn compilation data for the project with name &quot;{ProjectName}&quot; and path &quot;{ProjectPath}&quot;..
+        ///   Looks up a localized string similar to Failed to obtain the Roslyn compilation data for the project with the &quot;{ProjectName}&quot; name and the &quot;{ProjectPath}&quot; path..
         /// </summary>
         internal static string FailedToObtainRoslynCompilationDataForTheProjectError {
             get {
@@ -214,7 +214,7 @@ namespace Acuminator.Runner.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Finished Acuminator validation of the project &quot;{ProjectName}&quot;. Project validation result: {Result}..
+        ///   Looks up a localized string similar to Finished Acuminator validation of the &quot;{ProjectName}&quot; project. The result of the project validation: {Result}..
         /// </summary>
         internal static string FinishedAcuminatorValidationOfTheProjectInfo {
             get {
@@ -232,7 +232,7 @@ namespace Acuminator.Runner.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Initialize Acuminator analyzers..
+        ///   Looks up a localized string similar to Initializing Acuminator analyzers....
         /// </summary>
         internal static string InitializeAcuminatorAnalyzersStatusMessage {
             get {
@@ -241,11 +241,20 @@ namespace Acuminator.Runner.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Count of loaded projects: {ProjectsCount}..
+        ///   Looks up a localized string similar to The number of loaded projects: {ProjectsCount}..
         /// </summary>
         internal static string LoadedProjectsCount_Information {
             get {
                 return ResourceManager.GetString("LoadedProjectsCount_Information", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The MSBuild registration request was denied by the MSBuild locator..
+        /// </summary>
+        internal static string MSBuild_RegistrationDeniedWarning {
+            get {
+                return ResourceManager.GetString("MSBuild_RegistrationDeniedWarning", resourceCulture);
             }
         }
         
@@ -259,7 +268,7 @@ namespace Acuminator.Runner.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Error during registration of MSBuild instance..
+        ///   Looks up a localized string similar to An error occured during registration of the MSBuild instance..
         /// </summary>
         internal static string MSBuildInstanceRegistrationError {
             get {
@@ -277,7 +286,7 @@ namespace Acuminator.Runner.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Error during the registration of MSBuild instance. Failed to register MSBuild using a provided path &quot;{MSBuildPath}&quot;..
+        ///   Looks up a localized string similar to An error occured during the registration of the MSBuild instance. Failed to register MSBuild by using the provided path &quot;{MSBuildPath}&quot;..
         /// </summary>
         internal static string MSBuildRegistrationAtProvidedPathFailedError {
             get {
@@ -295,7 +304,7 @@ namespace Acuminator.Runner.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to No installed MSBuild version was found on the machine..
+        ///   Looks up a localized string similar to No installed MSBuild version has been found on the machine..
         /// </summary>
         internal static string NoInstalledMSBuildFoundError {
             get {
@@ -304,7 +313,7 @@ namespace Acuminator.Runner.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to No project in the provided &quot;{CodeSource}&quot; references Acumatica Platform.
+        ///   Looks up a localized string similar to No project in the provided &quot;{CodeSource}&quot; references the Acumatica Framework..
         /// </summary>
         internal static string NoProjectInCodeSourceReferencesAcumaticaPlatformError {
             get {
@@ -322,7 +331,7 @@ namespace Acuminator.Runner.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Not supported output format &quot;{0}&quot;. You can specify only &quot;{1}&quot; and &quot;{2}&quot; values as output formats..
+        ///   Looks up a localized string similar to Not supported output format &quot;{0}&quot;. You can specify only the &quot;{1}&quot; and &quot;{2}&quot; values as output formats..
         /// </summary>
         internal static string NotSupportedOutputFormat {
             get {
@@ -331,7 +340,7 @@ namespace Acuminator.Runner.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Obtained Roslyn compilation data for the project &quot;{ProjectName}&quot; successfully..
+        ///   Looks up a localized string similar to Roslyn compilation data for the project &quot;{ProjectName}&quot; has been obtained successfully..
         /// </summary>
         internal static string ObtainedRoslynCompilationDataForTheProjectDebug {
             get {
@@ -349,7 +358,7 @@ namespace Acuminator.Runner.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The project {ProjectName} does not reference Acumatica Platform. Validation can not be performed.
+        ///   Looks up a localized string similar to The {ProjectName} project does not reference Acumatica Framework. Validation can not be performed.
         /// </summary>
         internal static string ProjectDoesNotReferenceAcumaticaPlatformValidationError {
             get {
@@ -367,7 +376,7 @@ namespace Acuminator.Runner.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to A runtime error was encountered during the validation..
+        ///   Looks up a localized string similar to A runtime error has been encountered during the validation..
         /// </summary>
         internal static string RuntimeErrorHappenedDuringValidationMessage {
             get {
@@ -385,7 +394,7 @@ namespace Acuminator.Runner.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Start analyzing the code source &quot;{CodeSource}&quot;..
+        ///   Looks up a localized string similar to Analyzing the code source &quot;{CodeSource}&quot;....
         /// </summary>
         internal static string StartAnalyzingTheCodeSourceStatusMessage {
             get {
@@ -403,7 +412,7 @@ namespace Acuminator.Runner.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Start loading the code source &quot;{CodeSource}&quot;..
+        ///   Looks up a localized string similar to Loading the code source &quot;{CodeSource}&quot;....
         /// </summary>
         internal static string StartLoadingTheCodeSourceAtPathStatusMessage {
             get {
@@ -412,7 +421,7 @@ namespace Acuminator.Runner.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Start validating the solution..
+        ///   Looks up a localized string similar to Validating the solution....
         /// </summary>
         internal static string StartValidatingSolutionStatusMessage {
             get {
@@ -421,7 +430,7 @@ namespace Acuminator.Runner.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Successfully finished validating the solution..
+        ///   Looks up a localized string similar to Validation of the solution has been finished successfully..
         /// </summary>
         internal static string SuccessfullyFinishedSolutionValidationStatusMessage {
             get {
@@ -430,7 +439,7 @@ namespace Acuminator.Runner.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Successfully loaded the code source &quot;{CodeSource}&quot;..
+        ///   Looks up a localized string similar to The code source &quot;{CodeSource}&quot; has been loaded successfully..
         /// </summary>
         internal static string SuccessfullyLoadedCodeSourceAtPathStatusMessage {
             get {
@@ -439,7 +448,7 @@ namespace Acuminator.Runner.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Successfully registered MSBuild instance at the provided path &quot;{MSBuildPath}&quot;..
+        ///   Looks up a localized string similar to The MSBuild instance at the provided path &quot;{MSBuildPath}&quot; has been registered successfully..
         /// </summary>
         internal static string SuccessfullyRegisteredMSBuildAtProvidedPathStatusMessage {
             get {
@@ -448,7 +457,7 @@ namespace Acuminator.Runner.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Total Errors Count.
+        ///   Looks up a localized string similar to Total Error Count.
         /// </summary>
         internal static string TotalErrorsCountReportTitlePart {
             get {
@@ -457,7 +466,7 @@ namespace Acuminator.Runner.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Error on attempt to unregister MSBuild..
+        ///   Looks up a localized string similar to An error has occurred on attempt to unregister MSBuild..
         /// </summary>
         internal static string UnregisterMSBuildInstanceError {
             get {

--- a/src/Acuminator/Acuminator.Runner.NetFramework/Resources/Messages.Designer.cs
+++ b/src/Acuminator/Acuminator.Runner.NetFramework/Resources/Messages.Designer.cs
@@ -277,7 +277,7 @@ namespace Acuminator.Runner.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to An error occured during registration of the MSBuild instance..
+        ///   Looks up a localized string similar to An error occurred during registration of the MSBuild instance..
         /// </summary>
         internal static string MSBuildInstanceRegistrationError {
             get {
@@ -295,7 +295,7 @@ namespace Acuminator.Runner.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to An error occured during the registration of the MSBuild instance. Failed to register MSBuild by using the provided path &quot;{MSBuildPath}&quot;..
+        ///   Looks up a localized string similar to An error occurred during the registration of the MSBuild instance. Failed to register MSBuild by using the provided path &quot;{MSBuildPath}&quot;..
         /// </summary>
         internal static string MSBuildRegistrationAtProvidedPathFailedError {
             get {

--- a/src/Acuminator/Acuminator.Runner.NetFramework/Resources/Messages.Designer.cs
+++ b/src/Acuminator/Acuminator.Runner.NetFramework/Resources/Messages.Designer.cs
@@ -268,6 +268,15 @@ namespace Acuminator.Runner.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Failed to register MSBuild by using the provided path &quot;{MSBuildPath}&quot;. The path does not exist in the system..
+        /// </summary>
+        internal static string MSBuildDoesNotExistAtTheProvidedPathError {
+            get {
+                return ResourceManager.GetString("MSBuildDoesNotExistAtTheProvidedPathError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to An error occured during registration of the MSBuild instance..
         /// </summary>
         internal static string MSBuildInstanceRegistrationError {

--- a/src/Acuminator/Acuminator.Runner.NetFramework/Resources/Messages.resx
+++ b/src/Acuminator/Acuminator.Runner.NetFramework/Resources/Messages.resx
@@ -189,6 +189,9 @@
   <data name="MSBuildRegistrationAtProvidedPathFailedError" xml:space="preserve">
     <value>An error occured during the registration of the MSBuild instance. Failed to register MSBuild by using the provided path "{MSBuildPath}".</value>
   </data>
+  <data name="MSBuild_RegistrationDeniedWarning" xml:space="preserve">
+    <value>The MSBuild registration request was denied by the MSBuild locator.</value>
+  </data>
   <data name="MSBuild_VisualStudioNameAndVersion_Info" xml:space="preserve">
     <value>Found MSBuild instance with name "{VisualStudioName}", version "{VisualStudioVersion}".</value>
   </data>

--- a/src/Acuminator/Acuminator.Runner.NetFramework/Resources/Messages.resx
+++ b/src/Acuminator/Acuminator.Runner.NetFramework/Resources/Messages.resx
@@ -180,6 +180,9 @@
   <data name="LoadedProjectsCount_Information" xml:space="preserve">
     <value>The number of loaded projects: {ProjectsCount}.</value>
   </data>
+  <data name="MSBuildDoesNotExistAtTheProvidedPathError" xml:space="preserve">
+    <value>Failed to register MSBuild by using the provided path "{MSBuildPath}". The path does not exist in the system.</value>
+  </data>
   <data name="MSBuildInstanceRegistrationError" xml:space="preserve">
     <value>An error occured during registration of the MSBuild instance.</value>
   </data>

--- a/src/Acuminator/Acuminator.Runner.NetFramework/Resources/Messages.resx
+++ b/src/Acuminator/Acuminator.Runner.NetFramework/Resources/Messages.resx
@@ -184,13 +184,13 @@
     <value>Failed to register MSBuild by using the provided path "{MSBuildPath}". The path does not exist in the system.</value>
   </data>
   <data name="MSBuildInstanceRegistrationError" xml:space="preserve">
-    <value>An error occured during registration of the MSBuild instance.</value>
+    <value>An error occurred during registration of the MSBuild instance.</value>
   </data>
   <data name="MSBuildPath_Info" xml:space="preserve">
     <value>MSBuildPath: "{MSBuildPath}".</value>
   </data>
   <data name="MSBuildRegistrationAtProvidedPathFailedError" xml:space="preserve">
-    <value>An error occured during the registration of the MSBuild instance. Failed to register MSBuild by using the provided path "{MSBuildPath}".</value>
+    <value>An error occurred during the registration of the MSBuild instance. Failed to register MSBuild by using the provided path "{MSBuildPath}".</value>
   </data>
   <data name="MSBuild_RegistrationDeniedWarning" xml:space="preserve">
     <value>The MSBuild registration request was denied by the MSBuild locator.</value>


### PR DESCRIPTION
#### Changes Overview
- updated Roslyn dependencies of the Acuminator Console Runner to version 5.9.0 with the fix of the `MSBuildWorkspace` bug that prevented the analysis of old style .Net Framework projects
- added some extra guard checks to MSBuild registration
- improved minor issues in the MSBuild registration at the provided path 