### PR TITLE
Bugfix/atr 975 fix rename hanging 2

### DIFF
--- a/docs/dev/CodingGuidelines/CodingGuidelines.md
+++ b/docs/dev/CodingGuidelines/CodingGuidelines.md
@@ -355,8 +355,10 @@ You should avoid the use of `Task.Result` and `Task.Wait()` because this can cau
 
 For details, see the following articles: 
 
+* [Most recent practices recorded in the AI agent skill](https://github.com/madskristensen/vs-agent-plugins/blob/master/skills/handling-async-threading/SKILL.md)
 * [How to: Manage multiple threads in managed code](https://docs.microsoft.com/en-us/visualstudio/extensibility/managing-multiple-threads-in-managed-code) 
 * [Asynchronous and multithreaded programming within VS using the JoinableTaskFactory](https://blogs.msdn.microsoft.com/andrewarnottms/2014/05/07/asynchronous-and-multithreaded-programming-within-vs-using-the-joinabletaskfactory/)
+  - [Another link to the same article](https://docs.microsoft.com/en-us/archive/blogs/andrewarnott/asynchronous-and-multithreaded-programming-within-vs-using-the-joinabletaskfactory)
 * [Cookbook for Visual Studio](https://github.com/Microsoft/vs-threading/blob/master/doc/cookbook_vs.md)
 * [Three Threading Rules](https://github.com/Microsoft/vs-threading/blob/master/doc/threading_rules.md)
 

--- a/src/Acuminator/Acuminator.Analyzers/Acuminator.Analyzers.csproj
+++ b/src/Acuminator/Acuminator.Analyzers/Acuminator.Analyzers.csproj
@@ -3,7 +3,7 @@
     <Title>Acuminator Analyzers</Title>
     <AssemblyTitle>Acuminator.Analyzers</AssemblyTitle>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>4.0.1</Version>
+    <Version>4.1.0</Version>
     <LangVersion>13.0</LangVersion>
     <SignAssembly>False</SignAssembly>
     <Company>Acumatica, Inc.</Company>

--- a/src/Acuminator/Acuminator.Runner.NetFramework/Acuminator.Runner.NetFramework.csproj
+++ b/src/Acuminator/Acuminator.Runner.NetFramework/Acuminator.Runner.NetFramework.csproj
@@ -7,7 +7,7 @@
 		<TargetFramework>net48</TargetFramework>
 		<Deterministic>True</Deterministic>
 		<LangVersion>13.0</LangVersion>
-		<Version>4.0.1</Version>
+		<Version>4.1.0</Version>
 		<Nullable>enable</Nullable>
 		<WarningLevel>9999</WarningLevel>
 		<NeutralLanguage>en</NeutralLanguage>

--- a/src/Acuminator/Acuminator.Tests/Acuminator.Tests.csproj
+++ b/src/Acuminator/Acuminator.Tests/Acuminator.Tests.csproj
@@ -5,7 +5,7 @@
     <AssemblyTitle>Acuminator.Tests</AssemblyTitle>
     <!-- Target framework must be net48 because net481 is not supported by our build system -->
     <TargetFramework>net48</TargetFramework>
-    <Version>4.0.1</Version>
+    <Version>4.1.0</Version>
     <LangVersion>13.0</LangVersion>
     <Nullable>enable</Nullable>
     <WarningLevel>9999</WarningLevel>
@@ -124,7 +124,7 @@
     <PackageReference Include="System.Collections.Immutable" Version="8.0.0" />
     <PackageReference Include="System.Memory" Version="4.6.3" />
     <PackageReference Include="System.Reflection.Primitives" Version="4.3.0" />
-    <PackageReference Include="System.Runtime.Handles" Version="4.0.1" />
+    <PackageReference Include="System.Runtime.Handles" Version="4.1.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.abstractions" Version="2.0.3" />
     <PackageReference Include="xunit.analyzers" Version="0.10.0" />

--- a/src/Acuminator/Acuminator.Utilities/Acuminator.Utilities.csproj
+++ b/src/Acuminator/Acuminator.Utilities/Acuminator.Utilities.csproj
@@ -3,7 +3,7 @@
     <Title>Acuminator Utilities</Title>
     <AssemblyTitle>Acuminator.Utilities</AssemblyTitle>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>4.0.1</Version>
+    <Version>4.1.0</Version>
     <NeutralLanguage>en</NeutralLanguage>
     <Description>Acuminator.Utilities library with shared analysis helpers</Description>
     <Company>Acumatica, Inc.</Company>

--- a/src/Acuminator/Acuminator.Vsix/AcuminatorVSPackage.cs
+++ b/src/Acuminator/Acuminator.Vsix/AcuminatorVSPackage.cs
@@ -97,6 +97,24 @@ namespace Acuminator.Vsix
 
 		public static AcuminatorVSPackage Instance { get; private set; } = null!;
 
+		/// <summary>
+		/// The <see cref="JoinableTaskFactory"/> instance initialized for the <see cref="AsyncPackage"/>.<br/>
+		/// If the package is not initialized yet, <see cref="Microsoft.VisualStudio.Shell.ThreadHelper.JoinableTaskFactory"/> is returned instead.
+		/// </summary>
+		/// <remarks>
+		/// According to VS cookbook and VS team's discussion, the <see cref="AsyncPackage.JoinableTaskFactory"/> should be preferred over <see cref="Microsoft.VisualStudio.Shell.ThreadHelper.JoinableTaskFactory"/>:
+		/// <list type="bullet">
+		/// <item>https://github.com/VsixCommunity/Community.VisualStudio.Toolkit/issues/24</item>
+		/// <item>https://microsoft.github.io/VSSDK-Analyzers/analyzers/VSSDK007.html</item>
+		/// </list>
+		/// According to Claude Code research, both factories are created from the same <see cref="JoinableTaskContext"/> — the one bound to the VS main thread.<br/>
+		/// So, they have identical participation in the JTF dependency graph that prevents deadlocks on the UI thread. Swapping one for the other changes nothing about deadlock behavior.<br/>
+		/// The difference is the <see cref="JoinableTaskCollection"/>. <see cref="AsyncPackage.JoinableTaskFactory"/> has its own collection, and package disposal drains it.<br/> 
+		/// The work you started can't still be running against torn-down state after the package unloads.<br/>
+		/// On the other hand, <see cref="Microsoft.VisualStudio.Shell.ThreadHelper.JoinableTaskFactory"/> is ambient and tracks nothing on your behalf. That's the reason behind VSSDK007 diagnostic.
+		/// </remarks>
+		public static JoinableTaskFactory JTF => Instance?.JoinableTaskFactory ?? ThreadHelper.JoinableTaskFactory;
+
 		private readonly Lazy<GeneralOptionsPage?> _generalOptionsPage =
 			new(() => Instance.GetDialogPage(typeof(GeneralOptionsPage)) as GeneralOptionsPage, isThreadSafe: true);
 

--- a/src/Acuminator/Acuminator.Vsix/AcuminatorVSPackage.cs
+++ b/src/Acuminator/Acuminator.Vsix/AcuminatorVSPackage.cs
@@ -75,7 +75,7 @@ namespace Acuminator.Vsix
 		private const string SettingsCategoryName = SharedConstants.PackageName;
 
 		public const string PackageName = SharedConstants.PackageName;
-		public const string PackageVersion = "4.0.1";
+		public const string PackageVersion = "4.1.0";
 
 		/// <summary>
 		/// AcuminatorVSPackage GUID string.

--- a/src/Acuminator/Acuminator.Vsix/AcuminatorVSPackage.cs
+++ b/src/Acuminator/Acuminator.Vsix/AcuminatorVSPackage.cs
@@ -91,15 +91,20 @@ namespace Acuminator.Vsix
 
 		private const int INSTANCE_UNINITIALIZED = 0;
 		private const int INSTANCE_INITIALIZED = 1;
-		private static int _instanceInitialized;
+		private static int _instanceInitialized = INSTANCE_UNINITIALIZED;
+
+		private const int NOT_DISPOSED = 0;
+		private const int DISPOSED = 1;
+		private int _isDisposed = NOT_DISPOSED;
 
 		private OutOfProcessSettingsUpdater? _outOfProcessSettingsUpdater;
 
 		public static AcuminatorVSPackage Instance { get; private set; } = null!;
 
+
 		/// <summary>
 		/// The <see cref="JoinableTaskFactory"/> instance initialized for the <see cref="AsyncPackage"/>.<br/>
-		/// If the package is not initialized yet, <see cref="Microsoft.VisualStudio.Shell.ThreadHelper.JoinableTaskFactory"/> is returned instead.
+		/// If the package is not yet initialized or already disposed, <see cref="Microsoft.VisualStudio.Shell.ThreadHelper.JoinableTaskFactory"/> is returned instead.
 		/// </summary>
 		/// <remarks>
 		/// According to VS cookbook and VS team's discussion, the <see cref="AsyncPackage.JoinableTaskFactory"/> should be preferred over <see cref="Microsoft.VisualStudio.Shell.ThreadHelper.JoinableTaskFactory"/>:
@@ -107,13 +112,16 @@ namespace Acuminator.Vsix
 		/// <item>https://github.com/VsixCommunity/Community.VisualStudio.Toolkit/issues/24</item>
 		/// <item>https://microsoft.github.io/VSSDK-Analyzers/analyzers/VSSDK007.html</item>
 		/// </list>
-		/// According to Claude Code research, both factories are created from the same <see cref="JoinableTaskContext"/> — the one bound to the VS main thread.<br/>
+		/// Both factories are created from the same <see cref="JoinableTaskContext"/> — the one bound to the VS main thread.<br/>
 		/// So, they have identical participation in the JTF dependency graph that prevents deadlocks on the UI thread. Swapping one for the other changes nothing about deadlock behavior.<br/>
 		/// The difference is the <see cref="JoinableTaskCollection"/>. <see cref="AsyncPackage.JoinableTaskFactory"/> has its own collection, and package disposal drains it.<br/> 
 		/// The work you started can't still be running against torn-down state after the package unloads.<br/>
 		/// On the other hand, <see cref="Microsoft.VisualStudio.Shell.ThreadHelper.JoinableTaskFactory"/> is ambient and tracks nothing on your behalf. That's the reason behind VSSDK007 diagnostic.
 		/// </remarks>
-		public static JoinableTaskFactory JTF => Instance?.JoinableTaskFactory ?? ThreadHelper.JoinableTaskFactory;
+		public static JoinableTaskFactory JTF =>
+			Instance?._isDisposed == NOT_DISPOSED
+				? Instance.JoinableTaskFactory
+				: ThreadHelper.JoinableTaskFactory;
 
 		private readonly Lazy<GeneralOptionsPage?> _generalOptionsPage =
 			new(() => Instance.GetDialogPage(typeof(GeneralOptionsPage)) as GeneralOptionsPage, isThreadSafe: true);
@@ -363,6 +371,21 @@ namespace Acuminator.Vsix
 		protected override void Dispose(bool disposing)
 		{
 			base.Dispose(disposing);
+
+			// It is important to set flag after the base call to Dispose to avoid rare but possible VS hanging on package unload. 
+			// The _isDisposed flag check on JTF property prevents returning JTF from a disposed package. But if the code flips it before base.Dispose call, there will be a problem. 
+			// The base AsyncPackage.Dispose(bool) method does: disposeCancellationTokenSource.Cancel() -> ThreadHelper.JoinableTaskFactory.Run(JoinableTaskCollection.JoinTillEmptyAsync) — no token, no timeout —> Package.Dispose. 
+			// So the main thread blocks until every JoinableTask in the package collection finishes.
+			// During that drain, AcuminatorVSPackage.JTF already returns ThreadHelper's factory. A FileAndForgetAcuminatorTask wrapper started before shutdown is a member of the package collection (so the drain waits on it) 
+			// and awaits a foreign task. When that foreign task resumes and needs its main-thread hop via AcuminatorVSPackage.JTF.SwitchToMainThreadAsync(), RequestSwitchToMainThread (with a null ambient job) creates a transient 
+			// on ThreadHelper's factory — which has no collection, so the transient is not in the drained graph.A main thread blocked in Run pumps only joined work, 
+			// so that continuation never runs -> the foreign task never completes -> the wrapper never completes -> JoinTillEmptyAsync never returns -> indefinite hang on close.
+			//
+			// Had the flag been set after base.Dispose, the same hop would go through the package factory, land in the collection, and be pumped by the drain — no hang. 
+			// The "removed redundant cancellation tokens" commit compounds it: those switches no longer observe DisposalToken, so in-flight work can't self-cancel to escape the wait either.
+			if (Interlocked.Exchange(ref _isDisposed, DISPOSED) == DISPOSED)
+				return;
+
 			AcuminatorLogger?.Dispose();
 			_outOfProcessSettingsUpdater?.Dispose();
 

--- a/src/Acuminator/Acuminator.Vsix/AcuminatorVSPackage.cs
+++ b/src/Acuminator/Acuminator.Vsix/AcuminatorVSPackage.cs
@@ -95,7 +95,7 @@ namespace Acuminator.Vsix
 
 		private const int NOT_DISPOSED = 0;
 		private const int DISPOSED = 1;
-		private int _isDisposed = NOT_DISPOSED;
+		private volatile int _isDisposed = NOT_DISPOSED;
 
 		private OutOfProcessSettingsUpdater? _outOfProcessSettingsUpdater;
 

--- a/src/Acuminator/Acuminator.Vsix/Coloriser/AsyncTagging/BackgroundTagging.cs
+++ b/src/Acuminator/Acuminator.Vsix/Coloriser/AsyncTagging/BackgroundTagging.cs
@@ -124,7 +124,7 @@ namespace Acuminator.Vsix.Coloriser
 			}
 
 			// We should be on UI thread here but the tagger.RaiseTagsChangedAsync switches to UI thread from non UI threads internally if needed
-			return AcuminatorVSPackage.JTF.RunAsync(async () => await tagger.RaiseTagsChangedAsync(cancellationToken)).Task;
+			return AcuminatorVSPackage.JTF.RunAsync(tagger.RaiseTagsChangedAsync).Task;
 		}
 	}
 }

--- a/src/Acuminator/Acuminator.Vsix/Coloriser/AsyncTagging/BackgroundTagging.cs
+++ b/src/Acuminator/Acuminator.Vsix/Coloriser/AsyncTagging/BackgroundTagging.cs
@@ -124,7 +124,7 @@ namespace Acuminator.Vsix.Coloriser
 			}
 
 			// We should be on UI thread here but the tagger.RaiseTagsChangedAsync switches to UI thread from non UI threads internally if needed
-			return Shell.ThreadHelper.JoinableTaskFactory.RunAsync(tagger.RaiseTagsChangedAsync).Task;
+			return AcuminatorVSPackage.JTF.RunAsync(async () => await tagger.RaiseTagsChangedAsync(cancellationToken)).Task;
 		}
 	}
 }

--- a/src/Acuminator/Acuminator.Vsix/Coloriser/AsyncTagging/BackgroundTagging.cs
+++ b/src/Acuminator/Acuminator.Vsix/Coloriser/AsyncTagging/BackgroundTagging.cs
@@ -51,7 +51,7 @@ namespace Acuminator.Vsix.Coloriser
 																	 _vsTaskScheduler);
 
 			// ContinueWith schedules the lambda on the VS UI thread scheduler. The lambda runs on the UI thread and calls AfterTaggingActionAsync(...).
-			// Inside AfterTaggingActionAsync, the important path calls ThreadHelper.JoinableTaskFactory.RunAsync(tagger.RaiseTagsChangedAsync).Task 
+			// Inside AfterTaggingActionAsync, the important path calls AcuminatorVSPackage.JTF.RunAsync(tagger.RaiseTagsChangedAsync).Task 
 			// this starts RaiseTagsChangedAsync and immediately returns the underlying Task representing it (still running).
 			// The lambda returns that inner Task immediately — it does not await it.
 			// The outer Task<Task> stored in TaggingTask is marked as Completed (RanToCompletion) at this point, because the lambda has returned. 

--- a/src/Acuminator/Acuminator.Vsix/Coloriser/Base/PXTaggerBase.cs
+++ b/src/Acuminator/Acuminator.Vsix/Coloriser/Base/PXTaggerBase.cs
@@ -12,6 +12,7 @@ using Acuminator.Vsix.Settings;
 using Acuminator.Vsix.Utilities;
 
 using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Tagging;
 
 using ThreadHelper = Microsoft.VisualStudio.Shell.ThreadHelper;
 
@@ -56,6 +57,16 @@ namespace Acuminator.Vsix.Coloriser
 
 			_disposedNotification = new TextDocumentDisposedNotification(textDocumentFactory, Buffer);
 			_disposedNotification.CurrentTextDocumentDisposed += CleanupOnTextDocumentDisposed;
+		}
+
+		protected static IEnumerable<ITagSpan<TTag>> GetIntersectionWithRequestedTags<TTag>(
+																				IReadOnlyCollection<ITagSpan<TTag>> tags,
+																				NormalizedSnapshotSpanCollection requestedSpans)
+		where TTag : ITag
+		{
+			return tags?.Count > 0
+				? tags.Where(tag => requestedSpans.IntersectsWith(tag.Span))
+				: [];
 		}
 
 		protected virtual void ColoringSettingChangedHandler(object sender, SettingChangedEventArgs e)

--- a/src/Acuminator/Acuminator.Vsix/Coloriser/Base/PXTaggerBase.cs
+++ b/src/Acuminator/Acuminator.Vsix/Coloriser/Base/PXTaggerBase.cs
@@ -3,10 +3,13 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Acuminator.Utilities.Common;
 using Acuminator.Vsix.Settings;
+using Acuminator.Vsix.Utilities;
 
 using Microsoft.VisualStudio.Text;
 
@@ -64,11 +67,35 @@ namespace Acuminator.Vsix.Coloriser
 			RaiseTagsChanged();
 		}
 
-		internal async Task RaiseTagsChangedAsync()
+		/// <summary>
+		/// Raises the tags changed asynchronously and do not observe the raised task.
+		/// </summary>
+		/// <remarks>
+		/// The method is intended to be called from void-returning event handlers.
+		/// </remarks>
+		/// <param name="cancellation">Cancellation.</param>
+		/// <param name="reportedFrom">(Optional) The method raising the tag changed event.</param>
+		protected void RaiseTagsChangedAsyncAndForget(CancellationToken cancellation, [CallerMemberName] string? calledFrom = null)
+		{
+			if (ThreadHelper.CheckAccess())
+				RaiseTagsChanged();
+			else
+			{
+				string taggerName = this.GetType().Name;
+				calledFrom = calledFrom.NullIfWhiteSpace() ?? nameof(RaiseTagsChangedAsyncAndForget);
+
+				// See the VS cookbook for file and forget methods
+				// https://github.com/microsoft/vs-threading/blob/main/docfx/docs/cookbook_vs.md#task-returning-fire-and-forget-methods
+				RaiseTagsChangedAsync(cancellation)
+					.FileAndForget($"vs/{AcuminatorVSPackage.PackageName}/{taggerName}/{calledFrom}", cancellation);
+			}
+		}
+
+		internal async Task RaiseTagsChangedAsync(CancellationToken cancellation)
 		{
 			if (!ThreadHelper.CheckAccess())
 			{
-				await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+				await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(cancellation);
 			}
 
 			RaiseTagsChangedImpl();

--- a/src/Acuminator/Acuminator.Vsix/Coloriser/Base/PXTaggerBase.cs
+++ b/src/Acuminator/Acuminator.Vsix/Coloriser/Base/PXTaggerBase.cs
@@ -73,9 +73,8 @@ namespace Acuminator.Vsix.Coloriser
 		/// <remarks>
 		/// The method is intended to be called from void-returning event handlers.
 		/// </remarks>
-		/// <param name="cancellation">Cancellation.</param>
 		/// <param name="reportedFrom">(Optional) The method raising the tag changed event.</param>
-		protected void RaiseTagsChangedAsyncAndForget(CancellationToken cancellation, [CallerMemberName] string? calledFrom = null)
+		protected void RaiseTagsChangedAsyncAndForget([CallerMemberName] string? calledFrom = null)
 		{
 			if (ThreadHelper.CheckAccess())
 				RaiseTagsChanged();
@@ -86,12 +85,12 @@ namespace Acuminator.Vsix.Coloriser
 
 				// See the VS cookbook for file and forget methods
 				// https://github.com/microsoft/vs-threading/blob/main/docfx/docs/cookbook_vs.md#task-returning-fire-and-forget-methods
-				RaiseTagsChangedAsync(cancellation)
-					.FileAndForget($"vs/{AcuminatorVSPackage.PackageName}/{taggerName}/{calledFrom}", cancellation);
+				RaiseTagsChangedAsync()
+					.FileAndForgetAcuminatorTask($"vs/{AcuminatorVSPackage.PackageName}/{taggerName}/{calledFrom}");
 			}
 		}
 
-		internal async Task RaiseTagsChangedAsync(CancellationToken cancellation)
+		internal async Task RaiseTagsChangedAsync()
 		{
 			if (!ThreadHelper.CheckAccess())
 			{

--- a/src/Acuminator/Acuminator.Vsix/Coloriser/Base/PXTaggerBase.cs
+++ b/src/Acuminator/Acuminator.Vsix/Coloriser/Base/PXTaggerBase.cs
@@ -85,8 +85,8 @@ namespace Acuminator.Vsix.Coloriser
 
 				// See the VS cookbook for file and forget methods
 				// https://github.com/microsoft/vs-threading/blob/main/docfx/docs/cookbook_vs.md#task-returning-fire-and-forget-methods
-				RaiseTagsChangedAsync()
-					.FileAndForgetAcuminatorTask($"vs/{AcuminatorVSPackage.PackageName}/{taggerName}/{calledFrom}");
+				var raiseTaggerChanged = () => RaiseTagsChangedAsync();
+				raiseTaggerChanged.FileAndForgetAcuminatorTask($"vs/{AcuminatorVSPackage.PackageName}/{taggerName}/{calledFrom}");
 			}
 		}
 

--- a/src/Acuminator/Acuminator.Vsix/Coloriser/Base/PXTaggerBase.cs
+++ b/src/Acuminator/Acuminator.Vsix/Coloriser/Base/PXTaggerBase.cs
@@ -95,7 +95,7 @@ namespace Acuminator.Vsix.Coloriser
 		{
 			if (!ThreadHelper.CheckAccess())
 			{
-				await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(cancellation);
+				await AcuminatorVSPackage.JTF.SwitchToMainThreadAsync();
 			}
 
 			RaiseTagsChangedImpl();

--- a/src/Acuminator/Acuminator.Vsix/Coloriser/Base/PXTaggerBase.cs
+++ b/src/Acuminator/Acuminator.Vsix/Coloriser/Base/PXTaggerBase.cs
@@ -73,7 +73,7 @@ namespace Acuminator.Vsix.Coloriser
 		/// <remarks>
 		/// The method is intended to be called from void-returning event handlers.
 		/// </remarks>
-		/// <param name="reportedFrom">(Optional) The method raising the tag changed event.</param>
+		/// <param name="calledFrom">(Optional) The method raising the tag changed event.</param>
 		protected void RaiseTagsChangedAsyncAndForget([CallerMemberName] string? calledFrom = null)
 		{
 			if (ThreadHelper.CheckAccess())

--- a/src/Acuminator/Acuminator.Vsix/Coloriser/Outlining/PXOutliningTagger.cs
+++ b/src/Acuminator/Acuminator.Vsix/Coloriser/Outlining/PXOutliningTagger.cs
@@ -31,9 +31,9 @@ namespace Acuminator.Vsix.Coloriser
 		{
 		}
 
-		public IEnumerable<ITagSpan<IOutliningRegionTag>> GetTags(NormalizedSnapshotSpanCollection spans)
+		public IEnumerable<ITagSpan<IOutliningRegionTag>> GetTags(NormalizedSnapshotSpanCollection requestedSpans)
 		{
-			if (spans == null || spans.Count == 0 || AcuminatorVSPackage.Instance?.UseBqlOutlining != true)
+			if (requestedSpans?.Count is null or 0 || AcuminatorVSPackage.Instance?.UseBqlOutlining != true)
 				return [];
 
 			if (ColorizerTagger == null)
@@ -48,7 +48,8 @@ namespace Acuminator.Vsix.Coloriser
 			if (!HasReferenceToAcumaticaPlatform)
 				return [];
 
-			return ColorizerTagger.OutliningsTagsCache.ProcessedTags;
+			var processedTags = ColorizerTagger.OutliningsTagsCache.ProcessedTags;
+			return GetIntersectionWithRequestedTags(processedTags, requestedSpans);
 		}
 
 		private static bool TryGetColorizingTaggerFromBuffer(ITextBuffer textBuffer, out PXRoslynColorizerTagger colorizingTagger)

--- a/src/Acuminator/Acuminator.Vsix/Coloriser/Outlining/PXOutliningTaggerProvider.cs
+++ b/src/Acuminator/Acuminator.Vsix/Coloriser/Outlining/PXOutliningTaggerProvider.cs
@@ -28,7 +28,7 @@ public class PXOutliningTaggerProvider : ITaggerProvider
 
 	public ITagger<T>? CreateTagger<T>(ITextBuffer buffer) where T : ITag
 	{
-		if (buffer == null || !ThreadHelper.CheckAccess())
+		if (buffer == null || !typeof(ITagger<T>).IsAssignableFrom(typeof(PXOutliningTagger)) || !ThreadHelper.CheckAccess())
 			return null;
 
 		PXOutliningTagger outliningTagger = buffer.Properties.GetOrCreateSingletonProperty(typeof(PXOutliningTagger), () =>

--- a/src/Acuminator/Acuminator.Vsix/Coloriser/PXColorizerTaggerProvider.cs
+++ b/src/Acuminator/Acuminator.Vsix/Coloriser/PXColorizerTaggerProvider.cs
@@ -53,8 +53,11 @@ public class PXColorizerTaggerProvider : IViewTaggerProvider
 	public virtual ITagger<T>? CreateTagger<T>(ITextView textView, ITextBuffer textBuffer)
 	where T : ITag
 	{
-		if (textView == null || textBuffer == null || textView.TextBuffer != textBuffer || !ThreadHelper.CheckAccess())
+		if (textView == null || textBuffer == null || textView.TextBuffer != textBuffer || 
+			!typeof(ITagger<T>).IsAssignableFrom(typeof(PXRoslynColorizerTagger)) || !ThreadHelper.CheckAccess())
+		{
 			return null;
+		}
 
 		var tagger = textBuffer.Properties.GetOrCreateSingletonProperty(typeof(PXRoslynColorizerTagger), () =>
 		{

--- a/src/Acuminator/Acuminator.Vsix/Coloriser/PXRoslynColorizerTagger.cs
+++ b/src/Acuminator/Acuminator.Vsix/Coloriser/PXRoslynColorizerTagger.cs
@@ -15,7 +15,6 @@ using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Tagging;
 
-using static Microsoft.VisualStudio.Shell.VsTaskLibraryHelper;
 using ThreadHelper = Microsoft.VisualStudio.Shell.ThreadHelper;
 
 namespace Acuminator.Vsix.Coloriser;
@@ -280,15 +279,8 @@ internal partial class PXRoslynColorizerTagger : PXTaggerBase, ITagger<IClassifi
 		// We need to raise the tags changed event to trigger re-coloring on workspace change
 		ResetCacheAndFlags(newSnapshotToCache: null);
 
-		if (ThreadHelper.CheckAccess())
-			RaiseTagsChanged();
-		else
-		{
-			#pragma warning disable VSSDK007 // ThreadHelper.JoinableTaskFactory.RunAsync
-			ThreadHelper.JoinableTaskFactory.RunAsync(RaiseTagsChangedAsync)
-											.FileAndForget($"vs/{AcuminatorVSPackage.PackageName}/{nameof(PXRoslynColorizerTagger)}/{nameof(WorkspaceAttachedToDocumentChanged)}");
-			#pragma warning restore VSSDK007
-		}
+		var cancellation = BackgroundTagging?.CancellationToken ?? AcuminatorVSPackage.Instance?.DisposalToken ?? CancellationToken.None;
+		RaiseTagsChangedAsyncAndForget(cancellation);
 	}
 
 	private void OnWorkspaceChanged(object sender, WorkspaceChangeEventArgs e)
@@ -336,15 +328,8 @@ internal partial class PXRoslynColorizerTagger : PXTaggerBase, ITagger<IClassifi
 		{
 			ResetCacheAndFlags(newSnapshotToCache: null);
 
-			if (ThreadHelper.CheckAccess())
-				RaiseTagsChanged();
-			else
-			{
-#pragma warning disable VSSDK007 // ThreadHelper.JoinableTaskFactory.RunAsync
-				ThreadHelper.JoinableTaskFactory.RunAsync(RaiseTagsChangedAsync)
-												.FileAndForget($"vs/{AcuminatorVSPackage.PackageName}/{nameof(PXRoslynColorizerTagger)}/{nameof(OnWorkspaceChanged)}");
-#pragma warning restore VSSDK007
-			}
+			var cancellation = BackgroundTagging?.CancellationToken ?? AcuminatorVSPackage.Instance?.DisposalToken ?? CancellationToken.None;
+			RaiseTagsChangedAsyncAndForget(cancellation);
 		}
 	}
 

--- a/src/Acuminator/Acuminator.Vsix/Coloriser/PXRoslynColorizerTagger.cs
+++ b/src/Acuminator/Acuminator.Vsix/Coloriser/PXRoslynColorizerTagger.cs
@@ -136,13 +136,15 @@ internal partial class PXRoslynColorizerTagger : PXTaggerBase, ITagger<IClassifi
 	/// <summary>
 	/// Gets the tags asynchronously from the specified snapshot with Roslyn.
 	/// </summary>
-	/// <param name="spans">The spans for tagging. The current implementation doesn't take them into account and re-tags the entire document.</param>
+	/// <param name="requestedSpans">
+	/// The spans for tagging. The current implementation re-tags the entire document but returns the intersection with the requested spans.
+	/// </param>
 	/// <returns>
 	/// The current snapshot of the collected tags.
 	/// </returns>
-	public IEnumerable<ITagSpan<IClassificationTag>> GetTags(NormalizedSnapshotSpanCollection spans)
+	public IEnumerable<ITagSpan<IClassificationTag>> GetTags(NormalizedSnapshotSpanCollection requestedSpans)
 	{
-		if (spans?.Count is null or 0 || AcuminatorVSPackage.Instance?.ColoringEnabled != true || !HasReferenceToAcumaticaPlatform)
+		if (requestedSpans?.Count is null or 0 || AcuminatorVSPackage.Instance?.ColoringEnabled != true || !HasReferenceToAcumaticaPlatform)
 			return [];
 
 		var workspace = _roslynWorkspaceProvider.Workspace; 
@@ -150,11 +152,12 @@ internal partial class PXRoslynColorizerTagger : PXTaggerBase, ITagger<IClassifi
 		if (workspace == null)
 			return [];
 
-		ITextSnapshot newSnapshotToTag = spans[0].Snapshot;
+		ITextSnapshot newSnapshotToTag = requestedSpans[0].Snapshot;
 
 		if (CheckIfParsingAndRetaggingIsNotNecessary(newSnapshotToTag))
 		{
-			return ClassificationTagsCache.ProcessedTags;
+			var cachedProcessedTags = ClassificationTagsCache.ProcessedTags;
+			return GetIntersectionWithRequestedTags(cachedProcessedTags, requestedSpans);
 		}
 
 		if (BackgroundTagging != null)
@@ -166,7 +169,8 @@ internal partial class PXRoslynColorizerTagger : PXTaggerBase, ITagger<IClassifi
 		ResetCacheAndFlags(newSnapshotToTag);
 		BackgroundTagging = BackgroundTagging.StartBackgroundTagging(this);
 
-		return ClassificationTagsCache.ProcessedTags;
+		var processedTags = ClassificationTagsCache.ProcessedTags;
+		return GetIntersectionWithRequestedTags(processedTags, requestedSpans);
 	}
 
 	protected virtual bool CheckIfParsingAndRetaggingIsNotNecessary(ITextSnapshot newSnapshotToTag) =>

--- a/src/Acuminator/Acuminator.Vsix/Coloriser/PXRoslynColorizerTagger.cs
+++ b/src/Acuminator/Acuminator.Vsix/Coloriser/PXRoslynColorizerTagger.cs
@@ -278,9 +278,7 @@ internal partial class PXRoslynColorizerTagger : PXTaggerBase, ITagger<IClassifi
 
 		// We need to raise the tags changed event to trigger re-coloring on workspace change
 		ResetCacheAndFlags(newSnapshotToCache: null);
-
-		var cancellation = BackgroundTagging?.CancellationToken ?? AcuminatorVSPackage.Instance?.DisposalToken ?? CancellationToken.None;
-		RaiseTagsChangedAsyncAndForget(cancellation);
+		RaiseTagsChangedAsyncAndForget();
 	}
 
 	private void OnWorkspaceChanged(object sender, WorkspaceChangeEventArgs e)
@@ -327,9 +325,7 @@ internal partial class PXRoslynColorizerTagger : PXTaggerBase, ITagger<IClassifi
 		if (oldHasReferenceToAcumaticaPlatform != _hasReferenceToAcumaticaPlatform)
 		{
 			ResetCacheAndFlags(newSnapshotToCache: null);
-
-			var cancellation = BackgroundTagging?.CancellationToken ?? AcuminatorVSPackage.Instance?.DisposalToken ?? CancellationToken.None;
-			RaiseTagsChangedAsyncAndForget(cancellation);
+			RaiseTagsChangedAsyncAndForget();
 		}
 	}
 

--- a/src/Acuminator/Acuminator.Vsix/Coloriser/PXRoslynColorizerTagger.cs
+++ b/src/Acuminator/Acuminator.Vsix/Coloriser/PXRoslynColorizerTagger.cs
@@ -17,6 +17,8 @@ using Microsoft.VisualStudio.Text.Tagging;
 
 using ThreadHelper = Microsoft.VisualStudio.Shell.ThreadHelper;
 
+using static Microsoft.VisualStudio.Shell.TaskExtensions;
+
 namespace Acuminator.Vsix.Coloriser;
 
 /// <summary>
@@ -282,7 +284,12 @@ internal partial class PXRoslynColorizerTagger : PXTaggerBase, ITagger<IClassifi
 		if (ThreadHelper.CheckAccess())
 			RaiseTagsChanged();
 		else
-			ThreadHelper.JoinableTaskFactory.Run(RaiseTagsChangedAsync);
+		{
+			#pragma warning disable VSSDK007 // ThreadHelper.JoinableTaskFactory.RunAsync
+			ThreadHelper.JoinableTaskFactory.RunAsync(RaiseTagsChangedAsync)
+											.FireAndForget();
+			#pragma warning restore VSSDK007
+		}
 	}
 
 	private void OnWorkspaceChanged(object sender, WorkspaceChangeEventArgs e)
@@ -333,8 +340,13 @@ internal partial class PXRoslynColorizerTagger : PXTaggerBase, ITagger<IClassifi
 			if (ThreadHelper.CheckAccess())
 				RaiseTagsChanged();
 			else
-				ThreadHelper.JoinableTaskFactory.Run(RaiseTagsChangedAsync);
-		}	
+			{
+#pragma warning disable VSSDK007 // ThreadHelper.JoinableTaskFactory.RunAsync
+				ThreadHelper.JoinableTaskFactory.RunAsync(RaiseTagsChangedAsync)
+												.FireAndForget();
+#pragma warning restore VSSDK007
+			}
+		}
 	}
 
 	private bool GetAcumaticaReferenceOnProjectChange(WorkspaceChangeEventArgs e, bool oldHasReferenceToAcumaticaPlatform)

--- a/src/Acuminator/Acuminator.Vsix/Coloriser/PXRoslynColorizerTagger.cs
+++ b/src/Acuminator/Acuminator.Vsix/Coloriser/PXRoslynColorizerTagger.cs
@@ -15,9 +15,8 @@ using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Tagging;
 
+using static Microsoft.VisualStudio.Shell.VsTaskLibraryHelper;
 using ThreadHelper = Microsoft.VisualStudio.Shell.ThreadHelper;
-
-using static Microsoft.VisualStudio.Shell.TaskExtensions;
 
 namespace Acuminator.Vsix.Coloriser;
 
@@ -287,7 +286,7 @@ internal partial class PXRoslynColorizerTagger : PXTaggerBase, ITagger<IClassifi
 		{
 			#pragma warning disable VSSDK007 // ThreadHelper.JoinableTaskFactory.RunAsync
 			ThreadHelper.JoinableTaskFactory.RunAsync(RaiseTagsChangedAsync)
-											.FireAndForget();
+											.FileAndForget($"vs/{AcuminatorVSPackage.PackageName}/{nameof(PXRoslynColorizerTagger)}/{nameof(WorkspaceAttachedToDocumentChanged)}");
 			#pragma warning restore VSSDK007
 		}
 	}
@@ -343,7 +342,7 @@ internal partial class PXRoslynColorizerTagger : PXTaggerBase, ITagger<IClassifi
 			{
 #pragma warning disable VSSDK007 // ThreadHelper.JoinableTaskFactory.RunAsync
 				ThreadHelper.JoinableTaskFactory.RunAsync(RaiseTagsChangedAsync)
-												.FireAndForget();
+												.FileAndForget($"vs/{AcuminatorVSPackage.PackageName}/{nameof(PXRoslynColorizerTagger)}/{nameof(OnWorkspaceChanged)}");
 #pragma warning restore VSSDK007
 			}
 		}

--- a/src/Acuminator/Acuminator.Vsix/Coloriser/Roslyn/PXRoslynColorizerTagger.PXColorizerSyntaxWalker.cs
+++ b/src/Acuminator/Acuminator.Vsix/Coloriser/Roslyn/PXRoslynColorizerTagger.PXColorizerSyntaxWalker.cs
@@ -470,7 +470,7 @@ namespace Acuminator.Vsix.Coloriser
 				{
 					if (!cancellationToken.IsCancellationRequested)
 					{
-						await _tagger.RaiseTagsChangedAsync(cancellationToken);
+						await _tagger.RaiseTagsChangedAsync();
 					}
 				});
 				#pragma warning restore VSTHRD110 // Observe result of async calls

--- a/src/Acuminator/Acuminator.Vsix/Coloriser/Roslyn/PXRoslynColorizerTagger.PXColorizerSyntaxWalker.cs
+++ b/src/Acuminator/Acuminator.Vsix/Coloriser/Roslyn/PXRoslynColorizerTagger.PXColorizerSyntaxWalker.cs
@@ -470,7 +470,7 @@ namespace Acuminator.Vsix.Coloriser
 				{
 					if (!cancellationToken.IsCancellationRequested)
 					{
-						await _tagger.RaiseTagsChangedAsync();
+						await _tagger.RaiseTagsChangedAsync(cancellationToken);
 					}
 				});
 				#pragma warning restore VSTHRD110 // Observe result of async calls

--- a/src/Acuminator/Acuminator.Vsix/Coloriser/Roslyn/PXRoslynColorizerTagger.PXColorizerSyntaxWalker.cs
+++ b/src/Acuminator/Acuminator.Vsix/Coloriser/Roslyn/PXRoslynColorizerTagger.PXColorizerSyntaxWalker.cs
@@ -466,7 +466,7 @@ namespace Acuminator.Vsix.Coloriser
 				var cancellationToken = _cancellationToken;
 
 				#pragma warning disable VSTHRD110 // Observe result of async calls
-				Shell.ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+				AcuminatorVSPackage.JTF.RunAsync(async () =>
 				{
 					if (!cancellationToken.IsCancellationRequested)
 					{

--- a/src/Acuminator/Acuminator.Vsix/Commands/BQL Fixer/FixBqlCommand.cs
+++ b/src/Acuminator/Acuminator.Vsix/Commands/BQL Fixer/FixBqlCommand.cs
@@ -65,7 +65,7 @@ namespace Acuminator.Vsix.BqlFixer
 
 		private async System.Threading.Tasks.Task CommandCallbackAsync()
 		{
-			await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+			await AcuminatorVSPackage.JTF.SwitchToMainThreadAsync();
 			IWpfTextView? textView = await ServiceProvider.GetWpfTextViewAsync();
 
 			if (textView == null)
@@ -130,13 +130,13 @@ namespace Acuminator.Vsix.BqlFixer
 
 			// have to format, because cannot save all original indention
 			BqlFormatter formatter = BqlFormatter.FromTextView(textView);
-			var formatedRoot = formatter.Format(newSyntaxRoot, newSemanticModel);
+			var formattedRoot = formatter.Format(newSyntaxRoot, newSemanticModel);
 
-			await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(); // Return to UI thread
+			await AcuminatorVSPackage.JTF.SwitchToMainThreadAsync(); // Return to UI thread
 
 			if (!textView.TextBuffer.EditInProgress)
 			{
-				var formattedDocument = document.WithSyntaxRoot(formatedRoot);
+				var formattedDocument = document.WithSyntaxRoot(formattedRoot);
 				ApplyChanges(document, formattedDocument);
 			}
 		}

--- a/src/Acuminator/Acuminator.Vsix/Commands/BQL Fixer/FixBqlCommand.cs
+++ b/src/Acuminator/Acuminator.Vsix/Commands/BQL Fixer/FixBqlCommand.cs
@@ -61,7 +61,7 @@ namespace Acuminator.Vsix.BqlFixer
 
 		protected override void CommandCallback(object sender, EventArgs e) =>
 			CommandCallbackAsync()
-				.FileAndForget($"vs/{AcuminatorVSPackage.PackageName}/{nameof(FixBqlCommand)}");
+				.FileAndForget($"vs/{AcuminatorVSPackage.PackageName}/{nameof(FixBqlCommand)}", cancellation: AcuminatorVSPackage.Instance?.DisposalToken ?? default);
 
 		private async System.Threading.Tasks.Task CommandCallbackAsync()
 		{

--- a/src/Acuminator/Acuminator.Vsix/Commands/BQL Fixer/FixBqlCommand.cs
+++ b/src/Acuminator/Acuminator.Vsix/Commands/BQL Fixer/FixBqlCommand.cs
@@ -61,7 +61,7 @@ namespace Acuminator.Vsix.BqlFixer
 
 		protected override void CommandCallback(object sender, EventArgs e) =>
 			CommandCallbackAsync()
-				.FileAndForget($"vs/{AcuminatorVSPackage.PackageName}/{nameof(FixBqlCommand)}", cancellation: AcuminatorVSPackage.Instance?.DisposalToken ?? default);
+				.FileAndForgetAcuminatorTask($"vs/{AcuminatorVSPackage.PackageName}/{nameof(FixBqlCommand)}");
 
 		private async System.Threading.Tasks.Task CommandCallbackAsync()
 		{

--- a/src/Acuminator/Acuminator.Vsix/Commands/BQL Fixer/FixBqlCommand.cs
+++ b/src/Acuminator/Acuminator.Vsix/Commands/BQL Fixer/FixBqlCommand.cs
@@ -59,9 +59,11 @@ namespace Acuminator.Vsix.BqlFixer
 			}
 		}
 
-		protected override void CommandCallback(object sender, EventArgs e) =>
-			CommandCallbackAsync()
-				.FileAndForgetAcuminatorTask($"vs/{AcuminatorVSPackage.PackageName}/{nameof(FixBqlCommand)}");
+		protected override void CommandCallback(object sender, EventArgs e)
+		{
+			var commandExecutor = () => CommandCallbackAsync();
+			commandExecutor.FileAndForgetAcuminatorTask($"vs/{AcuminatorVSPackage.PackageName}/{nameof(FixBqlCommand)}");
+		}
 
 		private async System.Threading.Tasks.Task CommandCallbackAsync()
 		{

--- a/src/Acuminator/Acuminator.Vsix/Commands/DiagnosticSuppression/Base/SuppressDiagnosticCommandBase.cs
+++ b/src/Acuminator/Acuminator.Vsix/Commands/DiagnosticSuppression/Base/SuppressDiagnosticCommandBase.cs
@@ -104,7 +104,7 @@ namespace Acuminator.Vsix.DiagnosticSuppression
 
 		protected async Task<List<DiagnosticData>> GetDiagnosticsAsync(Document document, TextSpan caretSpan)
 		{
-			await Shell.ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+			await AcuminatorVSPackage.JTF.SwitchToMainThreadAsync();
 			IComponentModel? componentModel = await Package.GetServiceAsync<SComponentModel, IComponentModel>(throwOnFailure: false);
 
 			if (componentModel == null)
@@ -149,6 +149,6 @@ namespace Acuminator.Vsix.DiagnosticSuppression
 																	SemanticModel semanticModel, SyntaxNode nodeWithDiagnostic);
 
 		protected abstract Task SuppressMultipleDiagnosticOnNodeAsync(List<DiagnosticData> diagnosticData, Document document, SyntaxNode syntaxRoot,
-																	 SemanticModel semanticModel, SyntaxNode nodeWithDiagnostic);
+																	  SemanticModel semanticModel, SyntaxNode nodeWithDiagnostic);
 	}
 }

--- a/src/Acuminator/Acuminator.Vsix/Commands/DiagnosticSuppression/Base/SuppressDiagnosticCommandBase.cs
+++ b/src/Acuminator/Acuminator.Vsix/Commands/DiagnosticSuppression/Base/SuppressDiagnosticCommandBase.cs
@@ -141,14 +141,14 @@ namespace Acuminator.Vsix.DiagnosticSuppression
 				case 1:
 					return SuppressSingleDiagnosticOnNodeAsync(diagnosticData[0], document, syntaxRoot, semanticModel, nodeWithDiagnostic);
 				default:
-					return SupressMultipleDiagnosticOnNodeAsync(diagnosticData, document, syntaxRoot, semanticModel, nodeWithDiagnostic);
+					return SuppressMultipleDiagnosticOnNodeAsync(diagnosticData, document, syntaxRoot, semanticModel, nodeWithDiagnostic);
 			}
 		}
 
 		protected abstract Task SuppressSingleDiagnosticOnNodeAsync(DiagnosticData diagnostic, Document document, SyntaxNode syntaxRoot,
 																	SemanticModel semanticModel, SyntaxNode nodeWithDiagnostic);
 
-		protected abstract Task SupressMultipleDiagnosticOnNodeAsync(List<DiagnosticData> diagnosticData, Document document, SyntaxNode syntaxRoot,
+		protected abstract Task SuppressMultipleDiagnosticOnNodeAsync(List<DiagnosticData> diagnosticData, Document document, SyntaxNode syntaxRoot,
 																	 SemanticModel semanticModel, SyntaxNode nodeWithDiagnostic);
 	}
 }

--- a/src/Acuminator/Acuminator.Vsix/Commands/DiagnosticSuppression/Base/SuppressDiagnosticCommandBase.cs
+++ b/src/Acuminator/Acuminator.Vsix/Commands/DiagnosticSuppression/Base/SuppressDiagnosticCommandBase.cs
@@ -32,9 +32,11 @@ namespace Acuminator.Vsix.DiagnosticSuppression
 		{
 		}
 
-		protected override void CommandCallback(object sender, EventArgs e) =>
-			CommandCallbackAsync()
-				.FileAndForgetAcuminatorTask($"vs/{AcuminatorVSPackage.PackageName}/{this.GetType().Name}");
+		protected override void CommandCallback(object sender, EventArgs e)
+		{
+			var commandExecutor = () => CommandCallbackAsync();
+			commandExecutor.FileAndForgetAcuminatorTask($"vs/{AcuminatorVSPackage.PackageName}/{this.GetType().Name}");
+		}
 
 		protected virtual async Task CommandCallbackAsync()
 		{		

--- a/src/Acuminator/Acuminator.Vsix/Commands/DiagnosticSuppression/Base/SuppressDiagnosticCommandBase.cs
+++ b/src/Acuminator/Acuminator.Vsix/Commands/DiagnosticSuppression/Base/SuppressDiagnosticCommandBase.cs
@@ -34,7 +34,7 @@ namespace Acuminator.Vsix.DiagnosticSuppression
 
 		protected override void CommandCallback(object sender, EventArgs e) =>
 			CommandCallbackAsync()
-				.FileAndForget($"vs/{AcuminatorVSPackage.PackageName}/{this.GetType().Name}", cancellation: AcuminatorVSPackage.Instance?.DisposalToken ?? default);
+				.FileAndForgetAcuminatorTask($"vs/{AcuminatorVSPackage.PackageName}/{this.GetType().Name}");
 
 		protected virtual async Task CommandCallbackAsync()
 		{		

--- a/src/Acuminator/Acuminator.Vsix/Commands/DiagnosticSuppression/Base/SuppressDiagnosticCommandBase.cs
+++ b/src/Acuminator/Acuminator.Vsix/Commands/DiagnosticSuppression/Base/SuppressDiagnosticCommandBase.cs
@@ -34,7 +34,7 @@ namespace Acuminator.Vsix.DiagnosticSuppression
 
 		protected override void CommandCallback(object sender, EventArgs e) =>
 			CommandCallbackAsync()
-				.FileAndForget($"vs/{AcuminatorVSPackage.PackageName}/{this.GetType().Name}");
+				.FileAndForget($"vs/{AcuminatorVSPackage.PackageName}/{this.GetType().Name}", cancellation: AcuminatorVSPackage.Instance?.DisposalToken ?? default);
 
 		protected virtual async Task CommandCallbackAsync()
 		{		

--- a/src/Acuminator/Acuminator.Vsix/Commands/DiagnosticSuppression/BuildAction/VsixBuildActionSetterVS2019.cs
+++ b/src/Acuminator/Acuminator.Vsix/Commands/DiagnosticSuppression/BuildAction/VsixBuildActionSetterVS2019.cs
@@ -14,7 +14,7 @@ using Acuminator.Vsix.Logger;
 namespace Acuminator.Vsix.DiagnosticSuppression
 {
 	/// <summary>
-	/// A helper to set Build Action for newly added suppression file in VS 2019 or older that can use VS COM API directy.
+	/// A helper to set Build Action for newly added suppression file in VS 2019 or older that can use VS COM API directly.
 	/// </summary>
 	public class VsixBuildActionSetterVS2019 : ICustomBuildActionSetter
 	{
@@ -30,8 +30,8 @@ namespace Acuminator.Vsix.DiagnosticSuppression
 			{
 				#pragma warning disable VSTHRD104 // Offer async methods 
 				// Justification: need to use sync API since consumer is code action operation which require synchronous execution
-				// and located in the Utilities, so it can't use ThreadHelper.JoinableTaskFactory itself
-				return ThreadHelper.JoinableTaskFactory.Run(() => SetBuildActionAsync(roslynSuppressionFilePath, buildActionToSet));
+				// and located in the Utilities, so it can't use JoinableTaskFactory from AcuminatorVSPackage.JTF
+				return AcuminatorVSPackage.JTF.Run(() => SetBuildActionAsync(roslynSuppressionFilePath, buildActionToSet));
 				#pragma warning restore VSTHRD104 
 			}
 			catch (Exception ex)
@@ -44,7 +44,7 @@ namespace Acuminator.Vsix.DiagnosticSuppression
 		private async Task<bool> SetBuildActionAsync(string roslynSuppressionFilePath, string buildActionToSet)
 		{
 			var oldScheduler = TaskScheduler.Current;
-			await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+			await AcuminatorVSPackage.JTF.SwitchToMainThreadAsync();
 
 			try
 			{

--- a/src/Acuminator/Acuminator.Vsix/Commands/DiagnosticSuppression/BuildAction/VsixBuildActionSetterVS2019.cs
+++ b/src/Acuminator/Acuminator.Vsix/Commands/DiagnosticSuppression/BuildAction/VsixBuildActionSetterVS2019.cs
@@ -30,7 +30,7 @@ namespace Acuminator.Vsix.DiagnosticSuppression
 			{
 				#pragma warning disable VSTHRD104 // Offer async methods 
 				// Justification: need to use sync API since consumer is code action operation which require synchronous execution
-				// and located in the Utilities, so it can't use JoinableTaskFactory from AcuminatorVSPackage.JTF
+				// and located in the Utilities, so the calling code can't use JoinableTaskFactory from AcuminatorVSPackage.JTF
 				return AcuminatorVSPackage.JTF.Run(() => SetBuildActionAsync(roslynSuppressionFilePath, buildActionToSet));
 				#pragma warning restore VSTHRD104 
 			}

--- a/src/Acuminator/Acuminator.Vsix/Commands/DiagnosticSuppression/BuildAction/VsixBuildActionSetterVS2022.cs
+++ b/src/Acuminator/Acuminator.Vsix/Commands/DiagnosticSuppression/BuildAction/VsixBuildActionSetterVS2022.cs
@@ -35,7 +35,7 @@ namespace Acuminator.Vsix.DiagnosticSuppression
 				#pragma warning disable VSTHRD104 // Offer async methods 
 				// Justification: need to use sync API since consumer is code action operation which require synchronous execution
 				// and located in the Utilities, so it can't use ThreadHelper.JoinableTaskFactory itself
-				return ThreadHelper.JoinableTaskFactory.Run(() => SetBuildActionAsync(roslynSuppressionFilePath, buildActionToSet));
+				return AcuminatorVSPackage.JTF.Run(() => SetBuildActionAsync(roslynSuppressionFilePath, buildActionToSet));
 				#pragma warning restore VSTHRD104 
 			}
 			catch (Exception ex)
@@ -51,7 +51,7 @@ namespace Acuminator.Vsix.DiagnosticSuppression
 
 			try
 			{
-				await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+				await AcuminatorVSPackage.JTF.SwitchToMainThreadAsync();
 
 				dynamic? dte = GetDTE();
 

--- a/src/Acuminator/Acuminator.Vsix/Commands/DiagnosticSuppression/Suppression File/SuppressDiagnosticInSuppressionFileCommand.cs
+++ b/src/Acuminator/Acuminator.Vsix/Commands/DiagnosticSuppression/Suppression File/SuppressDiagnosticInSuppressionFileCommand.cs
@@ -92,7 +92,7 @@ namespace Acuminator.Vsix.DiagnosticSuppression
 
 		private async Task<(TextDocument SuppressionFile, Project Project)> GetProjectAndSuppressionFileAsync(ProjectId projectId)
 		{
-			await Shell.ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+			await AcuminatorVSPackage.JTF.SwitchToMainThreadAsync();
 			var workspace = await Package.GetVSWorkspaceAsync();
 			Project? project = workspace?.CurrentSolution?.GetProject(projectId);
 

--- a/src/Acuminator/Acuminator.Vsix/Commands/DiagnosticSuppression/Suppression File/SuppressDiagnosticInSuppressionFileCommand.cs
+++ b/src/Acuminator/Acuminator.Vsix/Commands/DiagnosticSuppression/Suppression File/SuppressDiagnosticInSuppressionFileCommand.cs
@@ -123,7 +123,7 @@ namespace Acuminator.Vsix.DiagnosticSuppression
 			MessageBox.Show(errorMessage.ToString(), AcuminatorVSPackage.PackageName);
 		}
 
-		protected override Task SupressMultipleDiagnosticOnNodeAsync(List<DiagnosticData> diagnosticData, Document document, SyntaxNode syntaxRoot,
+		protected override Task SuppressMultipleDiagnosticOnNodeAsync(List<DiagnosticData> diagnosticData, Document document, SyntaxNode syntaxRoot,
 																	 SemanticModel semanticModel, SyntaxNode nodeWithDiagnostic)
 		{
 			MessageBox.Show(VSIXResource.DiagnosticSuppression_MultipleDiagnosticFound, AcuminatorVSPackage.PackageName);

--- a/src/Acuminator/Acuminator.Vsix/Commands/Formatter/FormatBqlCommand.cs
+++ b/src/Acuminator/Acuminator.Vsix/Commands/Formatter/FormatBqlCommand.cs
@@ -69,7 +69,7 @@ namespace Acuminator.Vsix.Formatter
 
 		protected override void CommandCallback(object sender, EventArgs e) =>
 			CommandCallbackAsync()
-				.FileAndForget($"vs/{AcuminatorVSPackage.PackageName}/{nameof(FormatBqlCommand)}", cancellation: AcuminatorVSPackage.Instance?.DisposalToken ?? default);
+				.FileAndForgetAcuminatorTask($"vs/{AcuminatorVSPackage.PackageName}/{nameof(FormatBqlCommand)}");
 
 		private async System.Threading.Tasks.Task CommandCallbackAsync()
 		{

--- a/src/Acuminator/Acuminator.Vsix/Commands/Formatter/FormatBqlCommand.cs
+++ b/src/Acuminator/Acuminator.Vsix/Commands/Formatter/FormatBqlCommand.cs
@@ -73,7 +73,7 @@ namespace Acuminator.Vsix.Formatter
 
 		private async System.Threading.Tasks.Task CommandCallbackAsync()
 		{
-			await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+			await AcuminatorVSPackage.JTF.SwitchToMainThreadAsync();
 			IWpfTextView? textView = await ServiceProvider.GetWpfTextViewAsync();
 
 			if (textView == null || Package.DisposalToken.IsCancellationRequested)
@@ -124,7 +124,7 @@ namespace Acuminator.Vsix.Formatter
 				formattedRoot = formatter.Format(syntaxRoot, semanticModel) ?? syntaxRoot;
 			}
 
-			await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(); // Return to UI thread
+			await AcuminatorVSPackage.JTF.SwitchToMainThreadAsync(); // Return to UI thread
 
 			if (!textView.TextBuffer.EditInProgress && !syntaxRoot.Equals(formattedRoot))
 			{

--- a/src/Acuminator/Acuminator.Vsix/Commands/Formatter/FormatBqlCommand.cs
+++ b/src/Acuminator/Acuminator.Vsix/Commands/Formatter/FormatBqlCommand.cs
@@ -67,9 +67,11 @@ namespace Acuminator.Vsix.Formatter
 		}
 #pragma warning restore CS8774
 
-		protected override void CommandCallback(object sender, EventArgs e) =>
-			CommandCallbackAsync()
-				.FileAndForgetAcuminatorTask($"vs/{AcuminatorVSPackage.PackageName}/{nameof(FormatBqlCommand)}");
+		protected override void CommandCallback(object sender, EventArgs e)
+		{
+			var commandExecutor = () => CommandCallbackAsync();
+			commandExecutor.FileAndForgetAcuminatorTask($"vs/{AcuminatorVSPackage.PackageName}/{nameof(FormatBqlCommand)}");
+		}
 
 		private async System.Threading.Tasks.Task CommandCallbackAsync()
 		{

--- a/src/Acuminator/Acuminator.Vsix/Commands/Formatter/FormatBqlCommand.cs
+++ b/src/Acuminator/Acuminator.Vsix/Commands/Formatter/FormatBqlCommand.cs
@@ -69,7 +69,7 @@ namespace Acuminator.Vsix.Formatter
 
 		protected override void CommandCallback(object sender, EventArgs e) =>
 			CommandCallbackAsync()
-				.FileAndForget($"vs/{AcuminatorVSPackage.PackageName}/{nameof(FormatBqlCommand)}");
+				.FileAndForget($"vs/{AcuminatorVSPackage.PackageName}/{nameof(FormatBqlCommand)}", cancellation: AcuminatorVSPackage.Instance?.DisposalToken ?? default);
 
 		private async System.Threading.Tasks.Task CommandCallbackAsync()
 		{

--- a/src/Acuminator/Acuminator.Vsix/Commands/GoToDeclarationOrHandler/GoToDeclarationOrHandlerCommand.cs
+++ b/src/Acuminator/Acuminator.Vsix/Commands/GoToDeclarationOrHandler/GoToDeclarationOrHandlerCommand.cs
@@ -82,7 +82,7 @@ namespace Acuminator.Vsix.GoToDeclaration
 
 		protected override void CommandCallback(object sender, EventArgs e) =>
 			CommandCallbackAsync()
-				.FileAndForget($"vs/{AcuminatorVSPackage.PackageName}/{nameof(GoToDeclarationOrHandlerCommand)}");
+				.FileAndForget($"vs/{AcuminatorVSPackage.PackageName}/{nameof(GoToDeclarationOrHandlerCommand)}", cancellation: AcuminatorVSPackage.Instance?.DisposalToken ?? default);
 		
 		private async Task CommandCallbackAsync()
 		{

--- a/src/Acuminator/Acuminator.Vsix/Commands/GoToDeclarationOrHandler/GoToDeclarationOrHandlerCommand.cs
+++ b/src/Acuminator/Acuminator.Vsix/Commands/GoToDeclarationOrHandler/GoToDeclarationOrHandlerCommand.cs
@@ -82,7 +82,7 @@ namespace Acuminator.Vsix.GoToDeclaration
 
 		protected override void CommandCallback(object sender, EventArgs e) =>
 			CommandCallbackAsync()
-				.FileAndForget($"vs/{AcuminatorVSPackage.PackageName}/{nameof(GoToDeclarationOrHandlerCommand)}", cancellation: AcuminatorVSPackage.Instance?.DisposalToken ?? default);
+				.FileAndForgetAcuminatorTask($"vs/{AcuminatorVSPackage.PackageName}/{nameof(GoToDeclarationOrHandlerCommand)}");
 		
 		private async Task CommandCallbackAsync()
 		{

--- a/src/Acuminator/Acuminator.Vsix/Commands/GoToDeclarationOrHandler/GoToDeclarationOrHandlerCommand.cs
+++ b/src/Acuminator/Acuminator.Vsix/Commands/GoToDeclarationOrHandler/GoToDeclarationOrHandlerCommand.cs
@@ -80,10 +80,12 @@ namespace Acuminator.Vsix.GoToDeclaration
 		}
 #pragma warning restore CS8774
 
-		protected override void CommandCallback(object sender, EventArgs e) =>
-			CommandCallbackAsync()
-				.FileAndForgetAcuminatorTask($"vs/{AcuminatorVSPackage.PackageName}/{nameof(GoToDeclarationOrHandlerCommand)}");
-		
+		protected override void CommandCallback(object sender, EventArgs e)
+		{
+			var commandExecutor = () => CommandCallbackAsync();
+			commandExecutor.FileAndForgetAcuminatorTask($"vs/{AcuminatorVSPackage.PackageName}/{nameof(GoToDeclarationOrHandlerCommand)}");
+		}
+
 		private async Task CommandCallbackAsync()
 		{
 			IWpfTextView? textView = await ServiceProvider.GetWpfTextViewAsync();

--- a/src/Acuminator/Acuminator.Vsix/Properties/AssemblyInfo.cs
+++ b/src/Acuminator/Acuminator.Vsix/Properties/AssemblyInfo.cs
@@ -11,7 +11,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 [assembly: ComVisible(false)]
-[assembly: AssemblyVersion("4.0.1")]
-[assembly: AssemblyFileVersion("4.0.1")]
+[assembly: AssemblyVersion("4.1.0")]
+[assembly: AssemblyFileVersion("4.1.0")]
 
 [assembly: InternalsVisibleTo("Acuminator.Tests")]

--- a/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/CodeMapWindow.cs
+++ b/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/CodeMapWindow.cs
@@ -75,7 +75,7 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 			if (workspace == null)
 				return;
 
-			IWpfTextView? textView = await ThreadHelper.JoinableTaskFactory.RunAsync(serviceProvider.GetWpfTextViewAsync);
+			IWpfTextView? textView = await AcuminatorVSPackage.JTF.RunAsync(serviceProvider.GetWpfTextViewAsync);
 			Document? document = textView?.TextSnapshot?.GetOpenDocumentInCurrentContextWithChanges();
 
 			if (CodeMapWPFControl.DataContext is CodeMapWindowViewModel codeMapViewModel)

--- a/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/UI/CodeMapTreeControl.xaml.cs
+++ b/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/UI/CodeMapTreeControl.xaml.cs
@@ -41,7 +41,7 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 			{
 				var cancellation = treeNodeVM.Tree.CodeMapViewModel.CancellationToken ?? AcuminatorVSPackage.Instance?.DisposalToken ?? default;
 				NavigateOnClickAsync(treeNodeVM)
-					.FileAndForget($"vs/{AcuminatorVSPackage.PackageName}/{nameof(CodeMapWindowViewModel)}/{nameof(TreeNode_PreviewMouseLeftButtonDown)}", cancellation);
+					.FileAndForgetAcuminatorTask($"vs/{AcuminatorVSPackage.PackageName}/{nameof(CodeMapWindowViewModel)}/{nameof(TreeNode_PreviewMouseLeftButtonDown)}");
 			}
 		}
 

--- a/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/UI/CodeMapTreeControl.xaml.cs
+++ b/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/UI/CodeMapTreeControl.xaml.cs
@@ -39,8 +39,9 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 
 			if (e.ClickCount >= 2)
 			{
-				NavigateOnClickAsync(treeNodeVM)
-					.FileAndForgetAcuminatorTask($"vs/{AcuminatorVSPackage.PackageName}/{nameof(CodeMapWindowViewModel)}/{nameof(TreeNode_PreviewMouseLeftButtonDown)}");
+				var navigationHandler = () => NavigateOnClickAsync(treeNodeVM);
+				navigationHandler.FileAndForgetAcuminatorTask(
+						$"vs/{AcuminatorVSPackage.PackageName}/{nameof(CodeMapWindowViewModel)}/{nameof(TreeNode_PreviewMouseLeftButtonDown)}");
 			}
 		}
 

--- a/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/UI/CodeMapTreeControl.xaml.cs
+++ b/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/UI/CodeMapTreeControl.xaml.cs
@@ -39,7 +39,6 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 
 			if (e.ClickCount >= 2)
 			{
-				var cancellation = treeNodeVM.Tree.CodeMapViewModel.CancellationToken ?? AcuminatorVSPackage.Instance?.DisposalToken ?? default;
 				NavigateOnClickAsync(treeNodeVM)
 					.FileAndForgetAcuminatorTask($"vs/{AcuminatorVSPackage.PackageName}/{nameof(CodeMapWindowViewModel)}/{nameof(TreeNode_PreviewMouseLeftButtonDown)}");
 			}

--- a/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/UI/CodeMapTreeControl.xaml.cs
+++ b/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/UI/CodeMapTreeControl.xaml.cs
@@ -39,8 +39,9 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 
 			if (e.ClickCount >= 2)
 			{
+				var cancellation = treeNodeVM.Tree.CodeMapViewModel.CancellationToken ?? AcuminatorVSPackage.Instance?.DisposalToken ?? default;
 				NavigateOnClickAsync(treeNodeVM)
-					.FileAndForget($"vs/{AcuminatorVSPackage.PackageName}/{nameof(CodeMapWindowViewModel)}/{nameof(TreeNode_PreviewMouseLeftButtonDown)}");
+					.FileAndForget($"vs/{AcuminatorVSPackage.PackageName}/{nameof(CodeMapWindowViewModel)}/{nameof(TreeNode_PreviewMouseLeftButtonDown)}", cancellation);
 			}
 		}
 

--- a/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/CodeMapWindowViewModel.CodeMapDteEventsObserver.cs
+++ b/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/CodeMapWindowViewModel.CodeMapDteEventsObserver.cs
@@ -137,14 +137,16 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 
 					if (!wasVisible && _codeMapViewModel.IsVisible)   //Handle the case when WindowShowing event happens after WindowActivated event
 					{
+						var cancellation = _codeMapViewModel.CancellationToken ?? AcuminatorVSPackage.Instance?.DisposalToken ?? default;
 						RefreshCodeMapAsync()
-							.FileAndForget($"vs/{AcuminatorVSPackage.PackageName}/{nameof(CodeMapWindowViewModel)}/{nameof(SetVisibilityForCodeMapWindow)}");
+							.FileAndForget($"vs/{AcuminatorVSPackage.PackageName}/{nameof(CodeMapWindowViewModel)}/{nameof(SetVisibilityForCodeMapWindow)}", cancellation);
 					}
 				}
 				else if (IsSwitchingToAnotherDocumentWhileCodeMapIsEmpty())
-				{				
+				{
+					var cancellation = _codeMapViewModel.CancellationToken ?? AcuminatorVSPackage.Instance?.DisposalToken ?? default;
 					RefreshCodeMapAsync()
-						.FileAndForget($"vs/{AcuminatorVSPackage.PackageName}/{nameof(CodeMapWindowViewModel)}/{nameof(SetVisibilityForCodeMapWindow)}");			
+						.FileAndForget($"vs/{AcuminatorVSPackage.PackageName}/{nameof(CodeMapWindowViewModel)}/{nameof(SetVisibilityForCodeMapWindow)}", cancellation);
 				}	
 
 				//-------------------------------------------Local Function----------------------------------------------------------------------------------------
@@ -164,7 +166,8 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 
 			private void WindowEvents_WindowActivated(EnvDTE.Window gotFocus, EnvDTE.Window lostFocus) =>
 				WindowEventsWindowActivatedAsync(gotFocus, lostFocus)
-					.FileAndForget($"vs/{AcuminatorVSPackage.PackageName}/{nameof(CodeMapWindowViewModel)}/{nameof(WindowEvents_WindowActivated)}");
+					.FileAndForget($"vs/{AcuminatorVSPackage.PackageName}/{nameof(CodeMapWindowViewModel)}/{nameof(WindowEvents_WindowActivated)}",
+								   cancellation: _codeMapViewModel.CancellationToken ?? AcuminatorVSPackage.Instance?.DisposalToken ?? default);
 
 			private async Task WindowEventsWindowActivatedAsync(EnvDTE.Window gotFocus, EnvDTE.Window lostFocus)
 			{

--- a/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/CodeMapWindowViewModel.CodeMapDteEventsObserver.cs
+++ b/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/CodeMapWindowViewModel.CodeMapDteEventsObserver.cs
@@ -137,13 +137,15 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 
 					if (!wasVisible && _codeMapViewModel.IsVisible)   //Handle the case when WindowShowing event happens after WindowActivated event
 					{
-						RefreshCodeMapAsync()
+						var refreshCodeMapAction = () => RefreshCodeMapAsync();
+						refreshCodeMapAction
 							.FileAndForgetAcuminatorTask($"vs/{AcuminatorVSPackage.PackageName}/{nameof(CodeMapWindowViewModel)}/{nameof(SetVisibilityForCodeMapWindow)}");
 					}
 				}
 				else if (IsSwitchingToAnotherDocumentWhileCodeMapIsEmpty())
 				{
-					RefreshCodeMapAsync()
+					var refreshCodeMapAction = () => RefreshCodeMapAsync();
+					refreshCodeMapAction
 						.FileAndForgetAcuminatorTask($"vs/{AcuminatorVSPackage.PackageName}/{nameof(CodeMapWindowViewModel)}/{nameof(SetVisibilityForCodeMapWindow)}");
 				}	
 
@@ -162,9 +164,12 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 				_codeMapViewModel.DocumentModel = null;
 			}
 
-			private void WindowEvents_WindowActivated(EnvDTE.Window gotFocus, EnvDTE.Window lostFocus) =>
-				WindowEventsWindowActivatedAsync(gotFocus, lostFocus)
+			private void WindowEvents_WindowActivated(EnvDTE.Window gotFocus, EnvDTE.Window lostFocus)
+			{
+				var windowActivatedHandler = () => WindowEventsWindowActivatedAsync(gotFocus, lostFocus);
+				windowActivatedHandler
 					.FileAndForgetAcuminatorTask($"vs/{AcuminatorVSPackage.PackageName}/{nameof(CodeMapWindowViewModel)}/{nameof(WindowEvents_WindowActivated)}");
+			}
 
 			private async Task WindowEventsWindowActivatedAsync(EnvDTE.Window gotFocus, EnvDTE.Window lostFocus)
 			{

--- a/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/CodeMapWindowViewModel.CodeMapDteEventsObserver.cs
+++ b/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/CodeMapWindowViewModel.CodeMapDteEventsObserver.cs
@@ -139,14 +139,14 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 					{
 						var cancellation = _codeMapViewModel.CancellationToken ?? AcuminatorVSPackage.Instance?.DisposalToken ?? default;
 						RefreshCodeMapAsync()
-							.FileAndForget($"vs/{AcuminatorVSPackage.PackageName}/{nameof(CodeMapWindowViewModel)}/{nameof(SetVisibilityForCodeMapWindow)}", cancellation);
+							.FileAndForgetAcuminatorTask($"vs/{AcuminatorVSPackage.PackageName}/{nameof(CodeMapWindowViewModel)}/{nameof(SetVisibilityForCodeMapWindow)}");
 					}
 				}
 				else if (IsSwitchingToAnotherDocumentWhileCodeMapIsEmpty())
 				{
 					var cancellation = _codeMapViewModel.CancellationToken ?? AcuminatorVSPackage.Instance?.DisposalToken ?? default;
 					RefreshCodeMapAsync()
-						.FileAndForget($"vs/{AcuminatorVSPackage.PackageName}/{nameof(CodeMapWindowViewModel)}/{nameof(SetVisibilityForCodeMapWindow)}", cancellation);
+						.FileAndForgetAcuminatorTask($"vs/{AcuminatorVSPackage.PackageName}/{nameof(CodeMapWindowViewModel)}/{nameof(SetVisibilityForCodeMapWindow)}");
 				}	
 
 				//-------------------------------------------Local Function----------------------------------------------------------------------------------------
@@ -166,8 +166,7 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 
 			private void WindowEvents_WindowActivated(EnvDTE.Window gotFocus, EnvDTE.Window lostFocus) =>
 				WindowEventsWindowActivatedAsync(gotFocus, lostFocus)
-					.FileAndForget($"vs/{AcuminatorVSPackage.PackageName}/{nameof(CodeMapWindowViewModel)}/{nameof(WindowEvents_WindowActivated)}",
-								   cancellation: _codeMapViewModel.CancellationToken ?? AcuminatorVSPackage.Instance?.DisposalToken ?? default);
+					.FileAndForgetAcuminatorTask($"vs/{AcuminatorVSPackage.PackageName}/{nameof(CodeMapWindowViewModel)}/{nameof(WindowEvents_WindowActivated)}");
 
 			private async Task WindowEventsWindowActivatedAsync(EnvDTE.Window gotFocus, EnvDTE.Window lostFocus)
 			{

--- a/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/CodeMapWindowViewModel.CodeMapDteEventsObserver.cs
+++ b/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/CodeMapWindowViewModel.CodeMapDteEventsObserver.cs
@@ -137,14 +137,12 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 
 					if (!wasVisible && _codeMapViewModel.IsVisible)   //Handle the case when WindowShowing event happens after WindowActivated event
 					{
-						var cancellation = _codeMapViewModel.CancellationToken ?? AcuminatorVSPackage.Instance?.DisposalToken ?? default;
 						RefreshCodeMapAsync()
 							.FileAndForgetAcuminatorTask($"vs/{AcuminatorVSPackage.PackageName}/{nameof(CodeMapWindowViewModel)}/{nameof(SetVisibilityForCodeMapWindow)}");
 					}
 				}
 				else if (IsSwitchingToAnotherDocumentWhileCodeMapIsEmpty())
 				{
-					var cancellation = _codeMapViewModel.CancellationToken ?? AcuminatorVSPackage.Instance?.DisposalToken ?? default;
 					RefreshCodeMapAsync()
 						.FileAndForgetAcuminatorTask($"vs/{AcuminatorVSPackage.PackageName}/{nameof(CodeMapWindowViewModel)}/{nameof(SetVisibilityForCodeMapWindow)}");
 				}	

--- a/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/CodeMapWindowViewModel.CodeMapDteEventsObserver.cs
+++ b/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/CodeMapWindowViewModel.CodeMapDteEventsObserver.cs
@@ -173,7 +173,7 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 			{
 				if (!ThreadHelper.CheckAccess())
 				{
-					await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+					await AcuminatorVSPackage.JTF.SwitchToMainThreadAsync();
 				}
 
 				if (!_codeMapViewModel.IsVisible || Equals(gotFocus, lostFocus) || gotFocus.Document == null)
@@ -200,7 +200,7 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 
 				if (!ThreadHelper.CheckAccess())
 				{
-					await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+					await AcuminatorVSPackage.JTF.SwitchToMainThreadAsync();
 				}
 
 				var activeWpfTextViewTask = activeWpfTextView != null

--- a/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/CodeMapWindowViewModel.cs
+++ b/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/CodeMapWindowViewModel.cs
@@ -170,9 +170,12 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 			FilterVM.FilterChanged += FilterVM_FilterChanged;
 
 			RefreshCodeMapCommand = 
-				new Command(p => RefreshCodeMapAsync()
-									.FileAndForgetAcuminatorTask($"vs/{AcuminatorVSPackage.PackageName}/" +
-																 $"{nameof(CodeMapWindowViewModel)}/{nameof(RefreshCodeMapAsync)}"));
+				new Command(p =>
+				{
+					var refreshCodeMapAction = () => RefreshCodeMapAsync();
+					refreshCodeMapAction.FileAndForgetAcuminatorTask($"vs/{AcuminatorVSPackage.PackageName}/" +
+																	 $"{nameof(CodeMapWindowViewModel)}/{nameof(RefreshCodeMapAsync)}");
+				});
 			ExpandOrCollapseAllCommand = new Command(p => ExpandOrCollapseNodeDescendants(p as TreeNodeViewModel));
 
 			SortNodeChildrenByNameAscendingCommand =
@@ -213,9 +216,9 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 
 			if (codeMapViewModel.DocumentModel != null)
 			{
-				codeMapViewModel.BuildCodeMapAsync()
-								.FileAndForgetAcuminatorTask($"vs/{AcuminatorVSPackage.PackageName}/" +
-															 $"{nameof(CodeMapWindowViewModel)}/{nameof(BuildCodeMapAsync)}");
+				var buildCodeMapAction = () => codeMapViewModel.BuildCodeMapAsync();
+				buildCodeMapAction.FileAndForgetAcuminatorTask($"vs/{AcuminatorVSPackage.PackageName}/" +
+															   $"{nameof(CodeMapWindowViewModel)}/{nameof(BuildCodeMapAsync)}");
 			}
 
 			return codeMapViewModel;
@@ -380,8 +383,8 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 			if (recalculateCodeMapMode == CodeMapRefreshMode.Recalculate && DocumentModel?.WpfTextView != null)
 			{
 				DocumentModel = new DocumentModel(DocumentModel.WpfTextView, changedDocument);
-				BuildCodeMapAsync()
-				 .FileAndForgetAcuminatorTask($"vs/{AcuminatorVSPackage.PackageName}/{nameof(CodeMapWindowViewModel)}/{nameof(BuildCodeMapAsync)}");
+				var buildCodeMapAction = () => BuildCodeMapAsync();
+				buildCodeMapAction.FileAndForgetAcuminatorTask($"vs/{AcuminatorVSPackage.PackageName}/{nameof(CodeMapWindowViewModel)}/{nameof(BuildCodeMapAsync)}");
 			}
 		}
 

--- a/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/CodeMapWindowViewModel.cs
+++ b/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/CodeMapWindowViewModel.cs
@@ -169,7 +169,10 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 			FilterVM = new FilterViewModel();
 			FilterVM.FilterChanged += FilterVM_FilterChanged;
 
-			RefreshCodeMapCommand = new Command(p => RefreshCodeMapAsync().Forget());
+			RefreshCodeMapCommand = 
+				new Command(p => RefreshCodeMapAsync()
+									.FileAndForgetAcuminatorTask($"vs/{AcuminatorVSPackage.PackageName}/" +
+																 $"{nameof(CodeMapWindowViewModel)}/{nameof(RefreshCodeMapAsync)}"));
 			ExpandOrCollapseAllCommand = new Command(p => ExpandOrCollapseNodeDescendants(p as TreeNodeViewModel));
 
 			SortNodeChildrenByNameAscendingCommand =
@@ -209,7 +212,11 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 			}
 
 			if (codeMapViewModel.DocumentModel != null)
-				codeMapViewModel.BuildCodeMapAsync().Forget();
+			{
+				codeMapViewModel.BuildCodeMapAsync()
+								.FileAndForgetAcuminatorTask($"vs/{AcuminatorVSPackage.PackageName}/" +
+															 $"{nameof(CodeMapWindowViewModel)}/{nameof(BuildCodeMapAsync)}");
+			}
 
 			return codeMapViewModel;
 		}
@@ -373,7 +380,8 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 			if (recalculateCodeMapMode == CodeMapRefreshMode.Recalculate && DocumentModel?.WpfTextView != null)
 			{
 				DocumentModel = new DocumentModel(DocumentModel.WpfTextView, changedDocument);
-				BuildCodeMapAsync().Forget();
+				BuildCodeMapAsync()
+				 .FileAndForgetAcuminatorTask($"vs/{AcuminatorVSPackage.PackageName}/{nameof(CodeMapWindowViewModel)}/{nameof(BuildCodeMapAsync)}");
 			}
 		}
 

--- a/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/CodeMapWindowViewModel.cs
+++ b/src/Acuminator/Acuminator.Vsix/Tool Windows/CodeMap/ViewModel/CodeMapWindowViewModel.cs
@@ -248,7 +248,7 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 		{
 			if (!ThreadHelper.CheckAccess())
 			{
-				await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+				await AcuminatorVSPackage.JTF.SwitchToMainThreadAsync();
 			}
 
 			IsCalculating = false;
@@ -263,7 +263,7 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 
 			if (!ThreadHelper.CheckAccess())
 			{
-				await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+				await AcuminatorVSPackage.JTF.SwitchToMainThreadAsync();
 			}
 
 			var activeWpfTextViewTask = activeWpfTextView != null
@@ -307,7 +307,7 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 
 			if (!ThreadHelper.CheckAccess())
 			{
-				await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+				await AcuminatorVSPackage.JTF.SwitchToMainThreadAsync();
 			}
 
 			if (!IsVisible || e.IsActiveDocumentCleared(Document))
@@ -397,7 +397,7 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 
 					if (!ThreadHelper.CheckAccess())
 					{
-						await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+						await AcuminatorVSPackage.JTF.SwitchToMainThreadAsync();
 					}
 
 					IsCalculating = true;
@@ -415,7 +415,7 @@ namespace Acuminator.Vsix.ToolWindows.CodeMap
 					if (newTreeVM == null)
 						return;
 
-					await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+					await AcuminatorVSPackage.JTF.SwitchToMainThreadAsync();
 
 					Tree = newTreeVM;
 					AfterCodeMapTreeIsFiltered?.Invoke(this, new FilterEventArgs(filterOptions, oldFilterText: null));

--- a/src/Acuminator/Acuminator.Vsix/Tool Windows/OpenToolWindowCommandBase.cs
+++ b/src/Acuminator/Acuminator.Vsix/Tool Windows/OpenToolWindowCommandBase.cs
@@ -32,7 +32,7 @@ namespace Acuminator.Vsix.ToolWindows
 
 		protected virtual async Task<TWindow?> OpenToolWindowAsync()
 		{
-			await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+			await AcuminatorVSPackage.JTF.SwitchToMainThreadAsync();
 
 			// Get the instance number 0 of this tool window. This window is single instance so this instance
 			// is actually the only one.

--- a/src/Acuminator/Acuminator.Vsix/Tool Windows/OpenToolWindowCommandBase.cs
+++ b/src/Acuminator/Acuminator.Vsix/Tool Windows/OpenToolWindowCommandBase.cs
@@ -25,9 +25,11 @@ namespace Acuminator.Vsix.ToolWindows
 		/// </summary>
 		/// <param name="sender">The event sender.</param>
 		/// <param name="e">The event args.</param>
-		protected override void CommandCallback(object sender, EventArgs e) => 
-			OpenToolWindowAsync()
-				.FileAndForgetAcuminatorTask($"vs/{AcuminatorVSPackage.PackageName}/{nameof(OpenToolWindowAsync)}/{typeof(TWindow).Name}");
+		protected override void CommandCallback(object sender, EventArgs e)
+		{
+			var openToolWindowAction = () => OpenToolWindowAsync();
+			openToolWindowAction.FileAndForgetAcuminatorTask($"vs/{AcuminatorVSPackage.PackageName}/{nameof(OpenToolWindowAsync)}/{typeof(TWindow).Name}");
+		}
 
 		protected virtual async Task<TWindow?> OpenToolWindowAsync()
 		{

--- a/src/Acuminator/Acuminator.Vsix/Tool Windows/OpenToolWindowCommandBase.cs
+++ b/src/Acuminator/Acuminator.Vsix/Tool Windows/OpenToolWindowCommandBase.cs
@@ -27,7 +27,8 @@ namespace Acuminator.Vsix.ToolWindows
 		/// <param name="e">The event args.</param>
 		protected override void CommandCallback(object sender, EventArgs e) => 
 			OpenToolWindowAsync()
-				.FileAndForget($"vs/{AcuminatorVSPackage.PackageName}/{nameof(OpenToolWindowAsync)}/{typeof(TWindow).Name}");
+				.FileAndForget($"vs/{AcuminatorVSPackage.PackageName}/{nameof(OpenToolWindowAsync)}/{typeof(TWindow).Name}",
+							   cancellation: AcuminatorVSPackage.Instance?.DisposalToken ?? default);
 
 		protected virtual async Task<TWindow?> OpenToolWindowAsync()
 		{

--- a/src/Acuminator/Acuminator.Vsix/Tool Windows/OpenToolWindowCommandBase.cs
+++ b/src/Acuminator/Acuminator.Vsix/Tool Windows/OpenToolWindowCommandBase.cs
@@ -27,8 +27,7 @@ namespace Acuminator.Vsix.ToolWindows
 		/// <param name="e">The event args.</param>
 		protected override void CommandCallback(object sender, EventArgs e) => 
 			OpenToolWindowAsync()
-				.FileAndForget($"vs/{AcuminatorVSPackage.PackageName}/{nameof(OpenToolWindowAsync)}/{typeof(TWindow).Name}",
-							   cancellation: AcuminatorVSPackage.Instance?.DisposalToken ?? default);
+				.FileAndForgetAcuminatorTask($"vs/{AcuminatorVSPackage.PackageName}/{nameof(OpenToolWindowAsync)}/{typeof(TWindow).Name}");
 
 		protected virtual async Task<TWindow?> OpenToolWindowAsync()
 		{

--- a/src/Acuminator/Acuminator.Vsix/Utils/Logger/AcuminatorLogger.cs
+++ b/src/Acuminator/Acuminator.Vsix/Utils/Logger/AcuminatorLogger.cs
@@ -143,7 +143,7 @@ namespace Acuminator.Vsix.Logger
 			{
 				using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(timeoutSeconds));
 
-				var joinableTask = ThreadHelper.JoinableTaskFactory.RunAsync(() => _package.GetWpfTextViewAsync());
+				var joinableTask = AcuminatorVSPackage.JTF.RunAsync(() => _package.GetWpfTextViewAsync());
 				var activeTextView = joinableTask.Join(cts.Token);
 				return activeTextView;
 			}

--- a/src/Acuminator/Acuminator.Vsix/Utils/Navigation/VSDocumentNavigation.cs
+++ b/src/Acuminator/Acuminator.Vsix/Utils/Navigation/VSDocumentNavigation.cs
@@ -42,7 +42,7 @@ namespace Acuminator.Vsix.Utilities.Navigation
 			string filePath = location.SourceTree.FilePath;
 			TextSpan textSpanToNavigate = location.SourceSpan;
 
-			await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+			await AcuminatorVSPackage.JTF.SwitchToMainThreadAsync();
 
 			cToken.ThrowIfCancellationRequested();
 
@@ -75,7 +75,7 @@ namespace Acuminator.Vsix.Utilities.Navigation
 			reference.ThrowOnNull();
 			var filePath = reference.SyntaxTree?.FilePath;
 
-			await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+			await AcuminatorVSPackage.JTF.SwitchToMainThreadAsync();
 			var workspace = await AcuminatorVSPackage.Instance.GetVSWorkspaceAsync();
 			TextSpan textSpanToNavigate = await GetTextSpanToNavigateFromSymbolAsync(symbol, reference, cToken);
 
@@ -257,7 +257,7 @@ namespace Acuminator.Vsix.Utilities.Navigation
 			if (!File.Exists(filePath) )
 				return null;
 
-			await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+			await AcuminatorVSPackage.JTF.SwitchToMainThreadAsync();
 			DTE? dte = await serviceProvider.GetServiceAsync<DTE>();
 
 			if (dte == null)

--- a/src/Acuminator/Acuminator.Vsix/Utils/Tasks/VsTasksUtils.cs
+++ b/src/Acuminator/Acuminator.Vsix/Utils/Tasks/VsTasksUtils.cs
@@ -1,0 +1,88 @@
+﻿#nullable enable
+
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Acuminator.Utilities.Common;
+
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Threading;
+using Microsoft.VisualStudio.Telemetry;
+using Microsoft.Internal.VisualStudio.Shell;
+
+namespace Acuminator.Vsix.Utilities;
+
+/// <summary>
+/// The threading and task related utilities that use VS threading mechanisms.
+/// </summary>
+public static class VsTasksUtils
+{
+	/// <inheritdoc cref="FileAndForget(System.Threading.Tasks.Task, string?, CancellationToken, string?, bool, Func{Exception, bool}?)"/>
+	/// <param name="joinableTask">The <see cref="JoinableTask"/> to act on.</param>
+	public static void FileAndForget(this JoinableTask joinableTask, string? faultEventName, CancellationToken cancellation, 
+									 string? faultDescription = null, bool logCancellations = false, Func<Exception, bool>? fileOnlyIf = null) =>
+		FileAndForget(joinableTask.CheckIfNull().Task, faultEventName, cancellation, faultDescription, logCancellations, fileOnlyIf);
+
+	/// <summary>
+	/// A <see cref="System.Threading.Tasks.Task"/> extension method that file and forget.
+	/// </summary>
+	/// <remarks>
+	/// This code is written by example from <see cref="Microsoft.VisualStudio.Shell.VsTaskLibraryHelper"/>.FileAndForget method<br/>
+	/// which provides an example of how to handle fire-and-forget async action inside void-returning event handlers<br/>
+	/// with the use of JTF and VS telemetry mechanisms.<br/>
+	/// <br/>
+	/// The main reason of having a separate method instead of using the <see cref="Microsoft.VisualStudio.Shell.VsTaskLibraryHelper"/>.FileAndForget method is to<br/>
+	/// be able to use <see cref="JoinableTaskFactory"/> from the <see cref="AcuminatorVSPackage"/> class instead of the default one from <see cref="Microsoft.VisualStudio.Shell.ThreadHelper"/>.
+	/// </remarks>
+	/// <param name="task">The task to act on.</param>
+	/// <param name="faultEventName">Name of the fault event. Use the name of the component for this with the following convention:<br/>
+	/// <c>"vs/{AcuminatorVSPackage.PackageName}/{componentName}/{methodName}"</c>.</param>
+	/// <param name="cancellation">A token that allows processing to be cancelled.</param>
+	/// <param name="faultDescription">(Optional) Information describing the fault.</param>
+	/// <param name="logCancellations">(Optional) True to log cancellation exceptions. False by default.</param>
+	/// <param name="fileOnlyIf">(Optional) The optional condition on exceptions to be logged. Takes precedence over the <paramref name="logCancellations"/> flag.</param>
+	public static void FileAndForget(this System.Threading.Tasks.Task task, string? faultEventName, CancellationToken cancellation,
+									 string? faultDescription = null, bool logCancellations = false, Func<Exception, bool>? fileOnlyIf = null)
+	{
+		task.ThrowOnNull();
+		JoinableTask joinableTask = AcuminatorVSPackage.JTF.RunAsync(async delegate
+		{
+			try
+			{
+#pragma warning disable VSTHRD003 // Avoid awaiting foreign Tasks - This is already in JTF.RunAsync method, so we can safely await the task here.
+				await task.ConfigureAwait(continueOnCapturedContext: false);
+#pragma warning restore VSTHRD003
+			}
+			catch (Exception ex) when (FilterExceptions(ex, fileOnlyIf, logCancellations))
+			{
+				await AcuminatorVSPackage.JTF.SwitchToMainThreadAsync(cancellation);
+
+				FaultEvent telemetryEvent = new FaultEvent(faultEventName, faultDescription, ex)
+				{
+					IsIncludedInWatsonSample = false
+				};
+
+				TelemetryHelper.DataModelTelemetrySession?.PostEvent(telemetryEvent);
+				faultDescription = faultDescription.NullIfWhiteSpace()?.Trim();
+				string text = faultDescription != null 
+					? faultDescription + Environment.NewLine 
+					: string.Empty;
+				text += ex;
+
+				ActivityLog.TryLogError(faultEventName, text);
+			}
+		});
+	}
+
+	private static bool FilterExceptions(Exception exception, Func<Exception, bool>? fileOnlyIf, bool logCancellations)
+	{
+		if (fileOnlyIf?.Invoke(exception) == true)
+			return true;
+		else if (exception is OperationCanceledException)
+			return logCancellations;
+		else
+			return true;
+	}
+}

--- a/src/Acuminator/Acuminator.Vsix/Utils/Tasks/VsTasksUtils.cs
+++ b/src/Acuminator/Acuminator.Vsix/Utils/Tasks/VsTasksUtils.cs
@@ -36,7 +36,7 @@ public static class VsTasksUtils
 	/// <param name="faultDescription">(Optional) Information describing the fault.</param>
 	/// <param name="logCancellations">(Optional) True to log cancellation exceptions. False by default.</param>
 	/// <param name="fileOnlyIf">(Optional) The optional condition on exceptions to be logged. Takes precedence over the <paramref name="logCancellations"/> flag.</param>
-	public static void FileAndForgetAcuminatorTask(this Func<System.Threading.Tasks.Task>? asyncMethod, string? faultEventName, string? faultDescription = null, 
+	public static void FileAndForgetAcuminatorTask(this Func<System.Threading.Tasks.Task>? asyncMethod, string faultEventName, string? faultDescription = null, 
 												   bool logCancellations = false, Func<Exception, bool>? fileOnlyIf = null)
 	{
 		asyncMethod.ThrowOnNull();
@@ -53,7 +53,8 @@ public static class VsTasksUtils
 
 				await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
-				FaultEvent telemetryEvent = new FaultEvent(faultEventName, faultDescription, ex)
+				faultEventName = faultEventName.NullIfWhiteSpace()?.Trim() ?? $"vs/{AcuminatorVSPackage.PackageName}/UnknownComponent/UnknownMethod";
+				var telemetryEvent = new FaultEvent(faultEventName, faultDescription, ex)
 				{
 					IsIncludedInWatsonSample = false
 				};

--- a/src/Acuminator/Acuminator.Vsix/Utils/Tasks/VsTasksUtils.cs
+++ b/src/Acuminator/Acuminator.Vsix/Utils/Tasks/VsTasksUtils.cs
@@ -19,11 +19,11 @@ namespace Acuminator.Vsix.Utilities;
 /// </summary>
 public static class VsTasksUtils
 {
-	/// <inheritdoc cref="FileAndForget(System.Threading.Tasks.Task, string?, CancellationToken, string?, bool, Func{Exception, bool}?)"/>
+	/// <inheritdoc cref="FileAndForgetAcuminatorTask(System.Threading.Tasks.Task, string?, string?, bool, Func{Exception, bool}?)"/>
 	/// <param name="joinableTask">The <see cref="JoinableTask"/> to act on.</param>
-	public static void FileAndForget(this JoinableTask joinableTask, string? faultEventName, CancellationToken cancellation, 
-									 string? faultDescription = null, bool logCancellations = false, Func<Exception, bool>? fileOnlyIf = null) =>
-		FileAndForget(joinableTask.CheckIfNull().Task, faultEventName, cancellation, faultDescription, logCancellations, fileOnlyIf);
+	public static void FileAndForget(this JoinableTask joinableTask, string? faultEventName, string? faultDescription = null, 
+									 bool logCancellations = false, Func<Exception, bool>? fileOnlyIf = null) =>
+		FileAndForgetAcuminatorTask(joinableTask.CheckIfNull().Task, faultEventName, faultDescription, logCancellations, fileOnlyIf);
 
 	/// <summary>
 	/// A <see cref="System.Threading.Tasks.Task"/> extension method that file and forget.
@@ -39,12 +39,11 @@ public static class VsTasksUtils
 	/// <param name="task">The task to act on.</param>
 	/// <param name="faultEventName">Name of the fault event. Use the name of the component for this with the following convention:<br/>
 	/// <c>"vs/{AcuminatorVSPackage.PackageName}/{componentName}/{methodName}"</c>.</param>
-	/// <param name="cancellation">A token that allows processing to be cancelled.</param>
 	/// <param name="faultDescription">(Optional) Information describing the fault.</param>
 	/// <param name="logCancellations">(Optional) True to log cancellation exceptions. False by default.</param>
 	/// <param name="fileOnlyIf">(Optional) The optional condition on exceptions to be logged. Takes precedence over the <paramref name="logCancellations"/> flag.</param>
-	public static void FileAndForget(this System.Threading.Tasks.Task task, string? faultEventName, CancellationToken cancellation,
-									 string? faultDescription = null, bool logCancellations = false, Func<Exception, bool>? fileOnlyIf = null)
+	public static void FileAndForgetAcuminatorTask(this System.Threading.Tasks.Task task, string? faultEventName, string? faultDescription = null, 
+												   bool logCancellations = false, Func<Exception, bool>? fileOnlyIf = null)
 	{
 		task.ThrowOnNull();
 		JoinableTask joinableTask = AcuminatorVSPackage.JTF.RunAsync(async delegate

--- a/src/Acuminator/Acuminator.Vsix/Utils/Tasks/VsTasksUtils.cs
+++ b/src/Acuminator/Acuminator.Vsix/Utils/Tasks/VsTasksUtils.cs
@@ -2,8 +2,6 @@
 
 using System;
 using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 
 using Acuminator.Utilities.Common;
 
@@ -19,40 +17,34 @@ namespace Acuminator.Vsix.Utilities;
 /// </summary>
 public static class VsTasksUtils
 {
-	/// <inheritdoc cref="FileAndForgetAcuminatorTask(System.Threading.Tasks.Task, string?, string?, bool, Func{Exception, bool}?)"/>
-	/// <param name="joinableTask">The <see cref="JoinableTask"/> to act on.</param>
-	public static void FileAndForgetAcuminatorTask(this JoinableTask joinableTask, string? faultEventName, string? faultDescription = null, 
-												   bool logCancellations = false, Func<Exception, bool>? fileOnlyIf = null) =>
-		FileAndForgetAcuminatorTask(joinableTask.CheckIfNull().Task, faultEventName, faultDescription, logCancellations, fileOnlyIf);
-
 	/// <summary>
-	/// A <see cref="System.Threading.Tasks.Task"/> extension method that file and forget.
+	/// A <see cref="Func{System.Threading.Tasks.Task}"/> extension method that runs async method <paramref name="asyncMethod"/> 
+	/// in a correct context of JTF, files exceptions and forgets.
 	/// </summary>
 	/// <remarks>
-	/// This code is written by example from <see cref="Microsoft.VisualStudio.Shell.VsTaskLibraryHelper"/>.FileAndForget method<br/>
+	/// The code is based on <see cref="Microsoft.VisualStudio.Shell.VsTaskLibraryHelper"/>.FileAndForget method<br/>
 	/// which provides an example of how to handle fire-and-forget async action inside void-returning event handlers<br/>
 	/// with the use of JTF and VS telemetry mechanisms.<br/>
 	/// <br/>
-	/// The main reason of having a separate method instead of using the <see cref="Microsoft.VisualStudio.Shell.VsTaskLibraryHelper"/>.FileAndForget method is to<br/>
-	/// be able to use <see cref="JoinableTaskFactory"/> from the <see cref="AcuminatorVSPackage"/> class instead of the default one from <see cref="Microsoft.VisualStudio.Shell.ThreadHelper"/>.
+	/// The reason of having a separate method instead of using the <see cref="Microsoft.VisualStudio.Shell.VsTaskLibraryHelper"/>.FileAndForget method is to<br/>
+	/// be able to use <see cref="JoinableTaskFactory"/> from the <see cref="AcuminatorVSPackage"/> class instead of the default one from <see cref="ThreadHelper"/> to run the async method.<br/>
+	/// This code also supports skipping of <see cref="OperationCanceledException"/>s.
 	/// </remarks>
-	/// <param name="task">The task to act on.</param>
+	/// <param name="asyncMethod">The async method to act on.</param>
 	/// <param name="faultEventName">Name of the fault event. Use the name of the component for this with the following convention:<br/>
 	/// <c>"vs/{AcuminatorVSPackage.PackageName}/{componentName}/{methodName}"</c>.</param>
 	/// <param name="faultDescription">(Optional) Information describing the fault.</param>
 	/// <param name="logCancellations">(Optional) True to log cancellation exceptions. False by default.</param>
 	/// <param name="fileOnlyIf">(Optional) The optional condition on exceptions to be logged. Takes precedence over the <paramref name="logCancellations"/> flag.</param>
-	public static void FileAndForgetAcuminatorTask(this System.Threading.Tasks.Task task, string? faultEventName, string? faultDescription = null, 
+	public static void FileAndForgetAcuminatorTask(this Func<System.Threading.Tasks.Task>? asyncMethod, string? faultEventName, string? faultDescription = null, 
 												   bool logCancellations = false, Func<Exception, bool>? fileOnlyIf = null)
 	{
-		task.ThrowOnNull();
+		asyncMethod.ThrowOnNull();
 		JoinableTask joinableTask = AcuminatorVSPackage.JTF.RunAsync(async delegate
 		{
 			try
 			{
-#pragma warning disable VSTHRD003 // Avoid awaiting foreign Tasks - This is already in JTF.RunAsync method, so we can safely await the task here.
-				await task.ConfigureAwait(continueOnCapturedContext: false);
-#pragma warning restore VSTHRD003
+				await asyncMethod();
 			}
 			catch (Exception ex)
 			{

--- a/src/Acuminator/Acuminator.Vsix/Utils/Tasks/VsTasksUtils.cs
+++ b/src/Acuminator/Acuminator.Vsix/Utils/Tasks/VsTasksUtils.cs
@@ -57,7 +57,7 @@ public static class VsTasksUtils
 			}
 			catch (Exception ex) when (FilterExceptions(ex, fileOnlyIf, logCancellations))
 			{
-				await AcuminatorVSPackage.JTF.SwitchToMainThreadAsync(cancellation);
+				await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
 				FaultEvent telemetryEvent = new FaultEvent(faultEventName, faultDescription, ex)
 				{

--- a/src/Acuminator/Acuminator.Vsix/Utils/Tasks/VsTasksUtils.cs
+++ b/src/Acuminator/Acuminator.Vsix/Utils/Tasks/VsTasksUtils.cs
@@ -21,8 +21,8 @@ public static class VsTasksUtils
 {
 	/// <inheritdoc cref="FileAndForgetAcuminatorTask(System.Threading.Tasks.Task, string?, string?, bool, Func{Exception, bool}?)"/>
 	/// <param name="joinableTask">The <see cref="JoinableTask"/> to act on.</param>
-	public static void FileAndForget(this JoinableTask joinableTask, string? faultEventName, string? faultDescription = null, 
-									 bool logCancellations = false, Func<Exception, bool>? fileOnlyIf = null) =>
+	public static void FileAndForgetAcuminatorTask(this JoinableTask joinableTask, string? faultEventName, string? faultDescription = null, 
+												   bool logCancellations = false, Func<Exception, bool>? fileOnlyIf = null) =>
 		FileAndForgetAcuminatorTask(joinableTask.CheckIfNull().Task, faultEventName, faultDescription, logCancellations, fileOnlyIf);
 
 	/// <summary>
@@ -54,8 +54,11 @@ public static class VsTasksUtils
 				await task.ConfigureAwait(continueOnCapturedContext: false);
 #pragma warning restore VSTHRD003
 			}
-			catch (Exception ex) when (FilterExceptions(ex, fileOnlyIf, logCancellations))
+			catch (Exception ex)
 			{
+				if (!ShouldLogException(ex, fileOnlyIf, logCancellations))
+					return;
+
 				await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
 				FaultEvent telemetryEvent = new FaultEvent(faultEventName, faultDescription, ex)
@@ -75,10 +78,10 @@ public static class VsTasksUtils
 		});
 	}
 
-	private static bool FilterExceptions(Exception exception, Func<Exception, bool>? fileOnlyIf, bool logCancellations)
+	private static bool ShouldLogException(Exception exception, Func<Exception, bool>? fileOnlyIf, bool logCancellations)
 	{
-		if (fileOnlyIf?.Invoke(exception) == true)
-			return true;
+		if (fileOnlyIf != null)
+			return fileOnlyIf(exception);
 		else if (exception is OperationCanceledException)
 			return logCancellations;
 		else

--- a/src/Acuminator/Acuminator.Vsix/Utils/VSServicesExtensions.cs
+++ b/src/Acuminator/Acuminator.Vsix/Utils/VSServicesExtensions.cs
@@ -81,7 +81,7 @@ namespace Acuminator.Vsix.Utilities
 			return outliningManagerService.GetOutliningManager(textView);
 		}
 
-		internal static async Task<IWpfTextView?> GetWpfTextViewAsync(this IAsyncServiceProvider serviceProvider)
+		internal static async Task<IWpfTextView?> GetWpfTextViewAsync(this IAsyncServiceProvider? serviceProvider)
 		{
 			if (serviceProvider == null)
 				return null;
@@ -109,7 +109,7 @@ namespace Acuminator.Vsix.Utilities
 
 			if (!ThreadHelper.CheckAccess())
 			{
-				await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+				await AcuminatorVSPackage.JTF.SwitchToMainThreadAsync();
 			}
 
 			DTE2? dte2 = await serviceProvider.GetServiceAsync<SDTE, DTE2>(throwOnFailure: false);
@@ -149,7 +149,7 @@ namespace Acuminator.Vsix.Utilities
 			if (serviceProvider == null)
 				return null;
 
-			await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+			await AcuminatorVSPackage.JTF.SwitchToMainThreadAsync();
 			var errorService = await serviceProvider.GetServiceAsync<SVsErrorList, IVsTaskList>(throwOnFailure: false);
 
 			if (errorService == null)

--- a/src/Acuminator/Acuminator.Vsix/Utils/VSServicesExtensions.cs
+++ b/src/Acuminator/Acuminator.Vsix/Utils/VSServicesExtensions.cs
@@ -38,7 +38,7 @@ namespace Acuminator.Vsix.Utilities
 			return serviceProvider?.GetService(typeof(TService)) as TService;
 		}
 
-		public static async Task<TService?> GetServiceAsync<TService>(this IAsyncServiceProvider serviceProvider)
+		public static async Task<TService?> GetServiceAsync<TService>(this IAsyncServiceProvider? serviceProvider)
 		where TService : class
 		{
 			if (serviceProvider == null)
@@ -48,7 +48,7 @@ namespace Acuminator.Vsix.Utilities
 			return service as TService;
 		}
 
-		internal static async Task<VisualStudioWorkspace?> GetVSWorkspaceAsync(this IAsyncServiceProvider serviceProvider)
+		internal static async Task<VisualStudioWorkspace?> GetVSWorkspaceAsync(this IAsyncServiceProvider? serviceProvider)
 		{
 			if (serviceProvider == null)
 				return null;
@@ -58,7 +58,7 @@ namespace Acuminator.Vsix.Utilities
 			return componentModel?.GetService<VisualStudioWorkspace>();
 		}
 
-		internal static async Task<string?> GetSolutionPathAsync(this IAsyncServiceProvider serviceProvider)
+		internal static async Task<string?> GetSolutionPathAsync(this IAsyncServiceProvider? serviceProvider)
 		{
 			if (serviceProvider == null)
 				return null;
@@ -67,7 +67,7 @@ namespace Acuminator.Vsix.Utilities
 			return workspace?.CurrentSolution?.FilePath ?? string.Empty;
 		}
 
-		internal static async Task<IOutliningManager?> GetOutliningManagerAsync(this IAsyncServiceProvider serviceProvider, ITextView textView)
+		internal static async Task<IOutliningManager?> GetOutliningManagerAsync(this IAsyncServiceProvider? serviceProvider, ITextView? textView)
 		{
 			if (serviceProvider == null || textView == null)
 				return null;

--- a/src/Acuminator/Acuminator.Vsix/Utils/Version/VSVersionProvider.cs
+++ b/src/Acuminator/Acuminator.Vsix/Utils/Version/VSVersionProvider.cs
@@ -27,7 +27,7 @@ namespace Acuminator.Vsix.Utilities
 
 			if (!ThreadHelper.CheckAccess())
 			{
-				await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+				await AcuminatorVSPackage.JTF.SwitchToMainThreadAsync();
 			}
 
 			Version? shellVersion = await VS.Shell.GetVsVersionAsync();

--- a/src/Acuminator/Acuminator.Vsix/source.extension.vsixmanifest
+++ b/src/Acuminator/Acuminator.Vsix/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="Acumatica.Acuminator.778b19d1-1d5e-4fcb-8edb-eb103feeab7c" Version="4.0.1" Language="en-US" Publisher="Acumatica" />
+        <Identity Id="Acumatica.Acuminator.778b19d1-1d5e-4fcb-8edb-eb103feeab7c" Version="4.1.0" Language="en-US" Publisher="Acumatica" />
         <DisplayName>Acuminator</DisplayName>
         <Description xml:space="preserve">Acuminator is a Visual Studio extension that simplifies development with Acumatica Framework.  Acuminator provides the following functionality to boost developer productivity:
 - Static code analysis diagnostics, code fixes, and refactorings


### PR DESCRIPTION
#### Changes Overview
- Resolved deadlock in syntax coloring that appeared on attempts to synchronously refresh coloring tags on renaming of the document
- Added check of the requested tagger's type
- Fixed handling of JoinableTaskFactory in the VS integration, added custom FileAndForget helper method
- optimization - return only tags intersecting with the requested spans